### PR TITLE
Feat/campaign tags

### DIFF
--- a/src/app/[locale]/causes/CausesClient.tsx
+++ b/src/app/[locale]/causes/CausesClient.tsx
@@ -44,6 +44,7 @@ function CausesContent() {
   const [category, setCategory] = useState(searchParams.get('category') ?? 'all');
   const [status, setStatus] = useState(searchParams.get('status') ?? 'all');
   const [sort, setSort] = useState(searchParams.get('sort') ?? 'newest');
+  const [tag, setTag] = useState(searchParams.get('tag') ?? '');
 
   const debouncedSearch = useDebounce(rawSearch, 300);
 
@@ -70,9 +71,10 @@ function CausesContent() {
     if (category !== 'all') params.set('category', category);
     if (status !== 'all') params.set('status', status);
     if (sort !== 'newest') params.set('sort', sort);
+    if (tag) params.set('tag', tag);
     const qs = params.toString();
     router.replace(qs ? `/causes?${qs}` : '/causes', { scroll: false });
-  }, [debouncedSearch, category, status, sort, router]);
+  }, [debouncedSearch, category, status, sort, tag, router]);
 
   // Load user votes whenever wallet or campaigns change
   const loadUserVotes = useCallback(async () => {
@@ -203,14 +205,16 @@ function CausesContent() {
       const q = debouncedSearch.toLowerCase();
       result = result.filter(
         (c) =>
-          c.title.toLowerCase().includes(q) ||
-          c.description.toLowerCase().includes(q) ||
-          (CATEGORY_LABELS[c.category] ?? '').toLowerCase().includes(q)
-      );
-    }
-
-    if (category !== 'all') result = result.filter((c) => String(c.category) === category);
-    if (status !== 'all') result = result.filter((c) => c.status === status);
+            c.title.toLowerCase().includes(q) ||
+            c.description.toLowerCase().includes(q) ||
+            (CATEGORY_LABELS[c.category] ?? '').toLowerCase().includes(q) ||
+            c.tags?.some((t) => t.toLowerCase().includes(q))
+        );
+      }
+  
+      if (category !== 'all') result = result.filter((c) => String(c.category) === category);
+      if (status !== 'all') result = result.filter((c) => c.status === status);
+      if (tag) result = result.filter((c) => c.tags?.includes(tag));
 
     switch (sort) {
       case 'oldest':
@@ -242,16 +246,17 @@ function CausesContent() {
     }
 
     return result;
-  }, [campaigns, debouncedSearch, category, status, sort, voteCounts]);
+  }, [campaigns, debouncedSearch, category, status, sort, tag, voteCounts]);
 
   const hasActiveFilters =
-    debouncedSearch || category !== 'all' || status !== 'all' || sort !== 'newest';
+    debouncedSearch || category !== 'all' || status !== 'all' || sort !== 'newest' || tag;
 
   const clearFilters = () => {
     setRawSearch('');
     setCategory('all');
     setStatus('all');
     setSort('newest');
+    setTag('');
   };
 
   // -------------------------------------------------------------------------
@@ -269,6 +274,20 @@ function CausesContent() {
           <p className="text-zinc-600 dark:text-zinc-400">
             {t('pageSubtitle')}
           </p>
+          {tag && (
+            <div className="flex items-center gap-2 mt-4 px-3 py-1.5 bg-blue-50 dark:bg-blue-900/30 border border-blue-100 dark:border-blue-800 rounded-lg w-fit">
+              <span className="text-xs font-bold text-blue-600 dark:text-blue-400 uppercase tracking-wider">
+                Filter: #{tag}
+              </span>
+              <button
+                onClick={() => setTag('')}
+                className="ml-1 text-blue-400 hover:text-blue-600 dark:hover:text-blue-200 transition-colors"
+                aria-label="Clear tag filter"
+              >
+                ✕
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Search + filters bar */}
@@ -437,6 +456,7 @@ function CausesContent() {
                     onVote={handleVote}
                     onCancel={handleCancel}
                     onClaimRefund={handleClaimRefund}
+                    onTagClick={(t: string) => setTag(t)}
                     userVote={userVotes[campaign.id]}
                   />
                 ))}

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -30,6 +30,7 @@ interface ReviewData {
   hasRevenueSharing: boolean;
   revenueSharePercentage: number;
   estimatedDeadlineTimestamp: number;
+  tags: string[];
 }
 
 function validateForm(
@@ -39,6 +40,7 @@ function validateForm(
   durationDays: string,
   hasRevenueSharing: boolean,
   revenueSharePercentage: number,
+  tags: string[],
 ): FormErrorKeys {
   const errors: FormErrorKeys = {};
 
@@ -93,6 +95,8 @@ export default function CreateCampaignPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isReviewOpen, setIsReviewOpen] = useState(false);
   const [reviewData, setReviewData] = useState<ReviewData | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
 
   const DRAFT_KEY = 'proof_of_heart_next_draft';
 
@@ -109,6 +113,7 @@ export default function CreateCampaignPage() {
         if (parsed.hasRevenueSharing !== undefined) setHasRevenueSharing(parsed.hasRevenueSharing);
         if (parsed.revenueSharePercentage !== undefined)
           setRevenueSharePercentage(parsed.revenueSharePercentage);
+        if (parsed.tags) setTags(parsed.tags);
       }
     } catch (e) {
       console.warn('Failed to load draft from localStorage:', e);
@@ -127,12 +132,13 @@ export default function CreateCampaignPage() {
           category,
           hasRevenueSharing,
           revenueSharePercentage,
+          tags,
         }),
       );
     } catch (e) {
       console.warn('Failed to save draft to localStorage:', e);
     }
