### PR TITLE
fix(accessibility): add explicit vote labels and percentages

### DIFF
--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -221,6 +221,8 @@ export default function CauseDetailClient({ id }: { id: string }) {
   const goal = stroopsToXlm(campaign.funding_goal);
   const fundingPct = goal > 0 ? Math.min(100, Math.round((raised / goal) * 100)) : 0;
   const approvalRate = voteCounts.totalVotes > 0 ? Math.round((voteCounts.upvotes / voteCounts.totalVotes) * 100) : 0;
+  const voteBreakdownApprovePct = voteCounts.totalVotes > 0 ? approvalRate : 50;
+  const voteBreakdownRejectPct = 100 - voteBreakdownApprovePct;
   const categoryLabel = CATEGORY_LABELS[campaign.category] ?? 'Other';
   const platformFeePercent = platformFeeBps / 100;
   const estimatedFeeAmount = raised * (platformFeeBps / 10000);
@@ -390,8 +392,11 @@ export default function CauseDetailClient({ id }: { id: string }) {
                 <span className="text-red-500 dark:text-red-400 font-medium">✗ Reject ({voteCounts.downvotes})</span>
               </div>
               <div className="w-full bg-red-200 dark:bg-red-900/40 rounded-full h-2">
-                <div className="bg-green-500 h-2 rounded-full transition-all duration-300" style={{ width: voteCounts.totalVotes > 0 ? `${(voteCounts.upvotes / voteCounts.totalVotes) * 100}%` : '50%' }} />
+                <div className="bg-green-500 h-2 rounded-full transition-all duration-300" style={{ width: `${voteBreakdownApprovePct}%` }} />
               </div>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-2">
+                {voteBreakdownApprovePct}% Approve / {voteBreakdownRejectPct}% Reject
+              </p>
               <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-2">{voteCounts.totalVotes} total votes cast</p>
             </div>
 

--- a/src/app/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/causes/[id]/CauseDetailClient.tsx
@@ -242,6 +242,8 @@ export default function CauseDetailClient({ id }: { id: string }) {
 
   const approvalRate =
     voteCounts.totalVotes > 0 ? Math.round((voteCounts.upvotes / voteCounts.totalVotes) * 100) : 0;
+  const voteBreakdownApprovePct = voteCounts.totalVotes > 0 ? approvalRate : 50;
+  const voteBreakdownRejectPct = 100 - voteBreakdownApprovePct;
 
   const categoryLabel = CATEGORY_LABELS[campaign.category] ?? 'Other';
 
@@ -456,13 +458,13 @@ export default function CauseDetailClient({ id }: { id: string }) {
                 <div
                   className="bg-green-500 h-2 rounded-full transition-all duration-300"
                   style={{
-                    width:
-                      voteCounts.totalVotes > 0
-                        ? `${(voteCounts.upvotes / voteCounts.totalVotes) * 100}%`
-                        : '50%',
+                    width: `${voteBreakdownApprovePct}%`,
                   }}
                 />
               </div>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-2">
+                {voteBreakdownApprovePct}% Approve / {voteBreakdownRejectPct}% Reject
+              </p>
               <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-2">
                 {voteCounts.totalVotes} total votes cast
               </p>

--- a/src/components/VotingComponent.tsx
+++ b/src/components/VotingComponent.tsx
@@ -94,6 +94,8 @@ export default function VotingComponent({
   // Approval rate in basis points
   const currentApprovalBps =
     totalVotes > 0 ? Math.round((upvotes / totalVotes) * 10000) : 0;
+  const approvePercent = totalVotes > 0 ? Math.round((upvotes / totalVotes) * 100) : 50;
+  const rejectPercent = 100 - approvePercent;
 
   // Verify button visible once quorum met and approval threshold reached
   const canVerify =
@@ -122,14 +124,8 @@ export default function VotingComponent({
           }
           className={`${getVoteButtonClass('upvote')} flex-1 min-h-[44px] justify-center disabled:opacity-50 disabled:cursor-not-allowed`}
         >
-          <svg className="w-5 h-5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
-            <path
-              fillRule="evenodd"
-              d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z"
-              clipRule="evenodd"
-            />
-          </svg>
-          Approve
+          <span aria-hidden="true">✓</span>
+          <span>Approve</span>
         </button>
 
         <button
@@ -146,14 +142,8 @@ export default function VotingComponent({
           }
           className={`${getVoteButtonClass('downvote')} flex-1 min-h-[44px] justify-center disabled:opacity-50 disabled:cursor-not-allowed`}
         >
-          <svg className="w-5 h-5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
-            <path
-              fillRule="evenodd"
-              d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-              clipRule="evenodd"
-            />
-          </svg>
-          Reject
+          <span aria-hidden="true">✕</span>
+          <span>Reject</span>
         </button>
       </div>
 
@@ -171,10 +161,14 @@ export default function VotingComponent({
         <div
           className="bg-green-500 h-2 rounded-full transition-all duration-300"
           style={{
-            width: `${totalVotes > 0 ? (upvotes / totalVotes) * 100 : 50}%`,
+            width: `${approvePercent}%`,
           }}
         />
       </div>
+
+      <p className="w-full text-center text-xs text-zinc-600 dark:text-zinc-400">
+        {approvePercent}% Approve / {rejectPercent}% Reject
+      </p>
 
       <div className="flex justify-between w-full text-sm text-zinc-600 dark:text-zinc-400">
         <span>{upvotes} Approve</span>


### PR DESCRIPTION
Closes #101
Closes #116
Closes #117
Closes #134

## Changes
- replace vote button chevron icons with explicit approve/reject symbols for better non-color cues
- add explicit percentage text beside vote bars: `X% Approve / Y% Reject`
- apply the vote-breakdown text update in both localized and non-localized cause detail views

## Testing
- Not run in this environment (Jest is not available on PATH)