### PR TITLE
fix: i18n explore page, locale router, a11y modal, unify formatAddress

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -117,5 +117,15 @@
     "failed": "Failed",
     "verified": "Verified",
     "verifiedCampaign": "Verified campaign"
+  },
+  "Explore": {
+    "title": "Explore",
+    "subtitle": "Browse causes, see community validation, and support what matters.",
+    "all": "All",
+    "noCausesYet": "No causes yet",
+    "noCausesInCategory": "No causes in this category",
+    "checkBackSoon": "Check back soon — the community is just getting started.",
+    "tryDifferentCategory": "Try selecting a different category above.",
+    "tryAgain": "Try again"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -117,5 +117,15 @@
     "failed": "Fallida",
     "verified": "Verificada",
     "verifiedCampaign": "Campaña verificada"
+  },
+  "Explore": {
+    "title": "Explorar",
+    "subtitle": "Explora causas, ve la validación de la comunidad y apoya lo que importa.",
+    "all": "Todas",
+    "noCausesYet": "Aún no hay causas",
+    "noCausesInCategory": "No hay causas en esta categoría",
+    "checkBackSoon": "Vuelve pronto — la comunidad está comenzando.",
+    "tryDifferentCategory": "Intenta seleccionar otra categoría.",
+    "tryAgain": "Intentar de nuevo"
   }
 }

--- a/src/app/[locale]/causes/page.tsx
+++ b/src/app/[locale]/causes/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import { useTranslations } from 'next-intl';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from '@/i18n/routing';
 import { Campaign, Vote, CATEGORY_LABELS, CampaignStatus, Category } from '@/types';
 import { explorerTxUrl } from '@/utils/explorer';
 import { SORT_OPTIONS } from '@/lib/mockCauses';

--- a/src/app/[locale]/explore/page.tsx
+++ b/src/app/[locale]/explore/page.tsx
@@ -2,11 +2,13 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { useCampaigns } from '@/hooks/useCampaigns';
 import { Category, CATEGORY_LABELS, stroopsToXlm } from '@/types';
 import CampaignStatusBadge from '@/components/CampaignStatusBadge';
 import FundingProgressBar from '@/components/FundingProgressBar';
 import { CampaignRowSkeleton } from '@/components/Skeleton';