-  }, [title, description, fundingGoal, durationDays, category, hasRevenueSharing, revenueSharePercentage]);
+  }, [title, description, fundingGoal, durationDays, category, hasRevenueSharing, revenueSharePercentage, tags]);
 
   const isStartup = category === Category.EducationalStartup;
 
@@ -179,6 +185,7 @@ export default function CreateCampaignPage() {
         reviewData.category,
         reviewData.hasRevenueSharing,
         basisPoints,
+        reviewData.tags,
       );
 
       showSuccess(t('successMessage'));
@@ -219,6 +226,7 @@ export default function CreateCampaignPage() {
       durationDays,
       hasRevenueSharing,
       revenueSharePercentage,
+      tags,
     );
 
     if (Object.keys(keys).length > 0) {
@@ -239,6 +247,7 @@ export default function CreateCampaignPage() {
       hasRevenueSharing,
       revenueSharePercentage: hasRevenueSharing ? revenueSharePercentage : 0,
       estimatedDeadlineTimestamp: Math.floor(Date.now() / 1000) + parsedDays * 86400,
+      tags,
     });
     setIsReviewOpen(true);
   };
@@ -554,6 +563,49 @@ export default function CreateCampaignPage() {
             </div>
           )}
 
+          {/* Tags */}
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              {t('labelTags')} <span className="text-xs font-normal text-zinc-400">({t('tagsLimitTip')})</span>
+            </label>
+            <div className={`flex flex-wrap gap-2 p-2 rounded-lg border bg-zinc-50 dark:bg-zinc-700 transition-colors ${tags.length >= 3 ? 'border-zinc-200 dark:border-zinc-600' : 'border-zinc-200 dark:border-zinc-600 focus-within:ring-2 focus-within:ring-blue-500'}`}>
+              {tags.map((tag: string, idx: number) => (
+                <span key={idx} className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 text-xs font-medium border border-blue-200 dark:border-blue-800 transition-all">
+                  #{tag}
+                  <button
+                    type="button"
+                    onClick={() => setTags(tags.filter((_: string, i: number) => i !== idx))}
+                    className="hover:text-blue-900 dark:hover:text-blue-100 transition-colors"
+                  >
+                    ✕
+                  </button>
+                </span>
+              ))}
+              {tags.length < 3 && (
+                <input
+                  type="text"
+                  value={tagInput}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTagInput(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                  onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                    if (e.key === 'Enter' || e.key === ',') {
+                      e.preventDefault();
+                      const val = tagInput.trim();
+                      if (val && !tags.includes(val)) {
+                        setTags([...tags, val]);
+                        setTagInput('');
+                      }
+                    }
+                  }}
+                  placeholder={tags.length === 0 ? t('placeholderTags') : ''}
+                  className="flex-1 bg-transparent border-none outline-none text-sm text-zinc-900 dark:text-zinc-50 placeholder-zinc-400 min-w-[120px]"
+                />
+              )}
+            </div>
+            <p className="text-[10px] text-zinc-400 dark:text-zinc-500">
+              {t('tagsHelpText')}
+            </p>
+          </div>
+
           {/* Actions */}
           <div className="flex items-center justify-between pt-2 border-t border-zinc-100 dark:border-zinc-700">
             <button
