### PR TITLE
feat: implement refund claiming for failed or cancelled campaigns (#28)

### DIFF
--- a/src/app/causes/[id]/page.tsx
+++ b/src/app/causes/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useToast } from '../../../components/ToastProvider';
 import { parseContractError } from '../../../utils/contractErrors';
 import VotingComponent from '../../../components/VotingComponent';
 import WalletConnection from '../../../components/WalletConnection';
+import RefundButton from '../../../components/RefundButton';
 
 const STATUS_STYLES: Record<Campaign['status'], string> = {
   approved: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200',
@@ -209,6 +210,11 @@ export default function CauseDetailPage() {
                 <span className={`px-3 py-1 rounded-full text-xs font-semibold ${STATUS_STYLES[campaign.status]}`}>
                   {campaign.status.charAt(0).toUpperCase() + campaign.status.slice(1)}
                 </span>
+                {campaign.isCancelled && (
+                  <span className="px-3 py-1 rounded-full text-xs font-semibold bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200">
+                    Cancelled
+                  </span>
+                )}
               </div>
 
               <h1 className="text-2xl sm:text-3xl font-bold text-zinc-900 dark:text-zinc-50 mb-4 leading-tight">
@@ -272,6 +278,12 @@ export default function CauseDetailPage() {
               onVote={handleVote}
               userVote={userVote}
               isVoting={isVoting}
+            />
+
+            {/* Refund claiming (shown only when eligible) */}
+            <RefundButton
+              campaign={campaign}
+              contributor={userWalletAddress}
             />
 
             {/* Creator info */}

--- a/src/components/RefundButton.tsx
+++ b/src/components/RefundButton.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { Campaign } from '../types';
+import { useRefund } from '../hooks/useRefund';
+
+interface RefundButtonProps {
+  campaign: Campaign;
+  contributor: string | null;
+}
+
+/**
+ * Conditionally rendered refund UI for the campaign detail page.
+ *
+ * Shows a "Claim Refund" button when:
+ *  1. The campaign is refund-eligible (cancelled or failed)
+ *  2. The connected wallet has a non-zero contribution
+ *
+ * After a successful refund it shows the refunded amount and tx hash.
+ */
+export default function RefundButton({ campaign, contributor }: RefundButtonProps) {
+  const {
+    contributionAmount,
+    isRefundEligible,
+    isLoadingContribution,
+    isRefunding,
+    isRefunded,
+    refundedAmount,
+    transactionHash,
+    error,
+    claimRefundAction,
+  } = useRefund(campaign, contributor);
+
+  // Don't render anything if the campaign isn't refund-eligible
+  if (!isRefundEligible) return null;
+
+  // Don't render if no wallet is connected
+  if (!contributor) {
+    return (
+      <div className="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-xl p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xl">💰</span>
+          <h2 className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+            Refund Available
+          </h2>
+        </div>
+        <p className="text-sm text-amber-700 dark:text-amber-300">
+          This campaign is eligible for refunds.{' '}
+          {campaign.isCancelled
+            ? 'The campaign was cancelled by the creator.'
+            : 'The deadline has passed and the funding goal was not reached.'}
+        </p>
+        <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+          Connect your wallet to check if you can claim a refund.
+        </p>
+      </div>
+    );
+  }
+
+  // Loading contribution amount
+  if (isLoadingContribution) {
+    return (
+      <div className="bg-white dark:bg-zinc-800 rounded-xl shadow-sm border border-zinc-200 dark:border-zinc-700 p-5">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-xl">💰</span>
+          <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+            Checking Refund Eligibility…
+          </h2>
+        </div>
+        <div className="animate-pulse space-y-2">
+          <div className="h-4 bg-zinc-200 dark:bg-zinc-700 rounded w-3/4" />
+          <div className="h-8 bg-zinc-200 dark:bg-zinc-700 rounded w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  // No contribution — nothing to refund
+  if (contributionAmount === 0 && !isRefunded) {
+    return null;
+  }
+
+  // Successful refund state
+  if (isRefunded && refundedAmount !== null) {
+    return (
+      <div
+        id="refund-success-card"
+        className="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 rounded-xl p-5"
+      >
+        <div className="flex items-center gap-2 mb-3">
+          <span className="w-8 h-8 rounded-full bg-green-100 dark:bg-green-800 flex items-center justify-center text-green-600 dark:text-green-300 text-sm font-bold">
+            ✓
+          </span>
+          <h2 className="text-sm font-semibold text-green-800 dark:text-green-200">
+            Refund Claimed Successfully
+          </h2>
+        </div>
+        <div className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span className="text-green-700 dark:text-green-300">Refunded Amount</span>
+            <span className="font-bold text-green-800 dark:text-green-200">
+              {refundedAmount.toLocaleString()} XLM
+            </span>
+          </div>
+          {transactionHash && (
+            <div className="text-xs text-green-600 dark:text-green-400 break-all mt-2 p-2 bg-green-100 dark:bg-green-800/50 rounded-lg">
+              <span className="font-medium">Tx Hash: </span>
+              {transactionHash}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Refund button (main state)
+  return (
+    <div
+      id="refund-claim-card"
+      className="bg-white dark:bg-zinc-800 rounded-xl shadow-sm border border-zinc-200 dark:border-zinc-700 p-5"
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-xl">💰</span>
+        <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+          Claim Your Refund
+        </h2>
+      </div>
+
+      {/* Reason */}
+      <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
+        {campaign.isCancelled
+          ? 'This campaign was cancelled. You can reclaim your contribution.'
+          : 'The deadline passed and the funding goal was not reached. You can reclaim your contribution.'}
+      </p>
+
+      {/* Contribution info */}
+      <div className="flex items-center justify-between bg-zinc-50 dark:bg-zinc-700/50 rounded-lg p-3 mb-4">
+        <span className="text-sm text-zinc-600 dark:text-zinc-400">Your contribution</span>
+        <span className="text-lg font-bold text-zinc-900 dark:text-zinc-50">
+          {contributionAmount.toLocaleString()} XLM
+        </span>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-2 mb-3">
+          {error}
+        </div>
+      )}
+
+      {/* Claim button */}
+      <button
+        id="claim-refund-button"
+        onClick={claimRefundAction}
+        disabled={isRefunding}
+        className="w-full py-2.5 px-4 rounded-full font-semibold text-sm transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white shadow-md hover:shadow-lg"
+      >
+        {isRefunding ? (
+          <span className="flex items-center justify-center gap-2">
+            <span className="inline-block animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent" />
+            Processing Refund…
+          </span>
+        ) : (
+          `Claim Refund — ${contributionAmount.toLocaleString()} XLM`
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useRefund.ts
+++ b/src/hooks/useRefund.ts
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Campaign } from '../types';
+import { getContribution, claimRefund } from '../lib/contractClient';
+
+export interface UseRefundResult {
+  /** The contributor's refundable amount (XLM). 0 means no refund available. */
+  contributionAmount: number;
+  /** Whether the campaign qualifies for refunds (cancelled or failed). */
+  isRefundEligible: boolean;
+  /** True while fetching the contribution amount. */
+  isLoadingContribution: boolean;
+  /** True while the refund transaction is in progress. */
+  isRefunding: boolean;
+  /** True after a successful refund claim. */
+  isRefunded: boolean;
+  /** The refunded amount after a successful claim. */
+  refundedAmount: number | null;
+  /** Transaction hash of the successful refund. */
+  transactionHash: string | null;
+  /** Error message, if any. */
+  error: string | null;
+  /** Trigger the refund claim. */
+  claimRefundAction: () => Promise<void>;
+}
+
+/**
+ * Determines whether a campaign is eligible for refunds.
+ *
+ * A campaign is refund-eligible when:
+ *  - It has been cancelled, OR
+ *  - Its deadline has passed AND the funding goal was NOT reached
+ */
+function checkRefundEligibility(campaign: Campaign): boolean {
+  if (campaign.isCancelled) return true;
+  const now = Date.now() / 1000;
+  return now > campaign.deadline && campaign.amountRaised < campaign.fundingGoal;
+}
+
+/**
+ * Hook that manages the full refund-claim lifecycle for a single campaign.
+ *
+ * - Checks refund eligibility based on campaign state
+ * - Fetches the user's contribution amount via `get_contribution`
+ * - Handles the `claim_refund` contract call
+ * - Exposes success/error state for the UI
+ */
+export function useRefund(
+  campaign: Campaign | null,
+  contributor: string | null
+): UseRefundResult {
+  const [contributionAmount, setContributionAmount] = useState(0);
+  const [isLoadingContribution, setIsLoadingContribution] = useState(false);
+  const [isRefunding, setIsRefunding] = useState(false);
+  const [isRefunded, setIsRefunded] = useState(false);
+  const [refundedAmount, setRefundedAmount] = useState<number | null>(null);
+  const [transactionHash, setTransactionHash] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isRefundEligible = campaign ? checkRefundEligibility(campaign) : false;
+
+  // Fetch the contributor's contribution when the component mounts or inputs change.
+  useEffect(() => {
+    if (!campaign || !contributor || !isRefundEligible) {
+      setContributionAmount(0);
+      return;
+    }
+
+    let cancelled = false;
+
+    setIsLoadingContribution(true);
+    setError(null);
+
+    getContribution(campaign.id, contributor)
+      .then((amount) => {
+        if (!cancelled) setContributionAmount(amount);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch contribution.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingContribution(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [campaign?.id, contributor, isRefundEligible]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const claimRefundAction = useCallback(async () => {
+    if (!campaign || !contributor) return;
+    if (isRefunded) {
+      setError('Already refunded');
+      return;
+    }
+    if (contributionAmount === 0) {
+      setError('No contribution to refund.');
+      return;
+    }
+
+    setIsRefunding(true);
+    setError(null);
+
+    try {
+      const result = await claimRefund(campaign.id, contributor);
+      setIsRefunded(true);
+      setRefundedAmount(result.refundedAmount);
+      setTransactionHash(result.transactionHash);
+      setContributionAmount(0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Refund failed. Please try again.');
+    } finally {
+      setIsRefunding(false);
+    }
+  }, [campaign, contributor, isRefunded, contributionAmount]);
+
+  return {
+    contributionAmount,
+    isRefundEligible,
+    isLoadingContribution,
+    isRefunding,
+    isRefunded,
+    refundedAmount,
+    transactionHash,
+    error,
+    claimRefundAction,
+  };
+}

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -35,6 +35,10 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: 'environment',
     targetAmount: 10000,
     currentAmount: 6500,
+    deadline: Math.floor(Date.now() / 1000) + 86400 * 30, // 30 days from now
+    fundingGoal: 10000,
+    amountRaised: 6500,
+    isCancelled: false,
   },
   {
     id: 2,
@@ -50,6 +54,10 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: 'education',
     targetAmount: 5000,
     currentAmount: 1200,
+    deadline: Math.floor(Date.now() / 1000) - 86400, // Deadline passed (yesterday)
+    fundingGoal: 5000,
+    amountRaised: 1200,
+    isCancelled: false,
   },
   {
     id: 3,
@@ -65,6 +73,10 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: 'healthcare',
     targetAmount: 15000,
     currentAmount: 8900,
+    deadline: Math.floor(Date.now() / 1000) + 86400 * 60, // 60 days from now
+    fundingGoal: 15000,
+    amountRaised: 8900,
+    isCancelled: false,
   },
   {
     id: 4,
@@ -80,6 +92,10 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: 'environment',
     targetAmount: 8000,
     currentAmount: 3200,
+    deadline: Math.floor(Date.now() / 1000) + 86400 * 45, // 45 days from now
+    fundingGoal: 8000,
+    amountRaised: 3200,
+    isCancelled: true, // Cancelled — refund eligible
   },
   {
     id: 5,
@@ -95,6 +111,10 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: 'healthcare',
     targetAmount: 6000,
     currentAmount: 900,
+    deadline: Math.floor(Date.now() / 1000) + 86400 * 20, // 20 days from now
+    fundingGoal: 6000,
+    amountRaised: 900,
+    isCancelled: false,
   },
   {
     id: 6,
@@ -110,8 +130,17 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: 'environment',
     targetAmount: 20000,
     currentAmount: 17500,
+    deadline: Math.floor(Date.now() / 1000) + 86400 * 90, // 90 days from now
+    fundingGoal: 20000,
+    amountRaised: 17500,
+    isCancelled: false,
   },
 ];
+
+// Mock contribution amounts per connected wallet (keyed by "campaignId:contributor")
+const MOCK_CONTRIBUTIONS: Record<string, number> = {};
+// Track which contributors have already claimed refunds
+const MOCK_REFUNDED: Set<string> = new Set();
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -175,6 +204,92 @@ export async function getAllCampaigns(): Promise<Campaign[]> {
   // } catch (err) {
   //   throw new Error(parseContractError(err));
   // }
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Contribution / Refund API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the contribution amount (in XLM) for a given contributor on a
+ * specific campaign. Returns 0 when the contributor has no contribution.
+ */
+export async function getContribution(
+  campaignId: number,
+  contributor: string
+): Promise<number> {
+  if (USE_MOCKS) {
+    // Simulate a small delay
+    await new Promise((r) => setTimeout(r, 300));
+
+    const key = `${campaignId}:${contributor}`;
+
+    // If already refunded, contribution is zeroed
+    if (MOCK_REFUNDED.has(key)) return 0;
+
+    // Auto-seed a mock contribution when the wallet matches the demo address
+    if (!(key in MOCK_CONTRIBUTIONS)) {
+      // Give the connected wallet a mock contribution on refund-eligible campaigns
+      const campaign = MOCK_CAMPAIGNS.find((c) => c.id === campaignId);
+      if (campaign) {
+        const isEligible =
+          campaign.isCancelled ||
+          (Date.now() / 1000 > campaign.deadline &&
+            campaign.amountRaised < campaign.fundingGoal);
+        if (isEligible) {
+          // Seed a random contribution between 50 – 500 XLM
+          MOCK_CONTRIBUTIONS[key] = Math.floor(Math.random() * 451) + 50;
+        }
+      }
+    }
+
+    return MOCK_CONTRIBUTIONS[key] ?? 0;
+  }
+
+  // TODO(#14): Replace with real Soroban contract call
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+/**
+ * Claims a refund for a contributor on a failed/cancelled campaign.
+ * Returns a mock transaction hash on success.
+ */
+export async function claimRefund(
+  campaignId: number,
+  contributor: string
+): Promise<{ transactionHash: string; refundedAmount: number }> {
+  if (USE_MOCKS) {
+    // Simulate network delay
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const key = `${campaignId}:${contributor}`;
+
+    // Check if already refunded
+    if (MOCK_REFUNDED.has(key)) {
+      throw new Error('Already refunded');
+    }
+
+    const amount = MOCK_CONTRIBUTIONS[key] ?? 0;
+    if (amount === 0) {
+      throw new Error('No contribution found for this campaign.');
+    }
+
+    // Mark as refunded and zero the contribution
+    MOCK_REFUNDED.add(key);
+    MOCK_CONTRIBUTIONS[key] = 0;
+
+    return {
+      transactionHash: `mock_refund_tx_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
+      refundedAmount: amount,
+    };
+  }
+
+  // TODO(#14): Replace with real Soroban contract call
   throw new Error(
     'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,18 @@ export interface Campaign {
   category: string;
   targetAmount: number;  // in XLM
   currentAmount: number; // in XLM
+  deadline: number;      // Unix timestamp (seconds) — campaign end date
+  fundingGoal: number;   // funding goal in XLM (mirrors targetAmount on-chain)
+  amountRaised: number;  // total amount raised in XLM
+  isCancelled: boolean;  // true if the campaign was cancelled by creator/admin
+}
+
+/** Result returned after a successful refund claim. */
+export interface RefundResult {
+  campaignId: number;
+  contributor: string;
+  refundedAmount: number; // in XLM
+  transactionHash: string;
 }
 
 /** @deprecated Use Campaign instead — will be removed once contract integration is complete. */


### PR DESCRIPTION
Fixes #28

## Description
This PR implements the frontend UI and integration logic for claiming refunds on campaigns that have been cancelled or have failed to reach their funding goal by the deadline, thereby fulfilling the requirements of issue #28.

## Tasks and Fixes Made
- **Interface Updates:** Expanded the `Campaign` type definition to include new fields reflecting refund eligibility parameters (`deadline`, `fundingGoal`, `amountRaised`, and `isCancelled`) aligned with the underlying Soroban contract structure.
- **Contract Integration (Mock Layer):** Implemented `getContribution` and `claimRefund` functions in the contract client. Added refund-eligible mock campaigns to allow testing of the refund UI without requiring active mainnet contract deployment.
- **State Management:** Developed the `useRefund` React hook which independently computes eligibility checks (i.e., verifying if a campaign is explicitly cancelled or missed its funding deadline) and handles the entire sequence of fetching contribution amounts and performing the refund transaction.
- **UI Components:** Created a dedicated `RefundButton` component. This component dynamically renders the refund UI based on the user's connection status, their historical contribution amount, and the campaign's eligibility status. Additionally, it provides visual feedback during the mock transaction and upon successful completion, showing the refunded amount and transaction hash.
- **Page Integration:** Integrated the new `RefundButton` appropriately into the campaign details page UI (`app/causes/[id]/page.tsx`), alongside a new 'Cancelled' badge to indicate such campaigns within the view.
Closes #28 