### PR TITLE
fix(i18n): localize CampaignStatusBadge status labels

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -109,5 +109,13 @@
     "beFirstToSubmit": "Be the first to submit a cause for the community to vote on.",
     "tryDifferentKeyword": "Try a different keyword or clear the filters.",
     "tryAgain": "Try again"
+  },
+  "Status": {
+    "active": "Active",
+    "cancelled": "Cancelled",
+    "funded": "Funded",
+    "failed": "Failed",
+    "verified": "Verified",
+    "verifiedCampaign": "Verified campaign"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -109,5 +109,13 @@
     "beFirstToSubmit": "Sé el primero en enviar una causa para que la comunidad vote.",
     "tryDifferentKeyword": "Intenta con otra palabra clave o borra los filtros.",
     "tryAgain": "Intentar de nuevo"
+  },
+  "Status": {
+    "active": "Activa",
+    "cancelled": "Cancelada",
+    "funded": "Financiada",
+    "failed": "Fallida",
+    "verified": "Verificada",
+    "verifiedCampaign": "Campaña verificada"
   }
 }

--- a/src/components/CampaignStatusBadge.tsx
+++ b/src/components/CampaignStatusBadge.tsx
@@ -1,26 +1,27 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { Campaign, CampaignStatus, deriveCampaignStatus } from '../types';
 
-const STATUS_CONFIG: Record<CampaignStatus, { label: string; className: string }> = {
+const STATUS_CONFIG: Record<CampaignStatus, { key: CampaignStatus; className: string }> = {
   active: {
-    label: 'Active',
+    key: 'active',
     className: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200',
   },
   cancelled: {
-    label: 'Cancelled',
+    key: 'cancelled',
     className: 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200',
   },
   funded: {
-    label: 'Funded',
+    key: 'funded',
     className: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200',
   },
   failed: {
-    label: 'Failed',
+    key: 'failed',
     className: 'bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300',
   },
   verified: {
-    label: 'Verified',
+    key: 'verified',
     className: 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200',
   },
 };
@@ -30,6 +31,7 @@ interface CampaignStatusBadgeProps {
 }
 
 export default function CampaignStatusBadge({ campaign }: CampaignStatusBadgeProps) {
+  const t = useTranslations('Status');
   const status = deriveCampaignStatus(campaign);
   const config = STATUS_CONFIG[status];
 
@@ -38,12 +40,12 @@ export default function CampaignStatusBadge({ campaign }: CampaignStatusBadgePro
       <span
         className={`shrink-0 px-2.5 py-0.5 rounded-full text-xs font-semibold ${config.className}`}
       >
-        {config.label}
+        {t(config.key)}
       </span>
       {campaign.is_verified && status !== 'verified' && (
         <span
           className="shrink-0 inline-flex items-center gap-0.5 px-2 py-0.5 rounded-full text-xs font-semibold bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200"
-          title="Verified campaign"
+          title={t('verifiedCampaign')}
         >
           <svg
             className="w-3 h-3"
@@ -57,7 +59,7 @@ export default function CampaignStatusBadge({ campaign }: CampaignStatusBadgePro
               clipRule="evenodd"
             />
           </svg>
-          Verified
+          {t('verified')}
         </span>
       )}
     </span>


### PR DESCRIPTION
## Summary
- Replace hardcoded CampaignStatusBadge status labels with `next-intl` translations from `Status`.
- Add `Status.active`, `Status.cancelled`, `Status.funded`, `Status.failed`, `Status.verified`, and `Status.verifiedCampaign` in English and Spanish locale files.
- Keep behavior unchanged while rendering badge labels in the active locale.

## Test plan
- Switch locale to English and Spanish.
- Verify campaign badges render localized labels for active, cancelled, funded, failed, and verified.
- Verify the secondary verified pill text/tooltip are localized.

Closes Iris-IV/ProofOfHeart-frontend#126
