### PR TITLE
Feat/fix issue #153

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   reactCompiler: true,
   outputFileTracingRoot: path.join(__dirname),
   async redirects() {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,6 @@
+export default function robots() {
+  return {
+    rules: [{ userAgent: '*', allow: '/', disallow: ['/admin', '/api'] }],
+    sitemap: `${process.env.NEXT_PUBLIC_SITE_URL}/sitemap.xml`,
+  };
+}


### PR DESCRIPTION
Close #153

  ✦ Created /src/app/robots.ts. At build time, Next.js will generate /robots.txt that:
     - Allows all crawlers (*) to access /
     - Blocks /admin and /api routes
     - References the sitemap at {NEXT_PUBLIC_SITE_URL}/sitemap.xml