### PR TITLE
fix: perf, revalidation, ErrorBoundary hook, and campaign success UX (#301 #303 #306 #307)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,31 @@ To run the production container:
 docker run -p 3000:3000 proofofheart-frontend
 ```
 
+## 🛡 Error Reporting
+
+`src/components/ErrorBoundary.tsx` exposes an optional `onError` prop that receives a PII-safe error report (`name`, `message`, `stack`) whenever a React render error is caught.
+
+### Wiring Sentry (or another provider)
+
+1. Install the SDK: `npm install @sentry/nextjs`
+2. Follow the [Sentry Next.js setup guide](https://docs.sentry.io/platforms/javascript/guides/nextjs/) to create `sentry.client.config.ts`.
+3. Pass `onError` wherever you render `<ErrorBoundary>`:
+
+```tsx
+import * as Sentry from "@sentry/nextjs";
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+<ErrorBoundary
+  onError={({ name, message, stack }) =>
+    Sentry.captureException(Object.assign(new Error(message), { name, stack }))
+  }
+>
+  {children}
+</ErrorBoundary>
+```
+
+Only `error.name`, `error.message`, and `error.stack` are forwarded — no user data or wallet addresses are included by default.
+
 ## 📄 License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/messages/en.json
+++ b/messages/en.json
@@ -189,7 +189,7 @@
     "editDetails": "Edit Details",
     "confirmAndSign": "Confirm & Sign",
     "submitting": "Submitting\u2026",
-    "successMessage": "Campaign created successfully!",
+    "successMessage": "Campaign \"{title}\" created successfully!",
     "emailWebhookFailed": "Campaign created, but we could not save your optional email subscription.",
     "walletRequiredError": "Please connect your Freighter wallet before creating a campaign.",
     "validationTitleRequired": "Title is required.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -189,7 +189,7 @@
     "editDetails": "Editar Detalles",
     "confirmAndSign": "Confirmar y Firmar",
     "submitting": "Enviando\u2026",
-    "successMessage": "\u00a1Campa\u00f1a creada exitosamente!",
+    "successMessage": "\u00a1Campa\u00f1a \"{title}\" creada exitosamente!",
     "emailWebhookFailed": "La campa\u00f1a se cre\u00f3, pero no pudimos guardar tu suscripci\u00f3n de email opcional.",
     "walletRequiredError": "Por favor conecta tu wallet Freighter antes de crear una campa\u00f1a.",
     "validationTitleRequired": "El t\u00edtulo es obligatorio.",

--- a/src/app/[locale]/admin/AdminClient.tsx
+++ b/src/app/[locale]/admin/AdminClient.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/components/ToastProvider";
 import { useWallet } from "@/components/WalletContext";
 import { useCampaigns } from "@/hooks/useCampaigns";
@@ -45,6 +46,7 @@ import { Campaign } from "@/types";
 export default function AdminDashboard() {
   const { campaigns, isLoading, refetch, isRefreshing } = useCampaigns();
   const { publicKey, isWalletConnected, connectWallet, isLoading: isWalletLoading } = useWallet();
+  const queryClient = useQueryClient();
   const { showSuccess, showError, showWarning } = useToast();
   const t = useTranslations("Admin");
 
@@ -156,6 +158,7 @@ export default function AdminDashboard() {
       showSuccess("Campaign approved successfully!");
       setOptimisticRemovedIds((prev) => [...prev, id]);
       refetch();
+      queryClient.invalidateQueries({ queryKey: ['campaign', id] });
     } catch (err) {
       showError(parseContractError(err));
     } finally {
@@ -172,22 +175,22 @@ export default function AdminDashboard() {
     if (!campaignToReject) return;
     setCancellingId(campaignToReject.id);
     try {
-      const txHash = await cancelCampaign(id);
+      const txHash = await cancelCampaign(campaignToReject.id);
       if (publicKey) {
         appendAdminAuditLog({
           adminAddress: publicKey,
           action: "reject_campaign",
-          campaignId: id,
+          campaignId: campaignToReject.id,
           txHash,
-          details: `Rejected campaign #${id}`,
+          details: `Rejected campaign #${campaignToReject.id}`,
         });
         refreshAuditLog(publicKey);
       }
-      await cancelCampaign(campaignToReject.id);
       showSuccess("Campaign rejected and cancelled.");
       setOptimisticRemovedIds((prev) => [...prev, campaignToReject.id]);
       setIsRejectModalOpen(false);
       refetch();
+      queryClient.invalidateQueries({ queryKey: ['campaign', campaignToReject.id] });
     } catch (err) {
       showError(parseContractError(err));
     } finally {

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -267,7 +267,7 @@ export default function CreateCampaignPage() {
         publicKey,
       );
 
-      showSuccess(t('successMessage'));
+      showSuccess(t('successMessage', { title: reviewData.title }));
       setIsReviewOpen(false);
       setReviewData(null);
 
@@ -282,11 +282,13 @@ export default function CreateCampaignPage() {
       } else {
         router.push('/causes');
       }
+      // Keep isSubmitting true so the form stays disabled during navigation.
+      // The component will unmount before this matters on the success path.
+      return;
     } catch (err) {
       showError(parseContractError(err));
-    } finally {
-      setIsSubmitting(false);
     }
