### PR TITLE
fix(useCampaigns): make isRefreshing non-optional in result type (#94)

### DIFF
--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -8,7 +8,7 @@ import { useWindowVisibility } from './useWindowVisibility';
 export interface UseCampaignsResult {
   campaigns: Campaign[];
   isLoading: boolean;
-  isRefreshing?: boolean;
+  isRefreshing: boolean;
   error: string | null;
   refetch: () => void;
 }


### PR DESCRIPTION
The hook returns isRefreshing unconditionally as a boolean (`isFetching && !isLoading`), but the result type declared it optional. Drop the `?` so the type matches the runtime shape — consistent with useContributions which already uses a non-optional isRefreshing.

The runtime return was fixed in 756b70e (the react-query / window- visibility refactor); only the type needed updating to match. The admin dashboard refresh-button spinner already destructures isRefreshing correctly.

Closes #94 