### PR TITLE
[DX] Clarify or remove the --webpack flag in build script

### DIFF
--- a/docs/turbopack.md
+++ b/docs/turbopack.md
@@ -1,0 +1,27 @@
+# Turbopack Transition
+
+As of Next.js 16, Turbopack is the default bundler for both development and production builds. 
+
+## Bundler Configuration
+
+Previously, the `package.json` build script forced the legacy Webpack bundler using the `--webpack` flag:
+
+```json
+"build": "next build --webpack"
+```
+
+This flag has been removed to leverage the performance benefits of Turbopack.
+
+## Reverting to Webpack
+
+If a future dependency or configuration (e.g., a custom Webpack plugin) requires the legacy bundler, you can opt back in by adding the `--webpack` flag back to the build script in `package.json`:
+
+```bash
+npm run build -- --webpack
+# or update package.json
+"build": "next build --webpack"
+```
+
+## Known Blockers
+
+No blockers were found in the current `next.config.ts` or project structure. If a build error occurs specifically with Turbopack, please document it here.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint",
     "test": "jest",


### PR DESCRIPTION
## Summary
This PR addresses issue #139 by removing the unnecessary `--webpack` flag from the build script in `package.json`. Research indicated that the flag was added without a documented technical requirement, and the current config is compatible with Next.js 16's default bundler (Turbopack).

## Changes
- Updated `package.json` to remove `--webpack` from the `build` script.
- Added `docs/turbopack.md` to document the switch and provide instructions on how to opt back into Webpack if needed.

## Testing
- Verified that `next.config.ts` does not contain custom Webpack configurations.
- Note: A full production build verification requires registry credentials for the private SDK, which the user is requested to perform.

Closes #139