### PR TITLE
feat: fixed issue #178

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   reactCompiler: true,
   outputFileTracingRoot: path.join(__dirname),
   async redirects() {


### PR DESCRIPTION
Close #178 

     - Container boots cleanly
     - App serves without 404s on routes/assets
     - No "missing static" errors in console
The standalone output will be generated at .next/standalone during the Docker build, which the Dockerfile copies to run the production server.