+    setIsSubmitting(false);
   };
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,8 +3,15 @@
 import { AlertCircle, RefreshCcw } from "lucide-react";
 import React, { Component, ErrorInfo, ReactNode } from "react";
 
+interface ErrorReport {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
 interface Props {
   children?: ReactNode;
+  onError?: (report: ErrorReport) => void;
 }
 
 interface State {
@@ -24,7 +31,11 @@ class ErrorBoundary extends Component<Props, State> {
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("Uncaught error:", error, errorInfo);
-    // Here you could add error logging to an external service like Sentry
+    this.props.onError?.({
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    });
   }
 
   private handleReset = () => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { useWallet } from "@/components/WalletContext";
 import { useTheme } from "@/hooks/useTheme";
 import { Link } from '@/i18n/routing';
-import { getAdmin } from "@/lib/contractClient";
+import { useAdmin } from "@/hooks/useAdmin";
 import { formatAddress } from "@/lib/formatAddress";
 import LanguageSwitcher from "./LanguageSwitcher";
 import NotificationBell from "./NotificationBell";
@@ -20,7 +20,7 @@ export default function Navbar() {
   const { publicKey, isWalletConnected, connectWallet, disconnectWallet, isLoading } = useWallet();
   const { theme, toggleTheme } = useTheme();
   const t = useTranslations('Common');
-  const [adminAddress, setAdminAddress] = useState<string | null>(null);
+  const { admin: adminAddress } = useAdmin();
 
   const { campaigns } = useCampaigns();
   const pendingCount = useMemo(() => {
@@ -30,10 +30,6 @@ export default function Navbar() {
   const networkPassphrase = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE || '';
   const isTestnet = networkPassphrase.includes('Test SDF');
   const isMainnet = networkPassphrase.includes('Public Global');
-
-  useEffect(() => {
-    getAdmin().then(setAdminAddress).catch(() => { });
-  }, []);
 
   useEffect(() => {
     if (!menuOpen) {

--- a/src/hooks/useCampaign.ts
+++ b/src/hooks/useCampaign.ts
@@ -18,6 +18,7 @@ export function useCampaign(id: number): UseCampaignResult {
     queryKey: ['campaign', id],
     queryFn: () => getCampaign(id),
     enabled: !!id,
+    refetchOnWindowFocus: true,
   });
 
   return {


### PR DESCRIPTION
## Summary

Closes #301 
Closes #303 
Closes #306 
Closes #307 

### #301 — [perf] Navbar no longer re-fetches admin address on every render

`Navbar` was calling `getAdmin()` in a local `useEffect`, bypassing the shared React Query cache entirely. Every Navbar re-render (theme toggle, locale switch, etc.) previously hit the contract.

- Replaced `useState` + `useEffect` with the existing `useAdmin()` hook, which already uses `staleTime: Infinity` — the admin address is fetched once per session and reused across all consumers.

### #303 — [bug] Cause detail page now revalidates after admin verify/reject

Two-part fix:

1. **Focus revalidation** — `useCampaign` now explicitly sets `refetchOnWindowFocus: true`. A user who has the detail page open in another tab will see the updated status as soon as they switch back (data becomes stale after the global 60 s window).
2. **Same-tab revalidation** — `AdminClient` calls `queryClient.invalidateQueries({ queryKey: ['campaign', id] })` after every approve/reject, so a detail page open in the same browser session updates immediately without a manual refresh.

Also fixed a pre-existing bug in `handleConfirmReject` where `cancelCampaign(id)` was called with an undefined `id` and then `cancelCampaign(campaignToReject.id)` was called a second time — the whole block now calls `cancelCampaign(campaignToReject.id)` exactly once.

**Revalidation strategy**: React Query window-focus polling (stale-while-revalidate) for cross-tab updates; direct query invalidation for same-tab admin actions. No polling or event bus needed.

### #306 — [enhancement] ErrorBoundary exposes `onError` for external trackers

`ErrorBoundary` now accepts an optional `onError(report)` prop invoked from `componentDidCatch`. The report contains only `{ name, message, stack }` — no user data or wallet addresses.

README documents how to wire Sentry using the new prop.

### #307 — [bug] Campaign creation form success UX

- The `successMessage` translation now includes `{title}` so the toast reads **"Campaign 'My Cause' created successfully!"** — directly referencing the new campaign.
- `handleConfirmAndSign` returns early on success without calling `setIsSubmitting(false)`, keeping the form and confirm button disabled for the window between the toast and navigation completing, preventing accidental duplicate submissions.

## Test plan

- [ ] Connect a non-admin wallet; theme-toggle several times; confirm DevTools Network shows no repeated `getAdmin` calls after the first.
- [ ] Open a pending campaign's detail page in one tab; approve it from the admin dashboard in the same tab; verify the status badge updates without a manual refresh.
- [ ] Switch to the detail page tab from the admin tab; verify status updates on focus.
- [ ] Wrap a page section with `<ErrorBoundary onError={console.info} />`; trigger a render error; confirm the callback fires with `{ name, message, stack }`.
- [ ] Create a campaign; confirm the success toast shows the campaign title and the form stays disabled until navigation completes.