### PR TITLE
Fix footer locale-aware navigation

### DIFF
--- a/src/__tests__/components/Footer.test.tsx
+++ b/src/__tests__/components/Footer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import Footer from '@/components/Footer';
+
+jest.mock('@/i18n/routing', () => ({
+  Link: jest.fn(({ href, children, ...props }: ComponentProps<'a'>) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  )),
+}));
+
+const localizedLinkMock = jest.requireMock('@/i18n/routing').Link as jest.Mock;
+
+describe('Footer', () => {
+  beforeEach(() => {
+    localizedLinkMock.mockClear();
+  });
+
+  it('uses locale-aware links for internal product navigation', () => {
+    render(<Footer />);
+
+    expect(localizedLinkMock).toHaveBeenCalledTimes(3);
+    expect(localizedLinkMock.mock.calls.map(([props]) => props.href)).toEqual([
+      '/',
+      '/causes',
+      '/about',
+    ]);
+  });
+
+  it('renders a clean copyright notice', () => {
+    render(<Footer />);
+
+    expect(screen.getByText(/Copyright|©/)).toHaveTextContent(
+      `© ${new Date().getFullYear()} ProofOfHeart. All rights reserved.`
+    );
+  });
+});

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import Image from "next/image";
+import { Link } from "@/i18n/routing";
 
 const productLinks = [
   { href: "/", label: "Home" },
@@ -39,7 +39,7 @@ export default function Footer() {
                 {productLinks.map((link) => (
                   <li key={link.href}>
                     <Link
-                      href={link.href}
+                      href={link.href as Parameters<typeof Link>[0]["href"]}
                       className="text-zinc-600 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-50"
                     >
                       {link.label}
@@ -80,7 +80,7 @@ export default function Footer() {
         </div>
 
         <div className="mt-10 flex flex-col gap-2 border-t border-black/5 pt-6 text-sm text-zinc-500 dark:border-white/10 dark:text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
-          <p>© {year} ProofOfHeart. All rights reserved.</p>
+          <p>&copy; {year} ProofOfHeart. All rights reserved.</p>
           <p>Built with Next.js + Stellar</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Use the app's locale-aware routing Link for internal footer product links.
- Replace the rendered copyright character with a JSX entity.
- Add a Footer regression test covering internal locale-aware links and the copyright notice.

## Why

The app routes pages under locales such as `/en` and `/es`, but the footer imported `next/link` directly. That can make footer navigation drop the active locale instead of using the project routing wrapper. The copyright notice also had a display issue in the rendered source.

## Validation

- `npm run lint`
- `npm test -- Footer --runInBand`
- `npm test -- --runInBand`
- `npm run build`