### PR TITLE
Add transaction lifecycle, network guard, and admin audit backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node ./scripts/validate-production-build.mjs && next build",
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",

--- a/scripts/validate-production-build.mjs
+++ b/scripts/validate-production-build.mjs
@@ -1,0 +1,8 @@
+const isMockMode = process.env.NEXT_PUBLIC_USE_MOCKS === "true";
+
+if (isMockMode) {
+  console.error(
+    "Production build blocked: NEXT_PUBLIC_USE_MOCKS=true. Set NEXT_PUBLIC_USE_MOCKS=false before building.",
+  );
+  process.exit(1);
+}

--- a/src/app/[locale]/admin/AdminClient.tsx
+++ b/src/app/[locale]/admin/AdminClient.tsx
@@ -30,6 +30,7 @@ import {
   verifyCampaign,
   cancelCampaign,
 } from "@/lib/contractClient";
+import type { TransactionLifecyclePhase } from "@/lib/contractClient";
 import { isSameAddress } from "@/lib/stellar";
 import { stroopsToXlm, Category, CATEGORY_LABELS, basisPointsToPercentage } from "@/types";
 import { parseContractError } from "@/utils/contractErrors";
@@ -62,6 +63,17 @@ export default function AdminDashboard() {
   const [isUpdatingAdmin, setIsUpdatingAdmin] = useState(false);
   const [auditLog, setAuditLog] = useState<AdminAuditLogEntry[]>([]);
   const [reports, setReports] = useState<CampaignReport[]>([]);
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
+  const txPhaseLabel =
+    txPhase === "building"
+      ? "Preparing..."
+      : txPhase === "signing"
+        ? "Signing..."
+        : txPhase === "submitting"
+          ? "Submitting..."
+          : txPhase === "confirming"
+            ? "Confirming..."
+            : null;
 
   // Load reports from localStorage on mount
   useEffect(() => {
@@ -115,12 +127,12 @@ export default function AdminDashboard() {
     return isSameAddress(publicKey, adminAddress);
   }, [publicKey, adminAddress]);
 
-  const refreshAuditLog = (address = publicKey) => {
+  const refreshAuditLog = async (address = publicKey) => {
     if (!address) {
       setAuditLog([]);
       return;
     }
-    setAuditLog(getAdminAuditLog(address, 50));
+    setAuditLog(await getAdminAuditLog(address, 50));
   };
 
   const pendingCampaigns = useMemo(() => {
@@ -143,17 +155,20 @@ export default function AdminDashboard() {
 
   const handleApprove = async (id: number) => {
     setVerifyingId(id);
+    setTxPhase(null);
     try {
-      const txHash = await verifyCampaign(id);
+      const txHash = await verifyCampaign(id, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       if (publicKey) {
-        appendAdminAuditLog({
+        await appendAdminAuditLog({
           adminAddress: publicKey,
           action: "verify_campaign",
           campaignId: id,
           txHash,
           details: `Approved campaign #${id}`,
         });
-        refreshAuditLog(publicKey);
+        await refreshAuditLog(publicKey);
       }
       showSuccess("Campaign approved successfully!");
       setOptimisticRemovedIds((prev) => [...prev, id]);
@@ -163,6 +178,7 @@ export default function AdminDashboard() {
       showError(parseContractError(err));
     } finally {
       setVerifyingId(null);
+      setTxPhase(null);
     }
   };
 
@@ -174,17 +190,20 @@ export default function AdminDashboard() {
   const handleConfirmReject = async () => {
     if (!campaignToReject) return;
     setCancellingId(campaignToReject.id);
+    setTxPhase(null);
     try {
-      const txHash = await cancelCampaign(campaignToReject.id);
+      const txHash = await cancelCampaign(campaignToReject.id, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       if (publicKey) {
-        appendAdminAuditLog({
+        await appendAdminAuditLog({
           adminAddress: publicKey,
           action: "reject_campaign",
           campaignId: campaignToReject.id,
           txHash,
           details: `Rejected campaign #${campaignToReject.id}`,
         });
-        refreshAuditLog(publicKey);
+        await refreshAuditLog(publicKey);
       }
       showSuccess("Campaign rejected and cancelled.");
       setOptimisticRemovedIds((prev) => [...prev, campaignToReject.id]);
@@ -195,6 +214,7 @@ export default function AdminDashboard() {
       showError(parseContractError(err));
     } finally {
       setCancellingId(null);
+      setTxPhase(null);
     }
   };
 
@@ -212,18 +232,21 @@ export default function AdminDashboard() {
     if (isNaN(fee) || fee < 0 || fee > 10000) return showError("Invalid fee");
 
     setIsUpdatingFee(true);
+    setTxPhase(null);
     try {
-      const txHash = await updatePlatformFee(fee);
+      const txHash = await updatePlatformFee(fee, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       if (publicKey) {
         const previousFeeLabel =
           platformFee === null ? "unknown" : `${(platformFee / 100).toFixed(2)}%`;
-        appendAdminAuditLog({
+        await appendAdminAuditLog({
           adminAddress: publicKey,
           action: "update_platform_fee",
           txHash,
           details: `Updated platform fee from ${previousFeeLabel} to ${(fee / 100).toFixed(2)}% (${fee} bps)`,
         });
-        refreshAuditLog(publicKey);
+        await refreshAuditLog(publicKey);
       }
       setPlatformFee(fee);
       showSuccess("Platform fee updated");
@@ -231,6 +254,7 @@ export default function AdminDashboard() {
       showError(parseContractError(err));
     } finally {
       setIsUpdatingFee(false);
+      setTxPhase(null);
     }
   };
 
@@ -242,16 +266,19 @@ export default function AdminDashboard() {
     if (!StellarSdk.StrKey.isValidEd25519PublicKey(nextAdmin)) return showError("Invalid address");
 
     setIsUpdatingAdmin(true);
+    setTxPhase(null);
     try {
-      const txHash = await updateAdmin(nextAdmin);
+      const txHash = await updateAdmin(nextAdmin, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       if (publicKey) {
-        appendAdminAuditLog({
+        await appendAdminAuditLog({
           adminAddress: publicKey,
           action: "transfer_admin",
           txHash,
           details: `Transferred admin access to ${nextAdmin}`,
         });
-        refreshAuditLog(publicKey);
+        await refreshAuditLog(publicKey);
       }
       setAdminAddress(nextAdmin);
       setNewAdminInput("");
@@ -260,12 +287,13 @@ export default function AdminDashboard() {
       showError(parseContractError(err));
     } finally {
       setIsUpdatingAdmin(false);
+      setTxPhase(null);
     }
   };
 
   useEffect(() => {
     if (isAdmin && publicKey) {
-      refreshAuditLog(publicKey);
+      void refreshAuditLog(publicKey);
       return;
     }
     setAuditLog([]);
@@ -537,7 +565,7 @@ export default function AdminDashboard() {
                 disabled={isUpdatingFee || Number(feeInput) > 10000 || Number(feeInput) < 0}
                 className="w-full py-4 bg-zinc-950 dark:bg-white text-white dark:text-zinc-950 rounded-2xl font-black text-sm uppercase tracking-widest hover:opacity-90 active:scale-95 transition disabled:opacity-50"
               >
-                {isUpdatingFee ? t("awaitingSignature") : t("updatePlatformFee")}
+                {isUpdatingFee ? txPhaseLabel ?? t("awaitingSignature") : t("updatePlatformFee")}
               </button>
             </form>
           </section>
@@ -568,7 +596,7 @@ export default function AdminDashboard() {
                 disabled={isUpdatingAdmin}
                 className="w-full py-4 bg-red-600 text-white rounded-2xl font-black text-sm uppercase tracking-widest hover:bg-red-700 active:scale-95 transition shadow-lg shadow-red-500/25 disabled:opacity-50"
               >
-                {isUpdatingAdmin ? t("awaitingSignature") : t("transferAdmin")}
+                {isUpdatingAdmin ? txPhaseLabel ?? t("awaitingSignature") : t("transferAdmin")}
               </button>
             </form>
           </section>

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -8,7 +8,7 @@ import { useState, useEffect } from 'react';
 import { useToast } from '@/components/ToastProvider';
 import { useWallet } from '@/components/WalletContext';
 import { useRouter } from '@/i18n/routing';
-import { createCampaign, getCampaignCount } from '@/lib/contractClient';
+import { createCampaign, getCampaignCount, type TransactionLifecyclePhase } from '@/lib/contractClient';
 import { Category, CATEGORY_LABELS, xlmToStroops } from '@/types';
 import { parseContractError } from '@/utils/contractErrors';
 
@@ -119,6 +119,7 @@ export default function CreateCampaignPage() {
   const [tagInput, setTagInput] = useState('');
   const [descriptionTab, setDescriptionTab] = useState<'write' | 'preview'>('write');
   const [coverImageUrl, setCoverImageUrl] = useState('');
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
 
   const DRAFT_KEY = 'proof_of_heart_next_draft';
   const CREATOR_EMAIL_WEBHOOK_URL =
@@ -251,6 +252,9 @@ export default function CreateCampaignPage() {
         reviewData.hasRevenueSharing,
         basisPoints,
         reviewData.tags,
+        {
+          onStatus: ({ phase }) => setTxPhase(phase),
+        },
       );
 
       let newCampaignId: number | null = null;
@@ -289,6 +293,7 @@ export default function CreateCampaignPage() {
       showError(parseContractError(err));
     }
     setIsSubmitting(false);
+    setTxPhase(null);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -962,7 +967,15 @@ export default function CreateCampaignPage() {
                   {isSubmitting && (
                     <span className="inline-block motion-safe:animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent" />
                   )}
-                  {isSubmitting ? t('submitting') : t('confirmAndSign')}
+                  {isSubmitting
+                    ? txPhase === 'building'
+                      ? t('submitting')
+                      : txPhase === 'signing'
+                        ? 'Signing…'
+                        : txPhase === 'confirming'
+                          ? 'Confirming…'
+                          : t('submitting')
+                    : t('confirmAndSign')}
                 </button>
               </div>
             </div>

--- a/src/app/api/admin-audit-log/route.ts
+++ b/src/app/api/admin-audit-log/route.ts
@@ -1,0 +1,87 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+type AdminAuditAction = "verify_campaign" | "reject_campaign" | "update_platform_fee" | "transfer_admin";
+
+interface AdminAuditLogEntry {
+  adminAddress: string;
+  action: AdminAuditAction;
+  txHash: string;
+  timestamp: number;
+  campaignId?: number;
+  details?: string;
+}
+
+const DATA_DIR = path.join(process.cwd(), "data");
+const DATA_FILE = path.join(DATA_DIR, "admin-audit-log.json");
+
+async function ensureStore(): Promise<void> {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  try {
+    await fs.access(DATA_FILE);
+  } catch {
+    await fs.writeFile(DATA_FILE, "[]", "utf8");
+  }
+}
+
+async function readEntries(): Promise<AdminAuditLogEntry[]> {
+  await ensureStore();
+  try {
+    const raw = await fs.readFile(DATA_FILE, "utf8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as AdminAuditLogEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeEntries(entries: AdminAuditLogEntry[]): Promise<void> {
+  await ensureStore();
+  await fs.writeFile(DATA_FILE, JSON.stringify(entries.slice(-500), null, 2), "utf8");
+}
+
+function normalizeAddress(address: string): string {
+  return address.trim().toUpperCase();
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const adminAddress = url.searchParams.get("adminAddress");
+  const entries = await readEntries();
+
+  if (!adminAddress) {
+    return NextResponse.json({ entries });
+  }
+
+  const normalized = normalizeAddress(adminAddress);
+  return NextResponse.json({
+    entries: entries
+      .filter((entry) => normalizeAddress(entry.adminAddress) === normalized)
+      .sort((a, b) => b.timestamp - a.timestamp),
+  });
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as Partial<AdminAuditLogEntry>;
+  if (!body.adminAddress || !body.action || !body.txHash) {
+    return NextResponse.json({ error: "Invalid audit entry." }, { status: 400 });
+  }
+
+  const nextEntry: AdminAuditLogEntry = {
+    adminAddress: normalizeAddress(body.adminAddress),
+    action: body.action,
+    txHash: body.txHash,
+    timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),
+    campaignId: body.campaignId,
+    details: body.details,
+  };
+
+  const entries = await readEntries();
+  entries.push(nextEntry);
+  await writeEntries(entries);
+
+  return NextResponse.json({ entry: nextEntry }, { status: 201 });
+}

--- a/src/app/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/causes/[id]/CauseDetailClient.tsx
@@ -24,6 +24,7 @@ import {
   getContribution,
   claimRefund,
 } from "../../../lib/contractClient";
+import type { TransactionLifecyclePhase } from "../../../lib/contractClient";
 import { Campaign, Vote, CATEGORY_LABELS, stroopsToXlm } from "../../../types";
 import { parseContractError } from "../../../utils/contractErrors";
 
@@ -47,6 +48,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
   const [voteCounts, setVoteCounts] = useState({ upvotes: 0, downvotes: 0, totalVotes: 0 });
   const [isDonationModalOpen, setIsDonationModalOpen] = useState(false);
   const { showError, showSuccess, showWarning } = useToast();
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
 
   // Quorum / threshold state
   const [minVotesQuorum, setMinVotesQuorum] = useState<number | undefined>(undefined);
@@ -130,8 +132,11 @@ export default function CauseDetailClient({ id }: { id: string }) {
       return;
     }
     setIsVoting(true);
+    setTxPhase(null);
     try {
-      const txHash = await voteOnCampaign(campaignId, userWalletAddress, voteType === "upvote");
+      const txHash = await voteOnCampaign(campaignId, userWalletAddress, voteType === "upvote", {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       const newVote: Vote = {
         causeId: String(campaignId),
         voter: userWalletAddress,
@@ -151,27 +156,35 @@ export default function CauseDetailClient({ id }: { id: string }) {
       showError(parseContractError(error));
     } finally {
       setIsVoting(false);
+      setTxPhase(null);
     }
   };
 
   const handleVerifyWithVotes = async () => {
     setIsVerifying(true);
+    setTxPhase(null);
     try {
-      await verifyCampaignWithVotes(Number(id));
+      await verifyCampaignWithVotes(Number(id), {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       showSuccess("Campaign verified successfully via community vote!");
       refetch();
     } catch (error) {
       showError(parseContractError(error));
     } finally {
       setIsVerifying(false);
+      setTxPhase(null);
     }
   };
 
   const handleClaimRefund = async () => {
     if (!userWalletAddress || !campaign) return;
     setIsClaimingRefund(true);
+    setTxPhase(null);
     try {
-      const txHash = await claimRefund(campaign.id, userWalletAddress);
+      const txHash = await claimRefund(campaign.id, userWalletAddress, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       setRefundTxHash(txHash);
       setRefundableAmount(BigInt(0));
       showSuccess("Refund claimed successfully!");
@@ -185,6 +198,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
       }
     } finally {
       setIsClaimingRefund(false);
+      setTxPhase(null);
     }
   };
 
@@ -382,7 +396,13 @@ export default function CauseDetailClient({ id }: { id: string }) {
                       disabled={isClaimingRefund}
                       className="w-full min-h-[44px] py-2 px-4 bg-amber-500 hover:bg-amber-600 disabled:opacity-60 text-white font-semibold rounded-xl transition-colors text-sm"
                     >
-                      {isClaimingRefund ? "Processing…" : "Claim Refund"}
+                      {isClaimingRefund
+                        ? txPhase === "signing"
+                          ? "Signing…"
+                          : txPhase === "confirming"
+                            ? "Confirming…"
+                            : "Processing…"
+                        : "Claim Refund"}
                     </button>
                   </div>
                 ) : (

--- a/src/components/CampaignActions.tsx
+++ b/src/components/CampaignActions.tsx
@@ -20,6 +20,10 @@ import {
 import { isSameAddress } from "../lib/stellar";
 import { parseContractError } from "../utils/contractErrors";
 import { getAsyncActionErrorMessage, withActionTimeout } from "../utils/asyncAction";
+import type {
+  TransactionLifecyclePhase,
+  TransactionLifecycleOptions,
+} from "../lib/contractClient";
 
 interface CampaignActionsProps {
   campaign: Campaign;
@@ -33,6 +37,7 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
   const { platformFeeBps } = usePlatformFee();
   const { showSuccess, showError, showWarning } = useToast();
   const [isPending, setIsPending] = useState(false);
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
   const [contributionAmount, setContributionAmount] = useState("");
   const [revenueAmount, setRevenueAmount] = useState("");
   const [showRevenueInput, setShowRevenueInput] = useState(false);
@@ -41,23 +46,42 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
   const isAdmin = isSameAddress(publicKey, admin);
   const isContributor = contribution > BigInt(0);
 
-  const handleAction = async (action: () => Promise<string>, successMsg: string) => {
+  const phaseLabel =
+    txPhase === "building"
+      ? "Preparing..."
+      : txPhase === "signing"
+        ? "Signing..."
+        : txPhase === "submitting"
+          ? "Submitting..."
+          : txPhase === "confirming"
+            ? "Confirming..."
+            : null;
+
+  const handleAction = async (
+    action: (options?: TransactionLifecycleOptions) => Promise<string>,
+    successMsg: string,
+  ) => {
     setIsPending(true);
+    setTxPhase(null);
     try {
-      await withActionTimeout(action());
+      await withActionTimeout(action({ onStatus: ({ phase }) => setTxPhase(phase) }));
       showSuccess(successMsg);
       if (onActionSuccess) onActionSuccess();
     } catch (err) {
       showError(getAsyncActionErrorMessage(err, parseContractError));
     } finally {
       setIsPending(false);
+      setTxPhase(null);
     }
   };
 
   const handleDepositRevenue = async () => {
     const xlm = parseFloat(revenueAmount);
     if (!xlm || xlm <= 0) return;
-    await handleAction(() => depositRevenue(campaign.id, xlmToStroops(xlm)), "Revenue deposited!");
+    await handleAction(
+      (options) => depositRevenue(campaign.id, xlmToStroops(xlm), options),
+      "Revenue deposited!",
+    );
     setRevenueAmount("");
     setShowRevenueInput(false);
   };
@@ -107,7 +131,11 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
     }
     setIsPending(true);
     try {
-      await withActionTimeout(contribute(campaign.id, publicKey, xlmToStroops(parsedAmount)));
+      await withActionTimeout(
+        contribute(campaign.id, publicKey, xlmToStroops(parsedAmount), {
+          onStatus: ({ phase }) => setTxPhase(phase),
+        }),
+      );
       setContributionAmount("");
       showSuccess("Contribution submitted successfully.");
       onActionSuccess?.();
@@ -115,6 +143,7 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
       showError(getAsyncActionErrorMessage(err, parseContractError));
     } finally {
       setIsPending(false);
+      setTxPhase(null);
     }
   };
 
@@ -157,7 +186,7 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
                 <AsyncButtonContent
                   isPending={isPending}
                   idleLabel="Contribute"
-                  pendingLabel="Processing..."
+                  pendingLabel={phaseLabel ?? "Processing..."}
                 />
               </button>
             </div>
@@ -184,7 +213,7 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
             <div className="flex flex-col gap-3">
               <button
                 onClick={() =>
-                  handleAction(() => cancelCampaign(campaign.id), "Campaign cancelled.")
+                  handleAction((options) => cancelCampaign(campaign.id, options), "Campaign cancelled.")
                 }
                 disabled={
                   isPending ||
@@ -197,7 +226,7 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
                 <AsyncButtonContent
                   isPending={isPending}
                   idleLabel="Cancel Campaign"
-                  pendingLabel="Cancelling..."
+                  pendingLabel={phaseLabel ?? "Cancelling..."}
                 />
               </button>
               {campaign.has_revenue_sharing &&
@@ -226,7 +255,7 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
                         <AsyncButtonContent
                           isPending={isPending}
                           idleLabel="Confirm"
-                          pendingLabel="Processing..."
+                          pendingLabel={phaseLabel ?? "Processing..."}
                         />
                       </button>
                       <button
@@ -258,14 +287,16 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
         <div className="bg-white dark:bg-zinc-800 rounded-xl shadow-sm border border-zinc-200 dark:border-zinc-700 p-5">
           <h3 className="text-base font-semibold text-blue-600 mb-4">Admin Panel</h3>
           <button
-            onClick={() => handleAction(() => verifyCampaign(campaign.id), "Campaign verified!")}
+            onClick={() =>
+              handleAction((options) => verifyCampaign(campaign.id, options), "Campaign verified!")
+            }
             disabled={isPending}
             className="w-full py-3 min-h-[44px] bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
           >
             <AsyncButtonContent
               isPending={isPending}
               idleLabel="Verify Campaign"
-              pendingLabel="Verifying..."
+              pendingLabel={phaseLabel ?? "Verifying..."}
             />
           </button>
         </div>
@@ -280,7 +311,10 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
           <div className="flex flex-col gap-3">
             <button
               onClick={() =>
-                handleAction(() => claimRefund(campaign.id, publicKey!), "Refund claimed!")
+                handleAction(
+                  (options) => claimRefund(campaign.id, publicKey!, options),
+                  "Refund claimed!",
+                )
               }
               disabled={isPending || (campaign.is_active && !isExpired)}
               title={campaign.is_active && !isExpired ? "Cannot refund while active" : ""}
@@ -295,7 +329,10 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
             {campaign.has_revenue_sharing && (
               <button
                 onClick={() =>
-                  handleAction(() => claimRevenue(campaign.id, publicKey!), "Revenue claimed!")
+                  handleAction(
+                    (options) => claimRevenue(campaign.id, publicKey!, options),
+                    "Revenue claimed!",
+                  )
                 }
                 disabled={isPending}
                 className="w-full py-3 min-h-[44px] bg-indigo-600 hover:bg-indigo-700 disabled:bg-zinc-400 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"

--- a/src/components/DonationModal.tsx
+++ b/src/components/DonationModal.tsx
@@ -6,6 +6,7 @@ import { Campaign, xlmToStroops, stroopsToXlm } from "../types";
 import { useToast } from "./ToastProvider";
 import { useWallet } from "./WalletContext";
 import { parseContractError } from "../utils/contractErrors";
+import { type TransactionLifecyclePhase } from "../lib/contractClient";
 
 const EXPLORER_BASE =
   process.env.NEXT_PUBLIC_EXPLORER_URL ?? "https://stellar.expert/explorer/testnet/tx";
@@ -26,6 +27,7 @@ export default function DonationModal({ campaign, onClose, onSuccess }: Donation
   const [step, setStep] = useState<Step>("input");
   const [txHash, setTxHash] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
 
   const dialogRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
@@ -140,9 +142,12 @@ export default function DonationModal({ campaign, onClose, onSuccess }: Donation
     const amountToSend = validation.amount!;
     setError(null);
     setStep("pending");
+    setTxPhase(null);
     try {
       const stroops = xlmToStroops(amountToSend);
-      const hash = await contribute(campaign.id, publicKey, stroops);
+      const hash = await contribute(campaign.id, publicKey, stroops, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       setTxHash(hash);
       setStep("confirmed");
       onSuccess();
@@ -151,6 +156,7 @@ export default function DonationModal({ campaign, onClose, onSuccess }: Donation
       showError(msg);
       setError(msg);
       setStep("input");
+      setTxPhase(null);
     }
   };
 
@@ -260,7 +266,13 @@ export default function DonationModal({ campaign, onClose, onSuccess }: Donation
                 disabled={!publicKey || !validation.valid}
                 className="w-full py-3 bg-linear-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-all duration-200"
               >
-                Donate {amountNum > 0 ? `${amountNum} XLM` : ""}
+                {step === "pending"
+                  ? txPhase === "signing"
+                    ? "Signing..."
+                    : txPhase === "confirming"
+                      ? "Confirming..."
+                      : "Processing..."
+                  : `Donate ${amountNum > 0 ? `${amountNum} XLM` : ""}`}
               </button>
             </>
           )}
@@ -270,7 +282,11 @@ export default function DonationModal({ campaign, onClose, onSuccess }: Donation
             <div className="flex flex-col items-center gap-4 py-6">
               <div className="w-12 h-12 rounded-full border-4 border-blue-500 border-t-transparent motion-safe:animate-spin" />
               <p className="text-zinc-600 dark:text-zinc-400 text-sm text-center">
-                Waiting for Freighter signature and transaction confirmation…
+                {txPhase === "signing"
+                  ? "Waiting for Freighter signature…"
+                  : txPhase === "confirming"
+                    ? "Waiting for ledger confirmation…"
+                    : "Submitting transaction to the network…"}
               </p>
             </div>
           )}

--- a/src/components/MyContributionsSection.tsx
+++ b/src/components/MyContributionsSection.tsx
@@ -9,6 +9,7 @@ import { CampaignStatus, stroopsToXlm } from "../types";
 import { useToast } from "./ToastProvider";
 import { parseContractError } from "../utils/contractErrors";
 import type { WalletTransactionAction } from "../lib/transactionLog";
+import { type TransactionLifecyclePhase } from "../lib/contractClient";
 
 interface MyContributionsSectionProps {
   walletAddress: string;
@@ -71,6 +72,7 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
   const { showError, showSuccess } = useToast();
   const [pendingCampaignId, setPendingCampaignId] = useState<number | null>(null);
   const [pendingAction, setPendingAction] = useState<"refund" | "revenue" | null>(null);
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
   const { contributions, isLoading, isRefreshing, error, refetch } =
     useContributions(walletAddress);
 
@@ -82,8 +84,11 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
   const handleClaimRefund = async (campaignId: number) => {
     setPendingCampaignId(campaignId);
     setPendingAction("refund");
+    setTxPhase(null);
     try {
-      await claimRefund(campaignId, walletAddress);
+      await claimRefund(campaignId, walletAddress, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       showSuccess("Refund claimed successfully.");
       refetch();
     } catch (err) {
@@ -91,14 +96,18 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
     } finally {
       setPendingCampaignId(null);
       setPendingAction(null);
+      setTxPhase(null);
     }
   };
 
   const handleClaimRevenue = async (campaignId: number) => {
     setPendingCampaignId(campaignId);
     setPendingAction("revenue");
+    setTxPhase(null);
     try {
-      await claimRevenue(campaignId, walletAddress);
+      await claimRevenue(campaignId, walletAddress, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       showSuccess("Revenue claimed successfully.");
       refetch();
     } catch (err) {
@@ -106,6 +115,7 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
     } finally {
       setPendingCampaignId(null);
       setPendingAction(null);
+      setTxPhase(null);
     }
   };
 
@@ -171,7 +181,13 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
                       disabled={isPending}
                       className="inline-flex items-center rounded-full bg-amber-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:bg-zinc-400"
                     >
-                      {isPending && pendingAction === "refund" ? "Claiming..." : "Claim Refund"}
+                      {isPending && pendingAction === "refund"
+                        ? txPhase === "signing"
+                          ? "Signing..."
+                          : txPhase === "confirming"
+                            ? "Confirming..."
+                            : "Claiming..."
+                        : "Claim Refund"}
                     </button>
                   )}
                   {item.canClaimRevenue && (
@@ -181,7 +197,11 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
                       className="inline-flex items-center rounded-full bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-zinc-400"
                     >
                       {isPending && pendingAction === "revenue"
-                        ? "Claiming..."
+                        ? txPhase === "signing"
+                          ? "Signing..."
+                          : txPhase === "confirming"
+                            ? "Confirming..."
+                            : "Claiming..."
                         : `Claim Revenue (${formatXlmAmount(item.claimableRevenue)} XLM)`}
                     </button>
                   )}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,12 +12,20 @@ import { formatAddress } from "@/lib/formatAddress";
 import LanguageSwitcher from "./LanguageSwitcher";
 import NotificationBell from "./NotificationBell";
 import { useCampaigns } from "@/hooks/useCampaigns";
+import { IS_MOCK_MODE } from "@/lib/runtimeEnv";
 
 export default function Navbar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuToggleButtonRef = useRef<HTMLButtonElement>(null);
-  const { publicKey, isWalletConnected, connectWallet, disconnectWallet, isLoading } = useWallet();
+  const {
+    publicKey,
+    isWalletConnected,
+    walletNetworkWarning,
+    connectWallet,
+    disconnectWallet,
+    isLoading,
+  } = useWallet();
   const { theme, toggleTheme } = useTheme();
   const t = useTranslations('Common');
   const { admin: adminAddress } = useAdmin();
@@ -93,6 +101,11 @@ export default function Navbar() {
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/5 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-zinc-900/80 transition-all duration-300">
+      {walletNetworkWarning && (
+        <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-center text-xs font-semibold text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-200">
+          {walletNetworkWarning}
+        </div>
+      )}
       <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between gap-3 px-4 sm:px-6">
         <Link
           href="/"
@@ -131,6 +144,11 @@ export default function Navbar() {
         </nav>
 
         <div className="flex items-center gap-3">
+          {IS_MOCK_MODE && process.env.NODE_ENV !== "production" && (
+            <span className="hidden sm:inline-flex items-center rounded-full border border-amber-300 bg-amber-100 px-3 py-1 text-[10px] font-bold uppercase tracking-wider text-amber-800 dark:border-amber-700 dark:bg-amber-950/60 dark:text-amber-300">
+              Mock Mode
+            </span>
+          )}
           {isTestnet && (
             <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-yellow-100 text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-400 border border-yellow-200 dark:border-yellow-800 uppercase tracking-wider">
               Testnet

--- a/src/components/RevenueSharingPanel.tsx
+++ b/src/components/RevenueSharingPanel.tsx
@@ -8,6 +8,7 @@ import { useWallet } from "./WalletContext";
 import { useRevenueSharing } from "../hooks/useRevenueSharing";
 import { isSameAddress } from "../lib/stellar";
 import { parseContractError } from "../utils/contractErrors";
+import { type TransactionLifecyclePhase } from "../lib/contractClient";
 
 interface RevenueSharingPanelProps {
   campaign: Campaign;
@@ -34,6 +35,7 @@ export default function RevenueSharingPanel({
   const { showError, showSuccess, showWarning } = useToast();
   const [depositAmount, setDepositAmount] = useState("");
   const [isPending, setIsPending] = useState(false);
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
 
   const { revenuePool, contribution, claimed, contributorShare, claimable, isLoading, refetch } =
     useRevenueSharing(campaign.id, publicKey, campaign.amount_raised, campaign.has_revenue_sharing);
@@ -65,8 +67,11 @@ export default function RevenueSharingPanel({
     }
 
     setIsPending(true);
+    setTxPhase(null);
     try {
-      await depositRevenue(campaign.id, xlmToStroops(parsedAmount));
+      await depositRevenue(campaign.id, xlmToStroops(parsedAmount), {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       setDepositAmount("");
       refetch();
       onActionSuccess?.();
@@ -75,6 +80,7 @@ export default function RevenueSharingPanel({
       showError(parseContractError(err));
     } finally {
       setIsPending(false);
+      setTxPhase(null);
     }
   };
 
@@ -85,8 +91,11 @@ export default function RevenueSharingPanel({
     }
 
     setIsPending(true);
+    setTxPhase(null);
     try {
-      await claimRevenue(campaign.id, publicKey);
+      await claimRevenue(campaign.id, publicKey, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       refetch();
       onActionSuccess?.();
       showSuccess("Revenue claimed successfully.");
@@ -94,6 +103,7 @@ export default function RevenueSharingPanel({
       showError(parseContractError(err));
     } finally {
       setIsPending(false);
+      setTxPhase(null);
     }
   };
 
@@ -194,7 +204,13 @@ export default function RevenueSharingPanel({
               disabled={isPending || claimable <= BigInt(0) || !hasContribution}
               className="inline-flex items-center justify-center rounded-full bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-zinc-400"
             >
-              Claim Revenue
+              {isPending
+                ? txPhase === "signing"
+                  ? "Signing..."
+                  : txPhase === "confirming"
+                    ? "Confirming..."
+                    : "Processing..."
+                : "Claim Revenue"}
             </button>
           </div>
         </div>
@@ -225,7 +241,13 @@ export default function RevenueSharingPanel({
               disabled={isPending}
               className="inline-flex items-center justify-center rounded-full bg-zinc-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:bg-zinc-400 dark:bg-emerald-600 dark:hover:bg-emerald-700"
             >
-              Deposit Revenue
+              {isPending
+                ? txPhase === "signing"
+                  ? "Signing..."
+                  : txPhase === "confirming"
+                    ? "Confirming..."
+                    : "Processing..."
+                : "Deposit Revenue"}
             </button>
           </form>
         </div>

--- a/src/components/WalletContext.tsx
+++ b/src/components/WalletContext.tsx
@@ -1,11 +1,12 @@
 "use client";
-import { getAddress, isConnected, isAllowed } from "@stellar/freighter-api";
+import { getAddress, getNetwork, isConnected, isAllowed, WatchWalletChanges } from "@stellar/freighter-api";
 import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
 import { useToast } from "./ToastProvider";
 
 interface WalletContextType {
   publicKey: string | null;
   isWalletConnected: boolean;
+  walletNetworkWarning: string | null;
   connectWallet: () => Promise<void>;
   disconnectWallet: () => void;
   isLoading: boolean;
@@ -17,11 +18,27 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [isWalletConnected, setIsWalletConnected] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [walletNetworkWarning, setWalletNetworkWarning] = useState<string | null>(null);
   const { showError, showWarning, showSuccess } = useToast();
+  const appNetworkPassphrase = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE || "";
+  const appNetworkLabel = appNetworkPassphrase.includes("Public Global")
+    ? "Mainnet"
+    : appNetworkPassphrase.includes("Test SDF")
+      ? "Testnet"
+      : "the app network";
 
   useEffect(() => {
     // Always re-verify with Freighter rather than blindly trusting localStorage (#97)
-    checkWalletConnection();
+    void checkWalletConnection();
+
+    const watcher = new WatchWalletChanges(1000);
+    watcher.watch(() => {
+      void checkWalletConnection();
+    });
+
+    return () => {
+      watcher.stop();
+    };
   }, []);
 
   const checkWalletConnection = async () => {
@@ -30,13 +47,33 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       const allowed = await isAllowed();
       if (connected && allowed) {
         const key = await getAddress();
+        const network = await getNetwork();
+        const walletNetworkPassphrase = network.networkPassphrase || "";
+
+        if (walletNetworkPassphrase !== appNetworkPassphrase) {
+          setPublicKey(null);
+          setIsWalletConnected(false);
+          setWalletNetworkWarning(
+            `Switch Freighter to ${appNetworkLabel} to continue. Current wallet network does not match the app network.`,
+          );
+          localStorage.removeItem("stellar_wallet_public_key");
+          return;
+        }
+
+        setWalletNetworkWarning(null);
         setPublicKey(key.address);
         setIsWalletConnected(true);
         localStorage.setItem("stellar_wallet_public_key", key.address);
       } else {
+        setWalletNetworkWarning(null);
+        setPublicKey(null);
+        setIsWalletConnected(false);
         localStorage.removeItem("stellar_wallet_public_key");
       }
     } catch {
+      setWalletNetworkWarning(null);
+      setPublicKey(null);
+      setIsWalletConnected(false);
       localStorage.removeItem("stellar_wallet_public_key");
     }
   };
@@ -58,11 +95,25 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         return;
       }
       const key = await getAddress();
+      const network = await getNetwork();
+      if ((network.networkPassphrase || "") !== appNetworkPassphrase) {
+        const warning = `Switch Freighter to ${appNetworkLabel} to continue. Current wallet network does not match the app network.`;
+        setPublicKey(null);
+        setIsWalletConnected(false);
+        setWalletNetworkWarning(warning);
+        showWarning(warning);
+        setIsLoading(false);
+        return;
+      }
+      setWalletNetworkWarning(null);
       setPublicKey(key.address);
       setIsWalletConnected(true);
       localStorage.setItem("stellar_wallet_public_key", key.address);
       showSuccess("Wallet connected successfully.");
     } catch {
+      setPublicKey(null);
+      setIsWalletConnected(false);
+      setWalletNetworkWarning(null);
       showError("Failed to connect wallet. Please try again.");
     } finally {
       setIsLoading(false);
@@ -72,6 +123,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const disconnectWallet = () => {
     setPublicKey(null);
     setIsWalletConnected(false);
+    setWalletNetworkWarning(null);
     localStorage.removeItem("stellar_wallet_public_key");
     // Freighter has no programmatic revoke API. Inform the user how to fully sever access.
     showWarning(
@@ -81,7 +133,14 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <WalletContext.Provider
-      value={{ publicKey, isWalletConnected, connectWallet, disconnectWallet, isLoading }}
+      value={{
+        publicKey,
+        isWalletConnected,
+        walletNetworkWarning,
+        connectWallet,
+        disconnectWallet,
+        isLoading,
+      }}
     >
       {children}
     </WalletContext.Provider>

--- a/src/components/WithdrawFunds.tsx
+++ b/src/components/WithdrawFunds.tsx
@@ -8,6 +8,7 @@ import { useToast } from "./ToastProvider";
 import { isSameAddress } from "../lib/stellar";
 import { parseContractError } from "../utils/contractErrors";
 import { explorerTxUrl } from "../utils/explorer";
+import { type TransactionLifecyclePhase } from "../lib/contractClient";
 
 interface WithdrawFundsProps {
   campaign: Campaign;
@@ -25,6 +26,7 @@ export default function WithdrawFunds({
   const [isWithdrawing, setIsWithdrawing] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
   const { showError, showSuccess } = useToast();
 
   // Only the campaign creator should see this component
@@ -61,8 +63,11 @@ export default function WithdrawFunds({
 
   const handleWithdraw = async () => {
     setIsWithdrawing(true);
+    setTxPhase(null);
     try {
-      const hash = await withdrawFunds(campaign.id);
+      const hash = await withdrawFunds(campaign.id, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
       setTxHash(hash);
       showSuccess(
         `Withdrawal successful! You received ${creatorAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM.`,
@@ -73,6 +78,7 @@ export default function WithdrawFunds({
     } finally {
       setIsWithdrawing(false);
       setShowConfirm(false);
+      setTxPhase(null);
     }
   };
 
@@ -161,7 +167,13 @@ export default function WithdrawFunds({
               disabled={isWithdrawing}
               className="flex-1 px-4 py-3 min-h-[44px] bg-green-600 hover:bg-green-700 text-white text-sm font-semibold rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isWithdrawing ? "Processing…" : "Confirm Withdrawal"}
+              {isWithdrawing
+                ? txPhase === "signing"
+                  ? "Signing…"
+                  : txPhase === "confirming"
+                    ? "Confirming…"
+                    : "Processing…"
+                : "Confirm Withdrawal"}
             </button>
             <button
               onClick={() => setShowConfirm(false)}

--- a/src/lib/adminLog.ts
+++ b/src/lib/adminLog.ts
@@ -17,6 +17,7 @@ export interface AdminAuditLogEntry {
 
 const STORAGE_KEY = "proof_of_heart_admin_audit_log_v1";
 const MAX_ENTRIES = 500;
+const API_ENDPOINT = "/api/admin-audit-log";
 
 function canUseStorage(): boolean {
   return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
@@ -45,22 +46,72 @@ function writeAllEntries(entries: AdminAuditLogEntry[]): void {
   }
 }
 
-export function appendAdminAuditLog(
+async function readApiEntries(adminAddress?: string): Promise<AdminAuditLogEntry[]> {
+  const url = new URL(API_ENDPOINT, window.location.origin);
+  if (adminAddress) {
+    url.searchParams.set("adminAddress", adminAddress);
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch admin audit log.");
+  }
+
+  const payload = (await response.json()) as { entries?: AdminAuditLogEntry[] };
+  return Array.isArray(payload.entries) ? payload.entries : [];
+}
+
+async function persistApiEntry(entry: AdminAuditLogEntry): Promise<void> {
+  const response = await fetch(API_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(entry),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to persist admin audit log entry.");
+  }
+}
+
+export async function appendAdminAuditLog(
   entry: Omit<AdminAuditLogEntry, "timestamp" | "adminAddress"> & {
     adminAddress: string;
   },
-): void {
-  const allEntries = readAllEntries();
-  allEntries.push({
+): Promise<void> {
+  const nextEntry: AdminAuditLogEntry = {
     ...entry,
     adminAddress: normalizeAddress(entry.adminAddress),
     timestamp: Date.now(),
-  });
-  writeAllEntries(allEntries);
+  };
+
+  try {
+    await persistApiEntry(nextEntry);
+    writeAllEntries([...readAllEntries(), nextEntry]);
+    return;
+  } catch {
+    const allEntries = readAllEntries();
+    allEntries.push(nextEntry);
+    writeAllEntries(allEntries);
+  }
 }
 
-export function getAdminAuditLog(adminAddress: string, limit = 50): AdminAuditLogEntry[] {
+export async function getAdminAuditLog(adminAddress: string, limit = 50): Promise<AdminAuditLogEntry[]> {
   const normalizedAddress = normalizeAddress(adminAddress);
+
+  try {
+    const apiEntries = await readApiEntries(normalizedAddress);
+    if (apiEntries.length > 0) {
+      writeAllEntries(apiEntries);
+      return apiEntries.sort((a, b) => b.timestamp - a.timestamp).slice(0, Math.max(0, limit));
+    }
+  } catch {
+    // Fall back to local cache below.
+  }
+
   return readAllEntries()
     .filter((entry) => normalizeAddress(entry.adminAddress) === normalizedAddress)
     .sort((a, b) => b.timestamp - a.timestamp)

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -3,6 +3,7 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import { Campaign, CampaignStatus, Category } from "../types";
 import { appendWalletTransaction } from "./transactionLog";
 import { parseContractError, getContractErrorCode, ContractError } from "../utils/contractErrors";
+import { assertProductionContractConfig } from "./runtimeEnv";
 
 // ---------------------------------------------------------------------------
 // Environment configuration
@@ -21,6 +22,27 @@ const CONTRACT_ADDRESS =
 const NETWORK_PASSPHRASE =
   process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
 
+assertProductionContractConfig();
+
+export type TransactionLifecyclePhase =
+  | "building"
+  | "signing"
+  | "submitting"
+  | "confirming"
+  | "confirmed"
+  | "failed";
+
+export interface TransactionLifecycleUpdate {
+  phase: TransactionLifecyclePhase;
+  txHash?: string;
+  rpcStatus?: string;
+}
+
+export interface TransactionLifecycleOptions {
+  onStatus?: (update: TransactionLifecycleUpdate) => void;
+  timeoutMs?: number;
+}
+
 // ---------------------------------------------------------------------------
 // Soroban RPC server (lazily initialised)
 // ---------------------------------------------------------------------------
@@ -34,6 +56,10 @@ function getServer(): StellarSdk.rpc.Server {
   return _server;
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // ---------------------------------------------------------------------------
 // Helpers — transaction building & submission
 // ---------------------------------------------------------------------------
@@ -41,8 +67,10 @@ function getServer(): StellarSdk.rpc.Server {
 async function buildAndSubmitTransaction(
   sourcePublicKey: string,
   contractOp: StellarSdk.xdr.Operation,
+  options?: TransactionLifecycleOptions,
 ): Promise<StellarSdk.rpc.Api.GetSuccessfulTransactionResponse> {
   const server = getServer();
+  options?.onStatus?.({ phase: "building" });
   const sourceAccount = await server.getAccount(sourcePublicKey);
 
   const txBuilder = new StellarSdk.TransactionBuilder(sourceAccount, {
@@ -66,6 +94,7 @@ async function buildAndSubmitTransaction(
     )
     .build();
 
+  options?.onStatus?.({ phase: "signing" });
   const { signedTxXdr } = await signTransaction(preparedTx.toXDR(), {
     networkPassphrase: NETWORK_PASSPHRASE,
   });
@@ -75,23 +104,49 @@ async function buildAndSubmitTransaction(
     NETWORK_PASSPHRASE,
   ) as StellarSdk.Transaction;
 
+  options?.onStatus?.({ phase: "submitting" });
   const submissionResult = await server.sendTransaction(signedTx);
 
   if (submissionResult.status === "ERROR") {
+    options?.onStatus?.({ phase: "failed", txHash: submissionResult.hash, rpcStatus: submissionResult.status });
     throw new Error("Transaction submission failed.");
   }
 
-  let getResult = await server.getTransaction(submissionResult.hash);
-  while (getResult.status === "NOT_FOUND") {
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    getResult = await server.getTransaction(submissionResult.hash);
+  const txHash = submissionResult.hash;
+  options?.onStatus?.({ phase: "confirming", txHash, rpcStatus: submissionResult.status });
+
+  const timeoutMs = options?.timeoutMs ?? 90_000;
+  const startedAt = Date.now();
+  let pollDelay = 1_000;
+  let getResult = await server.getTransaction(txHash);
+
+  while (getResult.status === "NOT_FOUND" || getResult.status === "PENDING") {
+    if (Date.now() - startedAt >= timeoutMs) {
+      options?.onStatus?.({ phase: "failed", txHash, rpcStatus: getResult.status });
+      throw new Error("Transaction confirmation timed out.");
+    }
+
+    await sleep(pollDelay);
+    pollDelay = Math.min(Math.round(pollDelay * 1.5), 6_000);
+    getResult = await server.getTransaction(txHash);
   }
 
   if (getResult.status === "FAILED") {
+    options?.onStatus?.({ phase: "failed", txHash, rpcStatus: getResult.status });
     throw new Error("Transaction failed on-chain.");
   }
 
+  options?.onStatus?.({ phase: "confirmed", txHash, rpcStatus: getResult.status });
   return getResult as StellarSdk.rpc.Api.GetSuccessfulTransactionResponse;
+}
+
+function emitMockLifecycle(txHash: string, options?: TransactionLifecycleOptions): string {
+  options?.onStatus?.({ phase: "building", txHash });
+  options?.onStatus?.({ phase: "signing", txHash });
+  options?.onStatus?.({ phase: "submitting", txHash });
+  options?.onStatus?.({ phase: "confirming", txHash, rpcStatus: "SUCCESS" });
+  options?.onStatus?.({ phase: "confirmed", txHash, rpcStatus: "SUCCESS" });
+  return txHash;
 }
 
 async function invokeViewMethod(
@@ -392,8 +447,13 @@ export async function getPlatformFee(): Promise<number> {
 // Public API — Write (mutate) functions
 // ---------------------------------------------------------------------------
 
-export async function init(admin: string, token: string, platformFee: number): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_init";
+export async function init(
+  admin: string,
+  token: string,
+  platformFee: number,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_init", options);
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
     "init",
@@ -402,7 +462,7 @@ export async function init(admin: string, token: string, platformFee: number): P
     StellarSdk.nativeToScVal(platformFee, { type: "u32" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(admin, op);
+    const txResult = await buildAndSubmitTransaction(admin, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
@@ -419,8 +479,10 @@ export async function createCampaign(
   hasRevenueSharing: boolean,
   revenueSharePercentage: number,
   tags: string[],
+  options?: TransactionLifecycleOptions,
 ): Promise<string> {
   if (USE_MOCKS) {
+    const txHash = emitMockLifecycle("mock_tx_create_campaign", options);
     MOCK_CAMPAIGNS.push({
       id: MOCK_CAMPAIGNS.length + 1,
       creator,
@@ -440,7 +502,7 @@ export async function createCampaign(
       revenue_share_percentage: revenueSharePercentage,
       tags,
     });
-    return "mock_tx_create_campaign";
+    return txHash;
   }
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
@@ -455,7 +517,7 @@ export async function createCampaign(
     StellarSdk.nativeToScVal(revenueSharePercentage, { type: "u32" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(creator, op);
+    const txResult = await buildAndSubmitTransaction(creator, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
@@ -466,8 +528,9 @@ export async function contribute(
   campaignId: number,
   contributor: string,
   amount: bigint,
+  options?: TransactionLifecycleOptions,
 ): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_contribute";
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_contribute", options);
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
     "contribute",
@@ -476,7 +539,7 @@ export async function contribute(
     StellarSdk.nativeToScVal(amount, { type: "i128" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(contributor, op);
+    const txResult = await buildAndSubmitTransaction(contributor, op, options);
     appendWalletTransaction({
       walletAddress: contributor,
       campaignId,
@@ -489,13 +552,16 @@ export async function contribute(
   }
 }
 
-export async function withdrawFunds(campaignId: number): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_withdraw_funds";
+export async function withdrawFunds(
+  campaignId: number,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_withdraw_funds", options);
   const { address: callerAddress } = await getAddress();
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call("withdraw_funds", StellarSdk.nativeToScVal(campaignId, { type: "u32" }));
   try {
-    const txResult = await buildAndSubmitTransaction(callerAddress, op);
+    const txResult = await buildAndSubmitTransaction(callerAddress, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
@@ -506,8 +572,11 @@ export async function withdrawFunds(campaignId: number): Promise<string> {
  * Cancel a campaign (creator only).
  * Returns the transaction hash on success.
  */
-export async function cancelCampaign(campaignId: number): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_cancel_campaign";
+export async function cancelCampaign(
+  campaignId: number,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_cancel_campaign", options);
   const { address: callerAddress } = await getAddress();
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
@@ -515,7 +584,7 @@ export async function cancelCampaign(campaignId: number): Promise<string> {
     StellarSdk.nativeToScVal(campaignId, { type: "u32" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(callerAddress, op);
+    const txResult = await buildAndSubmitTransaction(callerAddress, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
@@ -526,8 +595,12 @@ export async function cancelCampaign(campaignId: number): Promise<string> {
  * Claim a refund from a cancelled or failed campaign.
  * Returns the transaction hash on success.
  */
-export async function claimRefund(campaignId: number, contributor: string): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_claim_refund";
+export async function claimRefund(
+  campaignId: number,
+  contributor: string,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_claim_refund", options);
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
     "claim_refund",
@@ -535,7 +608,7 @@ export async function claimRefund(campaignId: number, contributor: string): Prom
     new StellarSdk.Address(contributor).toScVal(),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(contributor, op);
+    const txResult = await buildAndSubmitTransaction(contributor, op, options);
     appendWalletTransaction({
       walletAddress: contributor,
       campaignId,
@@ -548,8 +621,12 @@ export async function claimRefund(campaignId: number, contributor: string): Prom
   }
 }
 
-export async function depositRevenue(campaignId: number, amount: bigint): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_deposit_revenue";
+export async function depositRevenue(
+  campaignId: number,
+  amount: bigint,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_deposit_revenue", options);
   const { address: callerAddress } = await getAddress();
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
@@ -558,15 +635,19 @@ export async function depositRevenue(campaignId: number, amount: bigint): Promis
     StellarSdk.nativeToScVal(amount, { type: "i128" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(callerAddress, op);
+    const txResult = await buildAndSubmitTransaction(callerAddress, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
   }
 }
 
-export async function claimRevenue(campaignId: number, contributor: string): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_claim_revenue";
+export async function claimRevenue(
+  campaignId: number,
+  contributor: string,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_claim_revenue", options);
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
     "claim_revenue",
@@ -574,7 +655,7 @@ export async function claimRevenue(campaignId: number, contributor: string): Pro
     new StellarSdk.Address(contributor).toScVal(),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(contributor, op);
+    const txResult = await buildAndSubmitTransaction(contributor, op, options);
     appendWalletTransaction({
       walletAddress: contributor,
       campaignId,
@@ -587,8 +668,11 @@ export async function claimRevenue(campaignId: number, contributor: string): Pro
   }
 }
 
-export async function verifyCampaign(campaignId: number): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_verify_campaign";
+export async function verifyCampaign(
+  campaignId: number,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_verify_campaign", options);
   const { address: callerAddress } = await getAddress();
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
@@ -596,7 +680,7 @@ export async function verifyCampaign(campaignId: number): Promise<string> {
     StellarSdk.nativeToScVal(campaignId, { type: "u32" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(callerAddress, op);
+    const txResult = await buildAndSubmitTransaction(callerAddress, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
@@ -606,8 +690,11 @@ export async function verifyCampaign(campaignId: number): Promise<string> {
 /**
  * Update the platform fee (admin only).
  */
-export async function updatePlatformFee(platformFee: number): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_update_platform_fee";
+export async function updatePlatformFee(
+  platformFee: number,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_update_platform_fee", options);
 
   const { address: callerAddress } = await getAddress();
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
@@ -617,7 +704,7 @@ export async function updatePlatformFee(platformFee: number): Promise<string> {
   );
 
   try {
-    const txResult = await buildAndSubmitTransaction(callerAddress, op);
+    const txResult = await buildAndSubmitTransaction(callerAddress, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
@@ -627,15 +714,18 @@ export async function updatePlatformFee(platformFee: number): Promise<string> {
 /**
  * Transfer the admin role to a new address (admin only).
  */
-export async function updateAdmin(newAdmin: string): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_update_admin";
+export async function updateAdmin(
+  newAdmin: string,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_update_admin", options);
 
   const { address: callerAddress } = await getAddress();
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call("update_admin", new StellarSdk.Address(newAdmin).toScVal());
 
   try {
-    const txResult = await buildAndSubmitTransaction(callerAddress, op);
+    const txResult = await buildAndSubmitTransaction(callerAddress, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));
@@ -716,8 +806,11 @@ export async function voteOnCampaign(
   campaignId: number,
   voter: string,
   approve: boolean,
+  options?: TransactionLifecycleOptions,
 ): Promise<string> {
-  if (USE_MOCKS) return `mock_tx_vote_${campaignId}_${approve ? "approve" : "reject"}`;
+  if (USE_MOCKS) {
+    return emitMockLifecycle(`mock_tx_vote_${campaignId}_${approve ? "approve" : "reject"}`, options);
+  }
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
     "vote_on_campaign",
@@ -726,7 +819,7 @@ export async function voteOnCampaign(
     StellarSdk.nativeToScVal(approve, { type: "bool" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(voter, op);
+    const txResult = await buildAndSubmitTransaction(voter, op, options);
     appendWalletTransaction({
       walletAddress: voter,
       campaignId,
@@ -743,8 +836,11 @@ export async function voteOnCampaign(
  * Trigger on-chain campaign verification using accumulated votes.
  * Can be called by anyone once quorum + threshold are met.
  */
-export async function verifyCampaignWithVotes(campaignId: number): Promise<string> {
-  if (USE_MOCKS) return "mock_tx_verify_with_votes";
+export async function verifyCampaignWithVotes(
+  campaignId: number,
+  options?: TransactionLifecycleOptions,
+): Promise<string> {
+  if (USE_MOCKS) return emitMockLifecycle("mock_tx_verify_with_votes", options);
   const { address: callerAddress } = await getAddress();
   const contract = new StellarSdk.Contract(CONTRACT_ADDRESS);
   const op = contract.call(
@@ -752,7 +848,7 @@ export async function verifyCampaignWithVotes(campaignId: number): Promise<strin
     StellarSdk.nativeToScVal(campaignId, { type: "u32" }),
   );
   try {
-    const txResult = await buildAndSubmitTransaction(callerAddress, op);
+    const txResult = await buildAndSubmitTransaction(callerAddress, op, options);
     return txResult.txHash;
   } catch (err) {
     throw new Error(parseContractError(err));

--- a/src/lib/runtimeEnv.ts
+++ b/src/lib/runtimeEnv.ts
@@ -1,0 +1,11 @@
+const USE_MOCKS = typeof process !== "undefined" && process.env.NEXT_PUBLIC_USE_MOCKS === "true";
+
+export const IS_MOCK_MODE = USE_MOCKS;
+
+export function assertProductionContractConfig(): void {
+  if (process.env.NODE_ENV === "production" && USE_MOCKS) {
+    throw new Error(
+      "Mock mode is disabled in production. Set NEXT_PUBLIC_USE_MOCKS=false before building or running the app.",
+    );
+  }
+}


### PR DESCRIPTION
Adds the shared transaction polling/status flow, blocks production mock builds, guards wallet network mismatches, and moves admin audit entries behind a backend-backed API store.

Closes #347
Closes #343
Closes #345
Closes #354