### PR TITLE
a11y: hide decorative SVGs from assistive tech (#115)

### DIFF
--- a/src/app/[locale]/causes/CausesClient.tsx
+++ b/src/app/[locale]/causes/CausesClient.tsx
@@ -299,6 +299,7 @@ function CausesContent() {
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -85,7 +85,7 @@ export default function CommentItem({
       >
         {comment.isPinned && (
           <div className="flex items-center gap-1.5 text-xs font-bold text-purple-600 dark:text-purple-400 mb-3">
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
             </svg>
             Pinned by Creator
@@ -104,7 +104,7 @@ export default function CommentItem({
                 </span>
                 {isVerified && (
                   <span className="inline-flex items-center text-[10px] bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-800 px-1.5 py-0.5 rounded-full font-bold" title="Verified Signature">
-                    <svg className="w-2.5 h-2.5 mr-0.5" fill="currentColor" viewBox="0 0 20 20">
+                    <svg className="w-2.5 h-2.5 mr-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                       <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                     </svg>
                     Verified
@@ -128,8 +128,9 @@ export default function CommentItem({
                 onClick={() => onPin(comment.id, !comment.isPinned)}
                 className="opacity-0 group-hover:opacity-100 transition-opacity p-1.5 text-zinc-400 hover:text-purple-600 dark:hover:text-purple-400 rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-700"
                 title={comment.isPinned ? "Unpin Comment" : "Pin Comment"}
+                aria-label={comment.isPinned ? "Unpin Comment" : "Pin Comment"}
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
                 </svg>
               </button>
@@ -139,8 +140,9 @@ export default function CommentItem({
               disabled={comment.isReported}
               className="opacity-0 group-hover:opacity-100 transition-opacity p-1.5 text-zinc-400 hover:text-red-500 rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-700 disabled:opacity-30"
               title="Report Comment"
+              aria-label="Report Comment"
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
               </svg>
             </button>
@@ -160,7 +162,7 @@ export default function CommentItem({
             onClick={() => setShowReplyForm(!showReplyForm)}
             className="text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors flex items-center gap-1.5"
           >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
             </svg>
             Reply

--- a/src/components/CommentsList.tsx
+++ b/src/components/CommentsList.tsx
@@ -87,7 +87,7 @@ export default function CommentsList({
     return (
       <div className="bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-700 rounded-xl p-8 text-center mt-4">
         <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center">
-          <svg className="w-8 h-8 text-zinc-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-8 h-8 text-zinc-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>
         </div>

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -39,7 +39,7 @@ export default function DeadlineCountdown({ deadline }: DeadlineCountdownProps) 
   if (!timeLeft) {
     return (
       <div className="flex items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400">
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -54,7 +54,7 @@ export default function DeadlineCountdown({ deadline }: DeadlineCountdownProps) 
 
   return (
     <div className="flex items-center gap-1.5 text-sm text-zinc-700 dark:text-zinc-300">
-      <svg className="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg className="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/src/components/UpdateComposer.tsx
+++ b/src/components/UpdateComposer.tsx
@@ -148,7 +148,7 @@ export default function UpdateComposer({
             >
               {isSubmitting ? (
                 <span className="flex items-center justify-center gap-2">
-                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                   </svg>

--- a/src/components/UpdateItem.tsx
+++ b/src/components/UpdateItem.tsx
@@ -102,7 +102,7 @@ export default function UpdateItem({ update }: UpdateItemProps) {
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-800"
                     title="Cryptographically verified update"
                   >
-                    <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 20 20">
+                    <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                       <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                     </svg>
                     Verified
@@ -122,7 +122,7 @@ export default function UpdateItem({ update }: UpdateItemProps) {
         
         {/* Verification Icon - Right side */}
         <div className="hidden sm:block opacity-20 group-hover:opacity-100 transition-opacity duration-300">
-          <svg className="w-5 h-5 text-zinc-400 dark:text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 text-zinc-400 dark:text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
           </svg>
         </div>

--- a/src/components/WithdrawFunds.tsx
+++ b/src/components/WithdrawFunds.tsx
@@ -85,6 +85,7 @@ export default function WithdrawFunds({
             className="w-5 h-5 text-green-600 dark:text-green-400"
             fill="currentColor"
             viewBox="0 0 20 20"
+            aria-hidden="true"
           >
             <path
               fillRule="evenodd"


### PR DESCRIPTION
Adds aria-hidden="true" to inline SVG icons whose meaning is already conveyed by adjacent text (search magnifier, deadline clock, verified/ pinned checkmarks, reply/spinner icons, empty-state illustrations, withdrawal success indicator).

For the icon-only Pin/Report buttons in CommentItem, also adds aria-label so the button has an accessible name independent of the title attribute (which screen readers don't announce reliably).

Closes #115 