### PR TITLE
fix: revenue share slider UX, locale static params, ISR revalidation, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot configuration — Issue #176
+# Keeps npm dependencies and GitHub Actions up to date automatically.
+# PRs are opened weekly so security advisories are caught promptly.
+
+version: 2
+
+updates:
+  # ── npm (frontend) ─────────────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Batch all non-breaking patch/minor updates for major frameworks together
+      # to reduce PR noise while still surfacing major-version bumps individually.
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      next-ecosystem:
+        patterns:
+          - "next"
+          - "@next/*"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "jest"
+          - "@jest/*"
+      linting:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+          - "prettier"
+
+  # ── GitHub Actions ──────────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -87,7 +87,8 @@ export default function CreateCampaignPage() {
   const [durationDays, setDurationDays] = useState('');
   const [category, setCategory] = useState<Category>(Category.Learner);
   const [hasRevenueSharing, setHasRevenueSharing] = useState(false);
-  const [revenueSharePercentage, setRevenueSharePercentage] = useState(1);
+  // #110 — default 5 % (500 bps); state is percent, converted to bps at submit
+  const [revenueSharePercentage, setRevenueSharePercentage] = useState(5);
   const [errorKeys, setErrorKeys] = useState<FormErrorKeys>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isReviewOpen, setIsReviewOpen] = useState(false);
@@ -482,6 +483,10 @@ export default function CreateCampaignPage() {
               </div>
 
               {hasRevenueSharing && (
+                // #110 — slider now models percent directly (0.5 % steps) so
+                // round percentages are easy to hit. A companion bps input lets
+                // users enter exact values when they need them. Submitted value
+                // is still converted to bps at submit time.
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <label
@@ -492,27 +497,55 @@ export default function CreateCampaignPage() {
                     </label>
                     <span className="text-sm font-semibold text-blue-600 dark:text-blue-400 tabular-nums">
                       {revenueSharePercentage.toFixed(2)}%
-                      <span className="text-xs text-zinc-400 font-normal ml-1">
-                        ({Math.round(revenueSharePercentage * 100)} bps)
-                      </span>
                     </span>
                   </div>
+
+                  {/* Slider — operates in percent, 0.5 % steps (#110) */}
                   <input
                     id="revenueShareSlider"
                     type="range"
-                    min="1"
-                    max="5000"
-                    step="1"
-                    value={Math.round(revenueSharePercentage * 100)}
+                    min="0.5"
+                    max="50"
+                    step="0.5"
+                    value={revenueSharePercentage}
                     onChange={(e) =>
-                      setRevenueSharePercentage(parseInt(e.target.value, 10) / 100)
+                      setRevenueSharePercentage(parseFloat(e.target.value))
                     }
+                    aria-label={t('labelRevenueSharePct')}
                     className="w-full h-2 rounded-full accent-blue-600 cursor-pointer"
                   />
                   <div className="flex justify-between text-xs text-zinc-400 mt-1">
-                    <span>0.01%</span>
+                    <span>0.5%</span>
                     <span>50%</span>
                   </div>
+
+                  {/* Precise bps input for exact values (#110) */}
+                  <div className="flex items-center gap-2 mt-2">
+                    <label
+                      htmlFor="revenueShareBps"
+                      className="text-xs text-zinc-500 dark:text-zinc-400 shrink-0"
+                    >
+                      Exact bps:
+                    </label>
+                    <input
+                      id="revenueShareBps"
+                      type="number"
+                      inputMode="numeric"
+                      min="1"
+                      max="5000"
+                      step="1"
+                      value={Math.round(revenueSharePercentage * 100)}
+                      onChange={(e) => {
+                        const bps = parseInt(e.target.value, 10);
+                        if (!isNaN(bps) && bps >= 1 && bps <= 5000) {
+                          setRevenueSharePercentage(bps / 100);
+                        }
+                      }}
+                      className="w-24 rounded-lg border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-900 outline-none transition focus:border-blue-500 focus:ring-1 focus:ring-blue-200 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-50"
+                    />
+                    <span className="text-xs text-zinc-400">/ 10 000</span>
+                  </div>
+
                   {err('revenueSharePercentage') && (
                     <p className="text-xs text-red-500 mt-1">{err('revenueSharePercentage')}</p>
                   )}

--- a/src/app/[locale]/causes/page.tsx
+++ b/src/app/[locale]/causes/page.tsx
@@ -1,6 +1,11 @@
 import { buildAlternates } from "@/lib/seo";
 import CausesClient from "./CausesClient";
 
+// #151 — ISR: allow the edge cache to serve a stale snapshot of the /causes
+// listing for up to 30 seconds before revalidating in the background. This
+// improves TTFB and SEO without sacrificing data freshness for active users.
+export const revalidate = 30;
+
 export function generateMetadata() {
   return {
     alternates: buildAlternates("/causes"),

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,12 @@ import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
 import "../globals.css";
 
+// #138 — Pre-render locale shells at build time so /en and /es appear in the
+// static-pages section of the build output instead of being dynamic routes.
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
 export const metadata: Metadata = {
   title: "ProofOfHeart",
   description:


### PR DESCRIPTION
## Summary

- **#110** — `NewCauseClient.tsx`: slider now operates in percent with `step=0.5` (was raw bps with `step=1`), making round percentages trivial to hit; added a companion "Exact bps" number input beside it so users who need sub-0.5% precision can still type an exact value; bps conversion still happens at submit time; default changed from 1 (0.01%) to 5 (5%)
- **#138** — `[locale]/layout.tsx`: exported `generateStaticParams()` that maps `routing.locales` to `{ locale }` objects — Next.js now pre-renders `/en` and `/es` shells at build time so they appear in the static-pages section of the build output
- **#151** — `[locale]/causes/page.tsx`: added `export const revalidate = 30` so the edge cache can serve a stale snapshot of the `/causes` listing for up to 30 s before revalidating in the background, improving TTFB and SEO without sacrificing freshness
- **#176** — `.github/dependabot.yml`: weekly npm + GitHub Actions dependency PRs (Monday 09:00 UTC); npm updates grouped by ecosystem (react, next, testing, linting) to reduce PR noise while still surfacing major-version bumps individually; `open-pull-requests-limit` set to 10/5 to avoid flooding the queue

## Test plan

- [ ] Revenue share slider: drag to 10% lands exactly on 10.00% / 1000 bps; typing `750` in the bps input shows 7.50%
- [ ] `next build` output lists `/en` and `/es` as static pages (not λ dynamic)
- [ ] `/causes` route shows `revalidate: 30` in build output (ISR)
- [ ] Dependabot PRs start appearing on the following Monday after merge

Closes #110
Closes #138
Closes #151
Closes #176