@@ -666,6 +718,21 @@ export default function CreateCampaignPage() {
                     {formatReviewDate(reviewData.estimatedDeadlineTimestamp)}
                   </dd>
                 </div>
+
+                {reviewData.tags.length > 0 && (
+                  <div className="rounded-xl border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 p-3">
+                    <dt className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                      {t('reviewFieldTags')}
+                    </dt>
+                    <dd className="flex flex-wrap gap-2 mt-1.5">
+                      {reviewData.tags.map((tag) => (
+                        <span key={tag} className="px-2 py-0.5 rounded bg-zinc-200 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-300 text-[10px] font-bold border border-zinc-300 dark:border-zinc-600">
+                          #{tag}
+                        </span>
+                      ))}
+                    </dd>
+                  </div>
+                )}
 
                 <div className="rounded-xl border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 p-3">
                   <dt className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -15,6 +15,7 @@ interface CauseCardProps {
   onVote: (campaignId: number, voteType: 'upvote' | 'downvote') => Promise<void>;
   onCancel: (campaignId: number) => Promise<void>;
   onClaimRefund: (campaignId: number) => Promise<void>;
+  onTagClick?: (tag: string) => void;
   userVote?: Vote;
 }
 
@@ -39,6 +40,7 @@ export default function CauseCard({
   onVote,
   onCancel,
   onClaimRefund,
+  onTagClick,
   userVote,
 }: CauseCardProps) {
   const [isVoting, setIsVoting] = useState(false);
@@ -120,6 +122,21 @@ export default function CauseCard({
         <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-3 leading-relaxed">
           {campaign.description}
         </p>
+
+        {/* Tags */}
+        {campaign.tags && campaign.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            {campaign.tags.map((tag) => (
+              <span
+                key={tag}
+                onClick={() => onTagClick?.(tag)}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-700/50 text-zinc-600 dark:text-zinc-400 text-[10px] font-medium border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors cursor-pointer"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
 
         {/* Funding progress */}
         <div className="space-y-1.5">

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -153,6 +153,7 @@ function decodeCampaign(val: StellarSdk.xdr.ScVal): Campaign {
     category: fields["category"].u32() as Category,
     has_revenue_sharing: fields["has_revenue_sharing"].b(),
     revenue_share_percentage: fields["revenue_share_percentage"].u32(),
+    tags: fields["tags"] ? (fields["tags"] as any).vec().map((v: any) => v.str().toString()) : [],
   };
 }
 
@@ -178,6 +179,7 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     has_revenue_sharing: false,
     created_at: Math.floor(Date.now() / 1000),
     revenue_share_percentage: 0,
+    tags: ["water", "rural", "health"],
   },
   {
     id: 2,
@@ -196,6 +198,7 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: Category.EducationalStartup,
     has_revenue_sharing: true,
     revenue_share_percentage: 500,
+    tags: ["education", "tech", "children"],
   },
   {
     id: 3,
@@ -214,6 +217,7 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     category: Category.Educator,
     has_revenue_sharing: false,
     revenue_share_percentage: 0,
+    tags: ["medical", "clinic", "rural"],
   },
   {
     id: 4,
@@ -409,8 +413,30 @@ export async function createCampaign(
   category: Category,
   hasRevenueSharing: boolean,
   revenueSharePercentage: number,
+  tags: string[],
 ): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_create_campaign";
+  if (USE_MOCKS) {
+    MOCK_CAMPAIGNS.push({
+      id: MOCK_CAMPAIGNS.length + 1,
+      creator,
+      title,
+      description,
+      funding_goal: fundingGoal,
+      deadline: Math.floor(Date.now() / 1000) + durationDays * 86400,
+      amount_raised: BigInt(0),
+      is_active: true,
+      status: "active",
+      created_at: Math.floor(Date.now() / 1000),
+      funds_withdrawn: false,
+      is_cancelled: false,
+      is_verified: false,
+      category,
+      has_revenue_sharing: hasRevenueSharing,
+      revenue_share_percentage: revenueSharePercentage,
+      tags,
+    });
+    return "mock_tx_create_campaign";
+  }
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
     "create_campaign",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,7 @@ export interface Campaign {
   category: Category;
   has_revenue_sharing: boolean;
   revenue_share_percentage: number; // basis points (e.g. 300 = 3%)
+  tags?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
Beyond 4 categories, there is no way for creators to tag a campaign ("community", "open-source", "africa", "education"). This PR adds support for up to 3 tags per campaign.

Proposed Changes
Added optional tags: string[] field to the 
Campaign
 interface in 
src/types/index.ts
.
Enhanced 
NewCauseClient.tsx
 to include an interactive tag input with validation (max 3 tags, alphanumeric/hyphenated).
Updated 
CauseCard.tsx
 to display interactive tag chips.
Implemented tag-based filtering logic in 
CausesClient.tsx
, allowing users to filter the campaign listing by clicking on tags.
Updated 
contractClient.ts
 with mock data support for tags.
Verification
Verified tag creation flow with validation.
Verified tags are displayed correctly on campaign cards.
Verified tag filtering narrows the listing and syncs with the URL.
Verified "active tag" filter can be cleared.


Closes #191

