### PR TITLE
fix(dashboard): remove dead loading state (#93)

### DIFF
--- a/src/app/[locale]/dashboard/DashboardClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardClient.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import MyContributionsSection from "@/components/MyContributionsSection";
-import { DashboardSkeleton, Spinner } from "@/components/Skeleton";
+import { Spinner } from "@/components/Skeleton";
 import { useWallet } from "@/components/WalletContext";
 import { useCampaigns } from "@/hooks/useCampaigns";
 import { getStellarBalance } from "@/lib/getStellarBalance";
@@ -14,7 +14,6 @@ import { explorerTxUrl } from "@/utils/explorer";
 export default function DashboardPage() {
   const t = useTranslations("Dashboard");
   const { publicKey, isWalletConnected } = useWallet();
-  const [loading, setLoading] = useState(true);
   const { campaigns } = useCampaigns();
   const [balance, setBalance] = useState<number | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
@@ -35,9 +34,8 @@ export default function DashboardPage() {
   }, [publicKey]);
 
   useEffect(() => {
-    setLoading(false);
     if (publicKey) fetchBalance();
-  }, [isWalletConnected, publicKey, fetchBalance]);
+  }, [publicKey, fetchBalance]);
 
   const mockVotes = useMemo(
     () => [
@@ -71,8 +69,6 @@ export default function DashboardPage() {
     () => campaigns.filter((c) => isSameAddress(c.creator, publicKey)),
     [campaigns, publicKey],
   );
-
-  if (loading) return <DashboardSkeleton />;
 
   if (!isWalletConnected || !publicKey) {
     return (


### PR DESCRIPTION
The duplicate `if (loading)` block from #93 was already removed in 8197a39, but the underlying `loading` state itself is still dead code: it starts true and is unconditionally flipped to false in a useEffect on first mount, before any async work runs. The skeleton renders for exactly one render cycle and never gates anything meaningful — the async wallet check in WalletContext runs independently and isn't waited on by this state.

Removes:
- The `loading` useState
- The synchronous `setLoading(false)` in the mount effect
- The orphaned `if (loading) return <DashboardSkeleton />;` gate
- The now-unused `DashboardSkeleton` import (component still exported for the skeleton registry in Skeleton.tsx)
- The `isWalletConnected` dep on the effect, which was only there to re-trigger the no-op setLoading

The wallet-connection gate immediately below handles the unconnected case and remains untouched.


Closes #93 