### PR TITLE
[Performance] Pause polling in useCampaigns when the tab is hidden

### DIFF
--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -3,6 +3,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getAllCampaigns } from '../lib/contractClient';
 import { Campaign } from '../types';
+import { useWindowVisibility } from './useWindowVisibility';
 
 export interface UseCampaignsResult {
   campaigns: Campaign[];
@@ -16,12 +17,13 @@ const POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_POLL_INTERVAL_LISTING_MS) |
 
 export function useCampaigns(): UseCampaignsResult {
   const queryClient = useQueryClient();
+  const isVisible = useWindowVisibility();
 
-  const { data, isLoading, isFetching, error, refetch } = useQuery<Campaign[], Error>({
+  const { data, isLoading, isFetching, error } = useQuery<Campaign[], Error>({
     queryKey: ['campaigns'],
     queryFn: getAllCampaigns,
     staleTime: POLL_INTERVAL,
-    refetchInterval: POLL_INTERVAL,
+    refetchInterval: isVisible ? POLL_INTERVAL : false,
     refetchIntervalInBackground: false,
   });
 

--- a/src/hooks/useWindowVisibility.ts
+++ b/src/hooks/useWindowVisibility.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+function subscribe(callback: () => void) {
+  window.addEventListener('visibilitychange', callback);
+  return () => window.removeEventListener('visibilitychange', callback);
+}
+
+function getSnapshot() {
+  return document.visibilityState === 'visible';
+}
+
+function getServerSnapshot() {
+  return true; // Default to visible on server/during hydration
+}
+
+/**
+ * A hook that returns true if the current window/tab is visible.
+ * Uses useSyncExternalStore for optimal performance and hydration safety.
+ */
+export function useWindowVisibility() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## Summary
This PR optimizes the `useCampaigns` hook by pausing the polling interval whenever the browser tab is hidden. This ensures that no internal timers remain active when the application is not visible, reducing CPU and power consumption.

## Changes
- Introduced a new `useWindowVisibility` hook using `useSyncExternalStore` for performant and hydration-safe visibility tracking.
- Updated `useCampaigns` to dynamically enable/disable the React Query `refetchInterval` based on the window's visibility state.

## Verification
- Logic verified: `refetchInterval` will be set to `false` when the tab is backgrounded, removing the background timer.

Closes #145