### PR TITLE
fix(accessibility): link create-campaign field errors to inputs

### DIFF
--- a/src/__tests__/pages/CreateCampaignPage.test.tsx
+++ b/src/__tests__/pages/CreateCampaignPage.test.tsx
@@ -168,6 +168,25 @@ describe('CreateCampaignPage — client-side validation', () => {
     expect(await screen.findByText(/title is required/i)).toBeInTheDocument();
   });
 
+  it('links field errors to inputs with aria-describedby and aria-invalid', async () => {
+    render(<CreateCampaignPage />);
+    await userEvent.click(screen.getByRole('button', { name: /launch campaign/i }));
+
+    const titleInput = screen.getByLabelText(/campaign title/i);
+    const descriptionInput = screen.getByLabelText(/description/i);
+    const fundingGoalInput = screen.getByLabelText(/funding goal/i);
+    const durationInput = screen.getByLabelText(/duration/i);
+
+    expect(titleInput).toHaveAttribute('aria-invalid', 'true');
+    expect(titleInput).toHaveAttribute('aria-describedby', 'title-error');
+    expect(descriptionInput).toHaveAttribute('aria-invalid', 'true');
+    expect(descriptionInput).toHaveAttribute('aria-describedby', 'description-error');
+    expect(fundingGoalInput).toHaveAttribute('aria-invalid', 'true');
+    expect(fundingGoalInput).toHaveAttribute('aria-describedby', 'funding-goal-error');
+    expect(durationInput).toHaveAttribute('aria-invalid', 'true');
+    expect(durationInput).toHaveAttribute('aria-describedby', 'duration-days-error');
+  });
+
   it('shows a title error when title exceeds 100 characters', async () => {
     render(<CreateCampaignPage />);
     // fireEvent.change bypasses the maxLength DOM attribute so we can test the JS validator

--- a/src/app/[locale]/causes/new/page.tsx
+++ b/src/app/[locale]/causes/new/page.tsx
@@ -200,6 +200,8 @@ export default function CreateCampaignPage() {
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               maxLength={100}
+              aria-invalid={Boolean(errors.title)}
+              aria-describedby={errors.title ? 'title-error' : undefined}
               placeholder="A clear, compelling title for your campaign"
               className={`w-full px-3 py-2 rounded-lg border text-sm bg-zinc-50 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors ${
                 errors.title
@@ -209,7 +211,9 @@ export default function CreateCampaignPage() {
             />
             <div className="flex justify-between mt-1">
               {errors.title ? (
-                <p className="text-xs text-red-500">{errors.title}</p>
+                <p id="title-error" className="text-xs text-red-500">
+                  {errors.title}
+                </p>
               ) : (
                 <span />
               )}
@@ -231,6 +235,8 @@ export default function CreateCampaignPage() {
               onChange={(e) => setDescription(e.target.value)}
               maxLength={1000}
               rows={5}
+              aria-invalid={Boolean(errors.description)}
+              aria-describedby={errors.description ? 'description-error' : undefined}
               placeholder="Describe your campaign, what it aims to achieve, and how funds will be used"
               className={`w-full px-3 py-2 rounded-lg border text-sm bg-zinc-50 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y transition-colors ${
                 errors.description
@@ -240,7 +246,9 @@ export default function CreateCampaignPage() {
             />
             <div className="flex justify-between mt-1">
               {errors.description ? (
-                <p className="text-xs text-red-500">{errors.description}</p>
+                <p id="description-error" className="text-xs text-red-500">
+                  {errors.description}
+                </p>
               ) : (
                 <span />
               )}
@@ -271,6 +279,8 @@ export default function CreateCampaignPage() {
                   onChange={(e) => setFundingGoal(e.target.value)}
                   min="0.0000001"
                   step="any"
+                  aria-invalid={Boolean(errors.fundingGoal)}
+                  aria-describedby={errors.fundingGoal ? 'funding-goal-error' : undefined}
                   placeholder="e.g. 1000"
                   className={`w-full pl-12 pr-3 py-2 rounded-lg border text-sm bg-zinc-50 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors ${
                     errors.fundingGoal
@@ -280,7 +290,9 @@ export default function CreateCampaignPage() {
                 />
               </div>
               {errors.fundingGoal && (
-                <p className="text-xs text-red-500 mt-1">{errors.fundingGoal}</p>
+                <p id="funding-goal-error" className="text-xs text-red-500 mt-1">
+                  {errors.fundingGoal}
+                </p>
               )}
             </div>
 
@@ -300,6 +312,8 @@ export default function CreateCampaignPage() {
                 min="1"
                 max="365"
                 step="1"
+                aria-invalid={Boolean(errors.durationDays)}
+                aria-describedby={errors.durationDays ? 'duration-days-error' : undefined}
                 placeholder="1–365"
                 className={`w-full px-3 py-2 rounded-lg border text-sm bg-zinc-50 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors ${
                   errors.durationDays
@@ -308,7 +322,9 @@ export default function CreateCampaignPage() {
                 }`}
               />
               {errors.durationDays && (
-                <p className="text-xs text-red-500 mt-1">{errors.durationDays}</p>
+                <p id="duration-days-error" className="text-xs text-red-500 mt-1">
+                  {errors.durationDays}
+                </p>
               )}
             </div>
           </div>


### PR DESCRIPTION
Closes #101
Closes #116
Closes #117
Closes #134

## Changes
- add `aria-invalid` and `aria-describedby` to create-campaign form fields with validation
- add stable error ids: `title-error`, `description-error`, `funding-goal-error`, and `duration-days-error`
- add a test that verifies invalid fields are linked to their error messages

## Testing
- `npm.cmd test -- CreateCampaignPage.test.tsx` (fails locally in this environment because `jest` is not installed on PATH)