### PR TITLE
[Accessibility] Add a skip-to-content link in the root layout

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -8,7 +8,8 @@
     "disconnect": "Disconnect",
     "admin": "Admin",
     "createCampaign": "Create Campaign",
-    "selectLanguage": "Select Language"
+    "selectLanguage": "Select Language",
+    "skipToMainContent": "Skip to main content"
   },
   "Home": {
     "heroTitle": "Decentralized validation for heart-driven causes.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -8,7 +8,8 @@
     "disconnect": "Desconectar",
     "admin": "Admin",
     "createCampaign": "Crear Campaña",
-    "selectLanguage": "Seleccionar Idioma"
+    "selectLanguage": "Seleccionar Idioma",
+    "skipToMainContent": "Saltar al contenido principal"
   },
   "Home": {
     "heroTitle": "Validación descentralizada para causas impulsadas por el corazón.",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,7 +7,7 @@ import { QueryProvider } from "@/components/QueryProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { NextIntlClientProvider } from 'next-intl';
-import { getMessages } from 'next-intl/server';
+import { getMessages, getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
 import "../globals.css";
@@ -35,11 +35,18 @@ export default async function RootLayout({
   // Providing all messages to the client
   // side is the easiest way to get started
   const messages = await getMessages();
+  const t = await getTranslations('Common');
 
   return (
     <html lang={locale} suppressHydrationWarning>
       <body className="antialiased">
         <NextIntlClientProvider messages={messages} locale={locale}>
+          <a 
+            href="#main" 
+            className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-3 focus:py-1 focus:text-sm focus:shadow"
+          >
+            {t('skipToMainContent')}
+          </a>
           <QueryProvider>
             <ThemeProvider>
               <ErrorBoundary>
@@ -47,7 +54,9 @@ export default async function RootLayout({
                   <WalletProvider>
                     <div className="flex min-h-screen flex-col">
                       <Navbar />
-                      <main className="flex-1">{children}</main>
+                      <main id="main" className="flex-1">
+                        {children}
+                      </main>
                       <Footer />
                     </div>
                   </WalletProvider>


### PR DESCRIPTION
## Summary
This PR improves accessibility for keyboard and screen reader users by adding a "Skip to main content" link at the very top of the root layout. This allows users to bypass navigation menus and reach the primary content directly.

## Changes
- Added `skipToMainContent` localized strings to `en.json` and `es.json`.
- Inlined the skip link in `layout.tsx` with appropriate `sr-only` and focus styles.
- Added `id="main"` to the main content area in the layout.

## Verification
- Pressing `Tab` as the first action on any page will now focus and display the skip link.
- Activating the link jumps focus to the `<main>` element.

Closes #112