### PR TITLE
fix(a11y): landmark regions and heading order audit (#120)

### DIFF
--- a/src/app/[locale]/HomeClient.tsx
+++ b/src/app/[locale]/HomeClient.tsx
@@ -16,7 +16,7 @@ export default function HomeClient() {
       <div className="absolute top-0 -right-4 w-72 h-72 bg-teal-400 rounded-full mix-blend-multiply filter blur-3xl opacity-10 motion-safe:animate-blob animation-delay-2000" />
       <div className="absolute -bottom-8 left-20 w-72 h-72 bg-purple-400 rounded-full mix-blend-multiply filter blur-3xl opacity-10 motion-safe:animate-blob animation-delay-4000" />
 
-      <main className="relative container mx-auto px-4 py-24 sm:px-6 lg:px-8">
+      <div className="relative container mx-auto px-4 py-24 sm:px-6 lg:px-8">
         {/* Hero Section */}
         <div className="text-center max-w-5xl mx-auto mb-16 sm:mb-24">
           <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm font-bold mb-8 motion-safe:animate-in fade-in slide-in-from-bottom-4 duration-500">
@@ -61,7 +61,9 @@ export default function HomeClient() {
         </div>
 
         {/* Features Section */}
-        <div className="mt-32 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+        <section aria-labelledby="features-heading" className="mt-32">
+          <h2 id="features-heading" className="sr-only">Key features</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           <FeatureCard
             icon={<Globe className="text-blue-500" />}
             title="Community First"
@@ -86,8 +88,9 @@ export default function HomeClient() {
             description="Smart contracts enforce the rules, removing the need for intermediaries."
             delay="delay-400"
           />
-        </div>
-      </main>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/app/[locale]/dashboard/DashboardClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardClient.tsx
@@ -73,9 +73,9 @@ export default function DashboardPage() {
   if (!isWalletConnected || !publicKey) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
-        <h2 className="text-xl font-semibold mb-4 text-zinc-900 dark:text-zinc-50">
+        <h1 className="text-xl font-semibold mb-4 text-zinc-900 dark:text-zinc-50">
           {t("noWalletHeading")}
-        </h2>
+        </h1>
         <Link
           href="/"
           className="px-6 py-3 min-h-[44px] inline-flex items-center bg-blue-600 text-white rounded-full font-medium hover:bg-blue-700 transition"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -35,9 +35,9 @@ export default function Footer() {
 
           <div className="flex flex-wrap gap-8">
             <div>
-              <h3 className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">
+              <h2 className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">
                 {t("productHeading")}
-              </h3>
+              </h2>
               <ul className="mt-3 space-y-2 text-sm">
                 {productLinks.map((link) => (
                   <li key={link.href}>
@@ -53,9 +53,9 @@ export default function Footer() {
             </div>
 
             <div>
-              <h3 className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">
+              <h2 className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">
                 {t("linksHeading")}
-              </h3>
+              </h2>
               <ul className="mt-3 space-y-2 text-sm">
                 <li>
                   <a


### PR DESCRIPTION
## Summary

Closes #120

Three violations found and fixed across the pages and shared components:

### 1. `HomeClient.tsx` — duplicate `<main>` landmark + h1→h3 heading skip

- **Problem:** `HomeClient` rendered its own `<main>` element while the root layout already wraps `{children}` in `<main id="main">`, producing two `<main>` landmarks on the home page.
- **Fix:** Replaced the inner `<main>` with a plain `<div>`.
- **Problem:** The hero section had an `<h1>` and the feature cards used `<h3>`, skipping `<h2>` entirely.
- **Fix:** Wrapped the feature cards in `<section aria-labelledby="features-heading">` with a visually hidden `<h2 id="features-heading" class="sr-only">Key features</h2>`. The heading chain is now h1 → h2 → h3 with no skipped levels.

### 2. `DashboardClient.tsx` — `<h2>` before `<h1>` in unauthenticated state

- **Problem:** When the wallet is not connected the component early-returns a `<h2>` ("Connect your wallet to continue") with no `<h1>` preceding it on the page, violating heading order.
- **Fix:** Changed that `<h2>` to `<h1>`. Both render paths (connected and disconnected) now each have exactly one `<h1>`.

### 3. `Footer.tsx` — `<h3>` elements with no parent `<h2>`

- **Problem:** The two navigation group labels inside `<footer>` were marked `<h3>` but there is no `<h2>` in the footer, so assistive technology encounters an orphaned heading level.
- **Fix:** Promoted both to `<h2>` — they are the top-level section headings within the footer landmark.

## Test plan

- [ ] Run axe DevTools on `/`, `/dashboard`, `/explore`, `/about`, `/causes` — no heading-order or landmark violations
- [ ] Verify page has exactly one `<main>` (layout's) and one `<header>` on all pages
- [ ] Screen reader: tab through home page — h1 hero → h2 "Key features" → h3 feature card titles announced in order
- [ ] Screen reader on Dashboard (disconnected wallet): first heading announced as h1 level
- [ ] Footer landmarks: two h2 navigation group headings announced correctly