+import { formatAddress } from '@/lib/formatAddress';
 
 const CATEGORY_ICONS: Record<Category, string> = {
   [Category.Learner]: '🎓',
@@ -15,11 +17,8 @@ const CATEGORY_ICONS: Record<Category, string> = {
   [Category.Publisher]: '📚',
 };
 
-function formatAddress(addr: string) {
-  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
-}
-
 export default function ExplorePage() {
+  const t = useTranslations('Explore');
   const { campaigns, isLoading, error, refetch } = useCampaigns();
   const [activeCategory, setActiveCategory] = useState<'all' | Category>('all');
 
@@ -50,10 +49,10 @@ export default function ExplorePage() {
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-14 sm:px-6">
       <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
-        Explore
+        {t('title')}
       </h1>
       <p className="mt-3 max-w-2xl text-base leading-7 text-zinc-600 dark:text-zinc-400">
-        Browse causes, see community validation, and support what matters.
+        {t('subtitle')}
       </p>
 
       {/* Category pills */}
@@ -68,7 +67,7 @@ export default function ExplorePage() {
                 : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700'
                 }`}
             >
-              {cat === 'all' ? 'All' : `${CATEGORY_ICONS[cat] ?? ''} ${CATEGORY_LABELS[cat]}`}
+              {cat === 'all' ? t('all') : `${CATEGORY_ICONS[cat] ?? ''} ${CATEGORY_LABELS[cat]}`}
             </button>
           ))}
         </div>
@@ -82,7 +81,7 @@ export default function ExplorePage() {
             onClick={refetch}
             className="px-5 py-2 bg-red-600 text-white rounded-full text-sm font-medium hover:bg-red-700 transition-colors"
           >
-            Try again
+            {t('tryAgain')}
           </button>
         </div>
       )}
@@ -101,12 +100,12 @@ export default function ExplorePage() {
         <div className="mt-16 text-center">
           <div className="text-5xl mb-4">🌐</div>
           <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50 mb-2">
-            {campaigns.length === 0 ? 'No causes yet' : 'No causes in this category'}
+            {campaigns.length === 0 ? t('noCausesYet') : t('noCausesInCategory')}
           </h2>
           <p className="text-zinc-600 dark:text-zinc-400">
             {campaigns.length === 0
-              ? 'Check back soon — the community is just getting started.'
-              : 'Try selecting a different category above.'}
+              ? t('checkBackSoon')
+              : t('tryDifferentCategory')}
           </p>
         </div>
       )}

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -7,6 +7,7 @@ import CampaignStatusBadge from './CampaignStatusBadge';
 import FundingProgressBar from './FundingProgressBar';
 import DeadlineCountdown from './DeadlineCountdown';
 import CancelCampaignModal from './cancelCampaignModal';
+import { formatAddress } from '@/lib/formatAddress';
 
 interface CauseCardProps {
   campaign: Campaign;
@@ -31,9 +32,6 @@ function formatDate(ts: number) {
   }).format(new Date(ts * 1000));
 }
 
-function formatAddress(addr: string) {
-  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
-}
 
 export default function CauseCard({
   campaign,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import { Link } from '@/i18n/routing';
 import LanguageSwitcher from "./LanguageSwitcher";
 import { getAdmin } from "@/lib/contractClient";
 import { Menu, X, Moon, Sun, ShieldCheck, Plus } from "lucide-react";
+import { formatAddress } from "@/lib/formatAddress";
 
 export default function Navbar() {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -37,7 +38,6 @@ export default function Navbar() {
     navLinks.push({ href: "/admin", label: t('admin') });
   }
 
-  const formatAddress = (address: string) => `${address.slice(0, 6)}...${address.slice(-4)}`;
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/5 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-zinc-900/80 transition-all duration-300">

--- a/src/components/WalletConnection.tsx
+++ b/src/components/WalletConnection.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getAddress, isConnected, isAllowed } from '@stellar/freighter-api';
 import { useToast } from './ToastProvider';
+import { formatAddress } from '@/lib/formatAddress';
 
 interface WalletConnectionProps {
   onWalletConnected: (publicKey: string) => void;
@@ -72,9 +73,6 @@ export default function WalletConnection({ onWalletConnected, onWalletDisconnect
     onWalletDisconnected();
   };
 
-  const formatAddress = (address: string) => {
-    return `${address.slice(0, 6)}...${address.slice(-4)}`;
-  };
 
   return (
     <div className="flex items-center gap-4">

--- a/src/components/cancelCampaignModal.tsx
+++ b/src/components/cancelCampaignModal.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+
 interface CancelCampaignModalProps {
   campaignTitle: string;
   isOpen: boolean;
@@ -22,15 +24,51 @@ export default function CancelCampaignModal({
   onConfirm,
   onClose,
 }: CancelCampaignModalProps) {
+  const keepActiveRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // ESC to close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      // Focus trap: cycle Tab/Shift+Tab between the two buttons
+      if (e.key === 'Tab') {
+        const first = keepActiveRef.current;
+        const last = cancelRef.current;
+        if (!first || !last) return;
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Auto-focus the safe "Keep Active" button when modal opens
+  useEffect(() => {
+    if (isOpen) keepActiveRef.current?.focus();
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
-    // Backdrop
+    // Backdrop — clicking outside also closes
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm px-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="cancel-modal-title"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div className="w-full max-w-md bg-white dark:bg-zinc-900 rounded-2xl shadow-2xl border border-zinc-200 dark:border-zinc-700 overflow-hidden">
         {/* Header */}
@@ -67,6 +105,7 @@ export default function CancelCampaignModal({
         {/* Actions */}
         <div className="flex gap-3 px-6 pb-6">
           <button
+            ref={keepActiveRef}
             type="button"
             onClick={onClose}
             disabled={isCancelling}
@@ -75,6 +114,7 @@ export default function CancelCampaignModal({
             Keep Active
           </button>
           <button
+            ref={cancelRef}
             type="button"
             onClick={onConfirm}
             disabled={isCancelling}

--- a/src/lib/formatAddress.ts
+++ b/src/lib/formatAddress.ts
@@ -1,0 +1,8 @@
+export function formatAddress(
+  addr: string,
+  opts?: { head?: number; tail?: number }
+): string {
+  const head = opts?.head ?? 6;
+  const tail = opts?.tail ?? 4;
+  return `${addr.slice(0, head)}...${addr.slice(-tail)}`;
+}


### PR DESCRIPTION
- #128: add Explore translation group; replace hardcoded strings with useTranslations
- #137: import useRouter from @/i18n/routing so locale is preserved on filter changes
- #106: add ESC key, focus trap, auto-focus, backdrop-click to CancelCampaignModal
- #100: extract formatAddress(addr, opts?) to src/lib/formatAddress.ts; remove duplicate inline helpers from Navbar, WalletConnection, CauseCard, explore page

closes #128
closes #100
closes #106
closes #137