### PR TITLE
chore: add GitHub Actions CI pipeline for build and lint (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Lint, Type-check & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (ESLint)
+        run: npm run lint
+
+      - name: Type-check (TypeScript)
+        run: npx tsc --noEmit
+
+      - name: Build (Next.js)
+        run: npm run build
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          NEXT_PUBLIC_USE_MOCKS: true


### PR DESCRIPTION
- Triggers on push to main and all pull requests targeting main
- Lint step: npm run lint (ESLint 9 flat config)
- Type-check step: npx tsc --noEmit (strict mode)
- Build step: npm run build (Next.js 16)
- Node.js 20 with npm dependency caching
- NEXT_TELEMETRY_DISABLED=1 to suppress Next.js telemetry in CI
- NEXT_PUBLIC_USE_MOCKS=true so build uses mock data instead of requiring a live contract connection

## chore: GitHub Actions CI Pipeline (#34)

Closes #34

  ### What was added

  A single workflow file at `.github/workflows/ci.yml` that runs automatically on
  every push to `main` and every pull request targeting `main`.

  ### Pipeline steps

  | Step | Command | Purpose |
  |---|---|---|
  | Install | `npm ci` | Clean, reproducible install from lock file |
  | Lint | `npm run lint` | ESLint 9 with flat config (`eslint.config.mjs`) |
  | Type-check | `npx tsc --noEmit` | Full TypeScript strict-mode check, no output files |
  | Build | `npm run build` | Next.js 16 production build |

  ### Configuration decisions

  **Node.js 20** — matches `@types/node: ^20` in `devDependencies`.

  **`actions/setup-node@v4` with `cache: 'npm'`** — caches `~/.npm` keyed on
  `package-lock.json` automatically. No separate cache step needed; repeat runs
  skip re-downloading packages.

  **`NEXT_TELEMETRY_DISABLED=1`** on the build step — prevents Next.js from sending
  anonymous telemetry during every CI run.

  **`NEXT_PUBLIC_USE_MOCKS=true`** on the build step — points all client-side
  contract calls at mock data so the build succeeds without a live Soroban RPC
  endpoint or deployed contract.

  ### Trigger matrix

  ```yaml
  on:
    push:
      branches: [main]        # runs on every merge to main
    pull_request:
      branches: [main]        # runs on every PR before merge

  Every PR will show a required status check before it can be merged, catching
  lint errors, type errors, and broken builds before they reach main.
  


 