### PR TITLE
feat: wire VotingComponent to contract voting functions (#44)

### DIFF
--- a/src/app/causes/[id]/page.tsx
+++ b/src/app/causes/[id]/page.tsx
@@ -3,11 +3,9 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
-import { Campaign, Vote } from '../../../types';
+import { Campaign } from '../../../types';
 import { useCampaign } from '../../../hooks/useCampaign';
-import { stellarVotingService } from '../../../services/stellarVoting';
 import { useToast } from '../../../components/ToastProvider';
-import { parseContractError } from '../../../utils/contractErrors';
 import VotingComponent from '../../../components/VotingComponent';
 import WalletConnection from '../../../components/WalletConnection';
 
@@ -36,74 +34,23 @@ export default function CauseDetailPage() {
 
   const { campaign: fetchedCampaign, isLoading, error, notFound } = useCampaign(id);
 
-  // Local copy for optimistic vote updates
+  // Local copy so we can refresh after a vote
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [userWalletAddress, setUserWalletAddress] = useState<string | null>(null);
-  const [userVote, setUserVote] = useState<Vote | undefined>(undefined);
-  const [isVoting, setIsVoting] = useState(false);
-  const { showError, showSuccess, showWarning } = useToast();
+  useToast(); // keep ToastProvider in context; toasts are shown inside VotingComponent
 
   useEffect(() => {
     if (fetchedCampaign) setCampaign(fetchedCampaign);
   }, [fetchedCampaign]);
 
-  useEffect(() => {
-    if (!userWalletAddress || !campaign) return;
-    const existing = stellarVotingService.getUserVote(String(campaign.id), userWalletAddress);
-    if (existing) {
-      setUserVote({
-        causeId: String(campaign.id),
-        voter: userWalletAddress,
-        voteType: existing.voteType,
-        timestamp: existing.timestamp,
-        transactionHash: 'mock-hash',
-      });
-    }
-  }, [userWalletAddress, campaign]);
-
   const handleWalletConnected = (publicKey: string) => setUserWalletAddress(publicKey);
-  const handleWalletDisconnected = () => {
-    setUserWalletAddress(null);
-    setUserVote(undefined);
-  };
+  const handleWalletDisconnected = () => setUserWalletAddress(null);
 
-  const handleVote = async (campaignId: number, voteType: 'upvote' | 'downvote') => {
-    if (!userWalletAddress) {
-      showWarning('Please connect your wallet first.');
-      return;
-    }
-    const id = String(campaignId);
-    if (stellarVotingService.hasUserVoted(id, userWalletAddress)) {
-      showWarning('You have already voted on this cause.');
-      return;
-    }
-    setIsVoting(true);
-    try {
-      const transactionHash = await stellarVotingService.castVote(id, voteType, userWalletAddress);
-      const newVote: Vote = {
-        causeId: id,
-        voter: userWalletAddress,
-        voteType,
-        timestamp: new Date(),
-        transactionHash,
-      };
-      setUserVote(newVote);
-      setCampaign((prev) =>
-        prev
-          ? {
-              ...prev,
-              upvotes: voteType === 'upvote' ? prev.upvotes + 1 : prev.upvotes,
-              downvotes: voteType === 'downvote' ? prev.downvotes + 1 : prev.downvotes,
-              totalVotes: prev.totalVotes + 1,
-            }
-          : prev
-      );
-      showSuccess('Your vote has been cast successfully.');
-    } catch (error) {
-      showError(parseContractError(error));
-    } finally {
-      setIsVoting(false);
-    }
+  // Refresh campaign data after a successful vote
+  const handleVoteSuccess = () => {
+    // Re-trigger useCampaign by bumping a key would require refetch; for now
+    // VotingComponent manages its own live counts via contract calls.
+    // If the parent needs a full refresh, wire useCampaign's refetch here.
   };
 
   // -------------------------------------------------------------------------
@@ -269,9 +216,7 @@ export default function CauseDetailPage() {
             <VotingComponent
               campaign={campaign}
               userWalletAddress={userWalletAddress}
-              onVote={handleVote}
-              userVote={userVote}
-              isVoting={isVoting}
+              onVoteSuccess={handleVoteSuccess}
             />
 
             {/* Creator info */}

--- a/src/components/VotingComponent.tsx
+++ b/src/components/VotingComponent.tsx
@@ -1,68 +1,144 @@
 'use client';
 
-import { useState } from 'react';
-import { Campaign, Vote } from '../types';
+import { useState, useEffect, useCallback } from 'react';
+import { Campaign } from '../types';
 import { useToast } from './ToastProvider';
 import { parseContractError } from '../utils/contractErrors';
+import {
+  voteOnCampaign,
+  getApproveVotes,
+  getRejectVotes,
+  hasVoted,
+  verifyWithVotes,
+  getMinVotesQuorum,
+  getApprovalThresholdBps,
+} from '../lib/contractClient';
 
 interface VotingComponentProps {
   campaign: Campaign;
   userWalletAddress: string | null;
-  onVote: (campaignId: number, voteType: 'upvote' | 'downvote') => Promise<void>;
-  userVote?: Vote;
-  isVoting: boolean;
+  /** Called after a successful vote so the parent can refresh campaign data. */
+  onVoteSuccess?: () => void;
+}
+
+interface VoteState {
+  approves: number;
+  rejects: number;
+  quorum: number;
+  thresholdBps: number;
+  alreadyVoted: boolean;
+  isLoading: boolean;
 }
 
 export default function VotingComponent({
   campaign,
   userWalletAddress,
-  onVote,
-  userVote,
-  isVoting,
+  onVoteSuccess,
 }: VotingComponentProps) {
-  const [localVote, setLocalVote] = useState<'upvote' | 'downvote' | null>(
-    userVote?.voteType ?? null
-  );
-  const { showError, showWarning } = useToast();
+  const { showError, showWarning, showSuccess } = useToast();
 
-  const handleVote = async (voteType: 'upvote' | 'downvote') => {
+  const [voteState, setVoteState] = useState<VoteState>({
+    approves: campaign.upvotes,
+    rejects: campaign.downvotes,
+    quorum: 10,
+    thresholdBps: 6000,
+    alreadyVoted: false,
+    isLoading: true,
+  });
+  const [isVoting, setIsVoting] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  // Fetch live vote counts + quorum config + has_voted status
+  const fetchVoteData = useCallback(async () => {
+    setVoteState((s) => ({ ...s, isLoading: true }));
+    try {
+      const [approves, rejects, quorum, thresholdBps] = await Promise.all([
+        getApproveVotes(campaign.id),
+        getRejectVotes(campaign.id),
+        getMinVotesQuorum(),
+        getApprovalThresholdBps(),
+      ]);
+
+      const alreadyVoted = userWalletAddress
+        ? await hasVoted(campaign.id, userWalletAddress)
+        : false;
+
+      setVoteState({ approves, rejects, quorum, thresholdBps, alreadyVoted, isLoading: false });
+    } catch (err) {
+      // Fall back to campaign prop values on error so UI still renders
+      setVoteState((s) => ({
+        ...s,
+        approves: campaign.upvotes,
+        rejects: campaign.downvotes,
+        isLoading: false,
+      }));
+    }
+  }, [campaign.id, campaign.upvotes, campaign.downvotes, userWalletAddress]);
+
+  useEffect(() => {
+    fetchVoteData();
+  }, [fetchVoteData]);
+
+  const totalVotes = voteState.approves + voteState.rejects;
+  const approvalRate =
+    totalVotes > 0 ? Math.round((voteState.approves / totalVotes) * 100) : 0;
+  const quorumMet = totalVotes >= voteState.quorum;
+  const thresholdMet = approvalRate >= voteState.thresholdBps / 100;
+  const canVerify = quorumMet && thresholdMet && campaign.status === 'pending';
+
+  const handleVote = async (approve: boolean) => {
     if (!userWalletAddress) {
       showWarning('Please connect your wallet to vote.');
       return;
     }
-    if (isVoting) return;
+    if (voteState.alreadyVoted) {
+      showWarning('You have already voted on this campaign.');
+      return;
+    }
+    setIsVoting(true);
     try {
-      await onVote(campaign.id, voteType);
-      setLocalVote(voteType);
-    } catch (error) {
-      console.error('Voting failed:', error);
-      showError(parseContractError(error));
+      await voteOnCampaign(campaign.id, userWalletAddress, approve);
+      showSuccess('Your vote has been cast successfully.');
+      await fetchVoteData();
+      onVoteSuccess?.();
+    } catch (err) {
+      showError(parseContractError(err));
+    } finally {
+      setIsVoting(false);
     }
   };
 
-  const getVoteButtonClass = (voteType: 'upvote' | 'downvote') => {
-    const isSelected = localVote === voteType;
-    const base =
-      'flex items-center gap-2 px-4 py-2 rounded-full font-medium transition-all duration-200 transform hover:scale-105';
-    if (voteType === 'upvote') {
-      return isSelected
-        ? `${base} bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 border-2 border-green-300 dark:border-green-700`
-        : `${base} bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-2 border-zinc-300 dark:border-zinc-600 hover:bg-green-50 dark:hover:bg-green-900/20`;
+  const handleVerify = async () => {
+    if (!userWalletAddress) {
+      showWarning('Please connect your wallet to verify.');
+      return;
     }
-    return isSelected
-      ? `${base} bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 border-2 border-red-300 dark:border-red-700`
-      : `${base} bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-2 border-zinc-300 dark:border-zinc-600 hover:bg-red-50 dark:hover:bg-red-900/20`;
+    setIsVerifying(true);
+    try {
+      await verifyWithVotes(campaign.id);
+      showSuccess('Campaign verified successfully.');
+      onVoteSuccess?.();
+    } catch (err) {
+      showError(parseContractError(err));
+    } finally {
+      setIsVerifying(false);
+    }
   };
+
+  const btnBase =
+    'flex items-center gap-2 px-4 py-2 rounded-full font-medium transition-all duration-200 transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100';
 
   return (
     <div className="flex flex-col items-center gap-4 p-4 bg-white dark:bg-zinc-800 rounded-lg shadow-sm border border-zinc-200 dark:border-zinc-700">
       <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">Vote on this cause</h3>
 
+      {/* Vote buttons */}
       <div className="flex gap-3">
         <button
-          onClick={() => handleVote('upvote')}
-          disabled={isVoting || !userWalletAddress}
-          className={getVoteButtonClass('upvote')}
+          onClick={() => handleVote(true)}
+          disabled={isVoting || !userWalletAddress || voteState.alreadyVoted || voteState.isLoading}
+          className={`${btnBase} bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-2 border-zinc-300 dark:border-zinc-600 hover:bg-green-50 dark:hover:bg-green-900/20`}
+          title={voteState.alreadyVoted ? 'You have already voted' : 'Approve this cause'}
         >
           <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
             <path
@@ -75,9 +151,10 @@ export default function VotingComponent({
         </button>
 
         <button
-          onClick={() => handleVote('downvote')}
-          disabled={isVoting || !userWalletAddress}
-          className={getVoteButtonClass('downvote')}
+          onClick={() => handleVote(false)}
+          disabled={isVoting || !userWalletAddress || voteState.alreadyVoted || voteState.isLoading}
+          className={`${btnBase} bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-2 border-zinc-300 dark:border-zinc-600 hover:bg-red-50 dark:hover:bg-red-900/20`}
+          title={voteState.alreadyVoted ? 'You have already voted' : 'Reject this cause'}
         >
           <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
             <path
@@ -90,38 +167,58 @@ export default function VotingComponent({
         </button>
       </div>
 
-      <div className="text-center">
-        <div className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-          {campaign.upvotes - campaign.downvotes}
+      {/* Approval rate bar */}
+      <div className="w-full">
+        <div className="flex justify-between text-sm text-zinc-600 dark:text-zinc-400 mb-1">
+          <span>{voteState.approves} Approve</span>
+          <span>{approvalRate}% approval</span>
+          <span>{voteState.rejects} Reject</span>
         </div>
-        <div className="text-sm text-zinc-600 dark:text-zinc-400">
-          Net votes ({campaign.totalVotes} total)
+        <div className="w-full bg-red-200 dark:bg-red-900/40 rounded-full h-2">
+          <div
+            className="bg-green-500 h-2 rounded-full transition-all duration-300"
+            style={{ width: `${totalVotes > 0 ? approvalRate : 50}%` }}
+          />
         </div>
       </div>
 
-      <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-2">
-        <div
-          className="bg-gradient-to-r from-green-500 to-red-500 h-2 rounded-full transition-all duration-300"
-          style={{
-            width: `${campaign.totalVotes > 0 ? (campaign.upvotes / campaign.totalVotes) * 100 : 50}%`,
-          }}
-        />
+      {/* Quorum progress */}
+      <div className="w-full">
+        <div className="flex justify-between text-xs text-zinc-500 dark:text-zinc-400 mb-1">
+          <span>Voting quorum</span>
+          <span>
+            {totalVotes} of {voteState.quorum} votes needed
+          </span>
+        </div>
+        <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-1.5">
+          <div
+            className={`h-1.5 rounded-full transition-all duration-300 ${quorumMet ? 'bg-blue-500' : 'bg-zinc-400'}`}
+            style={{ width: `${Math.min(100, (totalVotes / voteState.quorum) * 100)}%` }}
+          />
+        </div>
       </div>
 
-      <div className="flex justify-between w-full text-sm text-zinc-600 dark:text-zinc-400">
-        <span>{campaign.upvotes} Approve</span>
-        <span>{campaign.downvotes} Reject</span>
-      </div>
+      {/* Verify button — shown only when quorum + threshold are met */}
+      {canVerify && (
+        <button
+          onClick={handleVerify}
+          disabled={isVerifying || !userWalletAddress}
+          className={`${btnBase} w-full justify-center bg-blue-600 hover:bg-blue-700 text-white border-0`}
+        >
+          {isVerifying ? 'Verifying…' : 'Verify with votes'}
+        </button>
+      )}
 
+      {/* Status messages */}
       {!userWalletAddress && (
         <p className="text-sm text-amber-600 dark:text-amber-400 text-center">
           Connect your wallet to vote on this cause
         </p>
       )}
 
-      {userVote && (
+      {voteState.alreadyVoted && (
         <p className="text-sm text-green-600 dark:text-green-400 text-center">
-          You voted to {userVote.voteType} this cause
+          You have already voted on this campaign
         </p>
       )}
     </div>

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -12,9 +12,28 @@ import { Campaign } from '../types';
 // When issue #14 lands, import ContractErrorException and parseContractError from
 // '../utils/contractErrors' to wrap raw Soroban SDK errors before re-throwing.
 
+// ---------------------------------------------------------------------------
+// Mock voting state (mirrors what the contract tracks on-chain)
+// ---------------------------------------------------------------------------
+
+/** { campaignId -> { voter -> approve } } */
+const MOCK_VOTES: Record<number, Record<string, boolean>> = {};
+
+const MOCK_MIN_VOTES_QUORUM = 10;
+const MOCK_APPROVAL_THRESHOLD_BPS = 6000; // 60%
+
 const USE_MOCKS =
   typeof process !== 'undefined' &&
   process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+
+// ---------------------------------------------------------------------------
+// Voting helpers (mock)
+// ---------------------------------------------------------------------------
+
+function mockVotesFor(campaignId: number) {
+  if (!MOCK_VOTES[campaignId]) MOCK_VOTES[campaignId] = {};
+  return MOCK_VOTES[campaignId];
+}
 
 // ---------------------------------------------------------------------------
 // Mock data (mirrors mockCauses.ts but typed as Campaign)
@@ -175,6 +194,133 @@ export async function getAllCampaigns(): Promise<Campaign[]> {
   // } catch (err) {
   //   throw new Error(parseContractError(err));
   // }
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Voting functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Casts a vote on a campaign.
+ * Maps to contract: vote_on_campaign(campaign_id, voter, approve)
+ */
+export async function voteOnCampaign(
+  campaignId: number,
+  voter: string,
+  approve: boolean
+): Promise<void> {
+  if (USE_MOCKS) {
+    await new Promise((r) => setTimeout(r, 800)); // simulate tx latency
+    const votes = mockVotesFor(campaignId);
+    if (voter in votes) throw new Error('You have already voted on this campaign.');
+    votes[voter] = approve;
+    // Reflect in mock campaign data
+    const campaign = MOCK_CAMPAIGNS.find((c) => c.id === campaignId);
+    if (campaign) {
+      if (approve) campaign.upvotes += 1;
+      else campaign.downvotes += 1;
+      campaign.totalVotes += 1;
+    }
+    return;
+  }
+
+  // TODO(#14): Replace with real Soroban contract call, e.g.:
+  // const client = new ProofOfHeartClient({ contractId: CONTRACT_ID, rpc: RPC_URL });
+  // await client.vote_on_campaign({ campaign_id: campaignId, voter, approve });
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+/**
+ * Returns the number of approve votes for a campaign.
+ * Maps to contract: get_approve_votes(campaign_id) -> u32
+ */
+export async function getApproveVotes(campaignId: number): Promise<number> {
+  if (USE_MOCKS) {
+    const votes = mockVotesFor(campaignId);
+    return Object.values(votes).filter(Boolean).length;
+  }
+
+  // TODO(#14): const result = await client.get_approve_votes({ campaign_id: campaignId });
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+/**
+ * Returns the number of reject votes for a campaign.
+ * Maps to contract: get_reject_votes(campaign_id) -> u32
+ */
+export async function getRejectVotes(campaignId: number): Promise<number> {
+  if (USE_MOCKS) {
+    const votes = mockVotesFor(campaignId);
+    return Object.values(votes).filter((v) => !v).length;
+  }
+
+  // TODO(#14): const result = await client.get_reject_votes({ campaign_id: campaignId });
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+/**
+ * Checks whether a voter has already voted on a campaign.
+ * Maps to contract: has_voted(campaign_id, voter) -> bool
+ */
+export async function hasVoted(campaignId: number, voter: string): Promise<boolean> {
+  if (USE_MOCKS) {
+    return voter in mockVotesFor(campaignId);
+  }
+
+  // TODO(#14): const result = await client.has_voted({ campaign_id: campaignId, voter });
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+/**
+ * Triggers on-chain verification once quorum + threshold are met.
+ * Maps to contract: verify_campaign_with_votes(campaign_id)
+ */
+export async function verifyWithVotes(campaignId: number): Promise<void> {
+  if (USE_MOCKS) {
+    await new Promise((r) => setTimeout(r, 800));
+    const campaign = MOCK_CAMPAIGNS.find((c) => c.id === campaignId);
+    if (campaign) campaign.status = 'approved';
+    return;
+  }
+
+  // TODO(#14): await client.verify_campaign_with_votes({ campaign_id: campaignId });
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+/**
+ * Returns the minimum number of votes required for quorum.
+ * Maps to contract: get_min_votes_quorum() -> u32
+ */
+export async function getMinVotesQuorum(): Promise<number> {
+  if (USE_MOCKS) return MOCK_MIN_VOTES_QUORUM;
+
+  // TODO(#14): const result = await client.get_min_votes_quorum();
+  throw new Error(
+    'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
+  );
+}
+
+/**
+ * Returns the approval threshold in basis points (e.g. 6000 = 60%).
+ * Maps to contract: get_approval_threshold_bps() -> u32
+ */
+export async function getApprovalThresholdBps(): Promise<number> {
+  if (USE_MOCKS) return MOCK_APPROVAL_THRESHOLD_BPS;
+
+  // TODO(#14): const result = await client.get_approval_threshold_bps();
   throw new Error(
     'Live contract client is not yet wired up. Add NEXT_PUBLIC_USE_MOCKS=true to .env.local for development.'
   );

--- a/src/services/stellarVoting.ts
+++ b/src/services/stellarVoting.ts
@@ -1,5 +1,17 @@
-// Mock Stellar voting service - in production, this would integrate with actual Stellar smart contracts
-// For demonstration purposes, this simulates blockchain voting functionality
+/**
+ * @deprecated This mock service has been replaced by the real contract client.
+ * Use the voting functions in `src/lib/contractClient.ts` instead:
+ *   - voteOnCampaign(campaignId, voter, approve)
+ *   - getApproveVotes(campaignId)
+ *   - getRejectVotes(campaignId)
+ *   - hasVoted(campaignId, voter)
+ *   - verifyWithVotes(campaignId)
+ *
+ * This file is kept temporarily to avoid breaking any remaining references
+ * and will be removed in a follow-up cleanup PR.
+ */
+
+// Mock Stellar voting service - replaced by contractClient.ts voting functions
 
 export class StellarVotingService {
   // Mock storage for votes (in real implementation, this would be on-chain)


### PR DESCRIPTION
---

**feat: Wire VotingComponent to contract voting functions (#44)**

**What changed**

`contractClient.ts` — added 7 new contract-aligned functions:
- `voteOnCampaign(campaignId, voter, approve)` → maps to `vote_on_campaign`
- `getApproveVotes(campaignId)` → maps to `get_approve_votes`
- `getRejectVotes(campaignId)` → maps to `get_reject_votes`
- `hasVoted(campaignId, voter)` → maps to `has_voted`
- `verifyWithVotes(campaignId)` → maps to `verify_campaign_with_votes`
- `getMinVotesQuorum()` → maps to `get_min_votes_quorum`
- `getApprovalThresholdBps()` → maps to `get_approval_threshold_bps`

Each has a mock implementation (guarded by `NEXT_PUBLIC_USE_MOCKS`) and a `TODO(#14)` stub for the real Soroban RPC call.

`VotingComponent.tsx` — fully rewritten:
- Fetches live vote counts + quorum config on mount via contract functions
- `has_voted` check disables vote buttons for users who already voted
- Approval rate = `approves / (approves + rejects) * 100`
- Quorum progress bar shows "X of Y votes needed"
- "Verify with votes" button appears only when quorum is met and approval threshold is reached
- Unauthenticated users see a disabled state with a clear explanation
- Calls `onVoteSuccess` callback after a successful vote or verification

`causes/[id]/page.tsx` — removed all `stellarVotingService` usage; voting state is now owned by `VotingComponent`.

`stellarVoting.ts` — marked `@deprecated` with a pointer to `contractClient.ts`; kept to avoid breaking any stale imports until a cleanup PR removes it.

**Testing**
Set `NEXT_PUBLIC_USE_MOCKS=true` in `.env.local` and run the dev server. All voting flows work against the mock layer. Swap to real RPC once #14 lands.

**Depends on:** #14 (real Soroban RPC wiring)
Closes #44