### PR TITLE
Add shared off-chain API layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 NEXT_PUBLIC_CREATOR_EMAIL_WEBHOOK_URL=
 ```
 
+`NEXT_PUBLIC_API_URL` is the base URL for the off-chain service layer used by campaign comments, updates, reports, and wallet transaction history.
+
+Expected endpoints under that base URL:
+
+- `GET /campaigns/:campaignId/updates`
+- `POST /campaigns/:campaignId/updates`
+- `GET /campaigns/:campaignId/comments`
+- `POST /campaigns/:campaignId/comments`
+- `POST /campaigns/:campaignId/comments/:commentId/pin`
+- `POST /campaigns/:campaignId/comments/:commentId/report`
+- `POST /campaign-reports`
+- `PATCH /campaign-reports`
+- `POST /wallet-transactions`
+
+Authenticated off-chain mutations send wallet signatures with:
+
+- `X-Wallet-Address`
+- `X-Request-Signature`
+- `X-Request-Timestamp`
+- `X-Request-Purpose`
+
+The client retries transient failures and falls back to the existing mock/local stores when `NEXT_PUBLIC_API_URL` is not set.
+
 ## 🤝 Contributing!
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.

--- a/src/app/[locale]/causes/CausesClient.tsx
+++ b/src/app/[locale]/causes/CausesClient.tsx
@@ -9,7 +9,14 @@ import { useToast } from '@/components/ToastProvider';
 import { useWallet } from '@/components/WalletContext';
 import { useCampaigns } from '@/hooks/useCampaigns';
 import { useRouter } from '@/i18n/routing';
-import { cancelCampaign, claimRefund, voteOnCampaign, hasVoted } from '@/lib/contractClient';
+import {
+  cancelCampaign,
+  claimRefund,
+  voteOnCampaign,
+  hasVoted,
+  getApproveVotes,
+  getRejectVotes,
+} from '@/lib/contractClient';
 import { SORT_OPTIONS } from '@/lib/mockCauses';
 import { Campaign, Vote, CATEGORY_LABELS, CampaignStatus, Category } from '@/types';
 import { getAsyncActionErrorMessage, withActionTimeout } from '@/utils/asyncAction';
@@ -102,10 +109,40 @@ function CausesContent() {
     setUserVotes(votes);
   }, [userWalletAddress, campaigns]);
 
+  const loadVoteCounts = useCallback(async () => {
+    const counts: Record<number, { upvotes: number; downvotes: number; totalVotes: number }> = {};
+    await Promise.all(
+      campaigns.map(async (campaign) => {
+        try {
+          const [approves, rejects] = await Promise.all([
+            getApproveVotes(campaign.id),
+            getRejectVotes(campaign.id),
+          ]);
+          counts[campaign.id] = {
+            upvotes: approves,
+            downvotes: rejects,
+            totalVotes: approves + rejects,
+          };
+        } catch {
+          counts[campaign.id] = { upvotes: 0, downvotes: 0, totalVotes: 0 };
+        }
+      }),
+    );
+    setVoteCounts(counts);
+  }, [campaigns]);
+
   useEffect(() => {
     if (userWalletAddress) loadUserVotes();
     else setUserVotes({});
   }, [userWalletAddress, loadUserVotes]);
+
+  useEffect(() => {
+    if (campaigns.length > 0) {
+      loadVoteCounts();
+      return;
+    }
+    setVoteCounts({});
+  }, [campaigns, loadVoteCounts]);
 
   // -------------------------------------------------------------------------
   // Vote handler
@@ -460,6 +497,9 @@ function CausesContent() {
                     onClaimRefund={handleClaimRefund}
                     onTagClick={(t: string) => setTag(t)}
                     userVote={userVotes[campaign.id]}
+                    upvotes={voteCounts[campaign.id]?.upvotes ?? 0}
+                    downvotes={voteCounts[campaign.id]?.downvotes ?? 0}
+                    totalVotes={voteCounts[campaign.id]?.totalVotes ?? 0}
                   />
                 ))}
               </div>

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -22,6 +22,9 @@ interface CauseCardProps {
   onClaimRefund: (campaignId: number) => Promise<void>;
   onTagClick?: (tag: string) => void;
   userVote?: Vote;
+  upvotes?: number;
+  downvotes?: number;
+  totalVotes?: number;
 }
 
 const CATEGORY_ICONS: Record<string, string> = {
@@ -47,6 +50,9 @@ export default function CauseCard({
   onClaimRefund,
   onTagClick,
   userVote,
+  upvotes = 0,
+  downvotes = 0,
+  totalVotes = 0,
 }: CauseCardProps) {
   const [isVoting, setIsVoting] = useState(false);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
@@ -211,6 +217,9 @@ export default function CauseCard({
             isVoting={isVoting}
             onVote={handleVote}
             userWalletAddress={userWalletAddress}
+            upvotes={upvotes}
+            downvotes={downvotes}
+            totalVotes={totalVotes}
           />
         )}
 

--- a/src/lib/campaignComments.ts
+++ b/src/lib/campaignComments.ts
@@ -1,12 +1,13 @@
-import { signTransaction, getAddress } from "@stellar/freighter-api";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { Comment, CommentPayload } from "../types";
 import { parseContractError } from "../utils/contractErrors";
+import {
+  hasOffchainApiBaseUrl,
+  requestOffchainJson,
+  signOffchainPayload,
+} from "./offchainApiClient";
 
 const USE_MOCKS = typeof process !== "undefined" && process.env.NEXT_PUBLIC_USE_MOCKS === "true";
-
-const NETWORK_PASSPHRASE =
-  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
 
 // ---------------------------------------------------------------------------
 // Mock data for campaign comments
@@ -56,49 +57,8 @@ const MOCK_COMMENTS: Record<number, Comment[]> = {
 
 async function signPayload(payload: CommentPayload): Promise<string> {
   try {
-    const { address } = await getAddress();
-
-    const payloadString = JSON.stringify({
-      campaignId: payload.campaignId,
-      content: payload.content,
-      timestamp: payload.timestamp,
-    });
-
-    const payloadHash = StellarSdk.hash(Buffer.from(payloadString));
-
-    const { signedTxXdr } = await signTransaction(
-      new StellarSdk.TransactionBuilder(
-        new StellarSdk.Account(address, "0"),
-        {
-          fee: StellarSdk.BASE_FEE,
-          networkPassphrase: NETWORK_PASSPHRASE,
-        }
-      )
-        .addOperation(
-          StellarSdk.Operation.manageData({
-            name: "comment_signature",
-            value: payloadHash,
-          })
-        )
-        .setTimeout(30)
-        .build()
-        .toXDR(),
-      {
-        networkPassphrase: NETWORK_PASSPHRASE,
-      }
-    );
-
-    const signedTx = StellarSdk.TransactionBuilder.fromXDR(
-      signedTxXdr,
-      NETWORK_PASSPHRASE
-    ) as StellarSdk.Transaction;
-
-    const signatures = signedTx.signatures;
-    if (signatures.length === 0) {
-      throw new Error("No signature generated");
-    }
-
-    return signatures[0].signature().toString("hex");
+    const { signature } = await signOffchainPayload(payload, "comment_signature");
+    return signature;
   } catch (error) {
     throw new Error(`Failed to sign payload: ${parseContractError(error)}`);
   }
@@ -109,18 +69,12 @@ async function signPayload(payload: CommentPayload): Promise<string> {
 // ---------------------------------------------------------------------------
 
 export async function getCampaignComments(campaignId: number): Promise<Comment[]> {
-  if (USE_MOCKS) {
+  if (USE_MOCKS || !hasOffchainApiBaseUrl()) {
     return MOCK_COMMENTS[campaignId] ?? [];
   }
 
   try {
-    const response = await fetch(`/api/campaigns/${campaignId}/comments`);
-    if (!response.ok) {
-      if (response.status === 404) return [];
-      throw new Error(`Failed to fetch comments: ${response.statusText}`);
-    }
-    const comments = await response.json();
-    return comments;
+    return await requestOffchainJson<Comment[]>(`/campaigns/${campaignId}/comments`);
   } catch (error) {
     throw new Error(`Failed to fetch comments: ${parseContractError(error)}`);
   }
@@ -132,7 +86,7 @@ export async function createCampaignComment(
   authorAddress: string,
   parentId: string | null = null
 ): Promise<Comment> {
-  if (USE_MOCKS) {
+  if (USE_MOCKS || !hasOffchainApiBaseUrl()) {
     await new Promise((resolve) => setTimeout(resolve, 800));
 
     const timestamp = Math.floor(Date.now() / 1000);
@@ -165,34 +119,35 @@ export async function createCampaignComment(
 
     const signature = await signPayload(payload);
 
-    const response = await fetch(`/api/campaigns/${campaignId}/comments`, {
+    return await requestOffchainJson<Comment>(`/campaigns/${campaignId}/comments`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+      auth: {
+        purpose: "create_campaign_comment",
+        payload: {
+          campaignId,
+          content,
+          authorAddress,
+          timestamp,
+          parentId,
+          signature,
+        },
       },
-      body: JSON.stringify({
+      body: {
         campaignId,
         content,
         authorAddress,
         timestamp,
         parentId,
         signature,
-      }),
+      },
     });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || `Failed to create comment: ${response.statusText}`);
-    }
-
-    return await response.json();
   } catch (error) {
     throw new Error(`Failed to create comment: ${parseContractError(error)}`);
   }
 }
 
 export async function pinComment(campaignId: number, commentId: string, isPinned: boolean): Promise<Comment> {
-  if (USE_MOCKS) {
+  if (USE_MOCKS || !hasOffchainApiBaseUrl()) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     const comments = MOCK_COMMENTS[campaignId] || [];
     const commentIndex = comments.findIndex(c => c.id === commentId);
@@ -204,27 +159,21 @@ export async function pinComment(campaignId: number, commentId: string, isPinned
   }
 
   try {
-    const response = await fetch(`/api/campaigns/${campaignId}/comments/${commentId}/pin`, {
+    return await requestOffchainJson<Comment>(`/campaigns/${campaignId}/comments/${commentId}/pin`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+      auth: {
+        purpose: "pin_comment",
+        payload: { campaignId, commentId, isPinned },
       },
-      body: JSON.stringify({ isPinned }),
+      body: { isPinned },
     });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || "Failed to pin comment");
-    }
-
-    return await response.json();
   } catch (error) {
     throw new Error(`Failed to pin comment: ${parseContractError(error)}`);
   }
 }
 
 export async function reportComment(campaignId: number, commentId: string): Promise<Comment> {
-  if (USE_MOCKS) {
+  if (USE_MOCKS || !hasOffchainApiBaseUrl()) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     const comments = MOCK_COMMENTS[campaignId] || [];
     const commentIndex = comments.findIndex(c => c.id === commentId);
@@ -236,19 +185,13 @@ export async function reportComment(campaignId: number, commentId: string): Prom
   }
 
   try {
-    const response = await fetch(`/api/campaigns/${campaignId}/comments/${commentId}/report`, {
+    return await requestOffchainJson<Comment>(`/campaigns/${campaignId}/comments/${commentId}/report`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+      auth: {
+        purpose: "report_comment",
+        payload: { campaignId, commentId },
       },
     });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || "Failed to report comment");
-    }
-
-    return await response.json();
   } catch (error) {
     throw new Error(`Failed to report comment: ${parseContractError(error)}`);
   }

--- a/src/lib/campaignReports.ts
+++ b/src/lib/campaignReports.ts
@@ -1,5 +1,10 @@
 'use client';
 
+import {
+  hasOffchainApiBaseUrl,
+  requestOffchainJson,
+} from './offchainApiClient';
+
 export type ReportReason =
   | 'scam'
   | 'inappropriate'
@@ -53,6 +58,23 @@ function writeAll(reports: CampaignReport[]): void {
   }
 }
 
+async function syncReport(report: CampaignReport, reviewed = false): Promise<void> {
+  if (!hasOffchainApiBaseUrl()) return;
+
+  try {
+    await requestOffchainJson('/campaign-reports', {
+      method: reviewed ? 'PATCH' : 'POST',
+      auth: {
+        purpose: reviewed ? 'review_campaign_report' : 'submit_campaign_report',
+        payload: report,
+      },
+      body: report,
+    });
+  } catch {
+    // Keep the local cache authoritative when the backend is unavailable.
+  }
+}
+
 export function submitReport(
   campaignId: number,
   campaignTitle: string,
@@ -73,6 +95,7 @@ export function submitReport(
   const all = readAll();
   all.push(report);
   writeAll(all);
+  void syncReport(report);
   return report;
 }
 
@@ -87,4 +110,8 @@ export function getPendingReports(): CampaignReport[] {
 export function markReportReviewed(id: string): void {
   const all = readAll().map((r) => (r.id === id ? { ...r, status: 'reviewed' as const } : r));
   writeAll(all);
+  const reviewedReport = all.find((r) => r.id === id);
+  if (reviewedReport) {
+    void syncReport(reviewedReport, true);
+  }
 }

--- a/src/lib/campaignUpdates.ts
+++ b/src/lib/campaignUpdates.ts
@@ -1,21 +1,17 @@
-import { signTransaction, getAddress } from "@stellar/freighter-api";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { CampaignUpdate, UpdatePayload } from "../types";
 import { parseContractError } from "../utils/contractErrors";
+import {
+  hasOffchainApiBaseUrl,
+  requestOffchainJson,
+  signOffchainPayload,
+} from "./offchainApiClient";
 
 // ---------------------------------------------------------------------------
 // Environment configuration
 // ---------------------------------------------------------------------------
 
 const USE_MOCKS = typeof process !== "undefined" && process.env.NEXT_PUBLIC_USE_MOCKS === "true";
-
-const SOROBAN_RPC_URL =
-  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ??
-  process.env.NEXT_PUBLIC_RPC_URL ??
-  "https://soroban-testnet.stellar.org";
-
-const NETWORK_PASSPHRASE =
-  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
 
 // ---------------------------------------------------------------------------
 // Mock data for campaign updates
@@ -58,53 +54,8 @@ const MOCK_UPDATES: Record<number, CampaignUpdate[]> = {
 
 async function signPayload(payload: UpdatePayload): Promise<string> {
   try {
-    const { address } = await getAddress();
-    
-    // Create a deterministic hash of the payload for signing
-    const payloadString = JSON.stringify({
-      campaignId: payload.campaignId,
-      content: payload.content,
-      timestamp: payload.timestamp,
-    });
-    
-    // Create a hash of the payload
-    const payloadHash = StellarSdk.hash(Buffer.from(payloadString));
-    
-    // Sign the hash using Freighter
-    const { signedTxXdr } = await signTransaction(
-      new StellarSdk.TransactionBuilder(
-        new StellarSdk.Account(address, "0"),
-        {
-          fee: StellarSdk.BASE_FEE,
-          networkPassphrase: NETWORK_PASSPHRASE,
-        }
-      )
-        .addOperation(
-          StellarSdk.Operation.manageData({
-            name: "update_signature",
-            value: payloadHash,
-          })
-        )
-        .setTimeout(30)
-        .build()
-        .toXDR(),
-      {
-        networkPassphrase: NETWORK_PASSPHRASE,
-      }
-    );
-    
-    // Extract the signature from the signed transaction
-    const signedTx = StellarSdk.TransactionBuilder.fromXDR(
-      signedTxXdr,
-      NETWORK_PASSPHRASE
-    ) as StellarSdk.Transaction;
-    
-    const signatures = signedTx.signatures;
-    if (signatures.length === 0) {
-      throw new Error("No signature generated");
-    }
-    
-    return signatures[0].signature().toString("hex");
+    const { signature } = await signOffchainPayload(payload, "update_signature");
+    return signature;
   } catch (error) {
     throw new Error(`Failed to sign payload: ${parseContractError(error)}`);
   }
@@ -119,25 +70,14 @@ async function signPayload(payload: UpdatePayload): Promise<string> {
  * Updates are returned in reverse chronological order (newest first).
  */
 export async function getCampaignUpdates(campaignId: number): Promise<CampaignUpdate[]> {
-  if (USE_MOCKS) {
+  if (USE_MOCKS || !hasOffchainApiBaseUrl()) {
     // Return mock updates or empty array
     return MOCK_UPDATES[campaignId] ?? [];
   }
 
   try {
-    // In production, this would call your backend API
-    // For now, we'll use a placeholder that assumes off-chain storage
-    const response = await fetch(`/api/campaigns/${campaignId}/updates`);
-    
-    if (!response.ok) {
-      if (response.status === 404) {
-        return [];
-      }
-      throw new Error(`Failed to fetch updates: ${response.statusText}`);
-    }
-    
-    const updates = await response.json();
-    
+    const updates = await requestOffchainJson<CampaignUpdate[]>(`/campaigns/${campaignId}/updates`);
+
     // Sort by timestamp descending (newest first)
     return updates.sort((a: CampaignUpdate, b: CampaignUpdate) => b.timestamp - a.timestamp);
   } catch (error) {
@@ -160,7 +100,7 @@ export async function createCampaignUpdate(
   creatorAddress: string,
   notify: boolean = false
 ): Promise<CampaignUpdate> {
-  if (USE_MOCKS) {
+  if (USE_MOCKS || !hasOffchainApiBaseUrl()) {
     // Simulate network delay
     await new Promise((resolve) => setTimeout(resolve, 800));
     
@@ -194,32 +134,32 @@ export async function createCampaignUpdate(
   try {
     const timestamp = Math.floor(Date.now() / 1000);
     const payload: UpdatePayload = { campaignId, content, timestamp };
-    
+
     // Sign the payload
     const signature = await signPayload(payload);
-    
-    // Send to backend
-    const response = await fetch(`/api/campaigns/${campaignId}/updates`, {
+
+    return await requestOffchainJson<CampaignUpdate>(`/campaigns/${campaignId}/updates`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+      auth: {
+        purpose: "create_campaign_update",
+        payload: {
+          campaignId,
+          content,
+          authorAddress: creatorAddress,
+          timestamp,
+          signature,
+          notify,
+        },
       },
-      body: JSON.stringify({
+      body: {
         campaignId,
         content,
         authorAddress: creatorAddress,
         timestamp,
         signature,
-        notify, // Pass notify flag to backend
-      }),
+        notify,
+      },
     });
-    
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || `Failed to create update: ${response.statusText}`);
-    }
-    
-    return await response.json();
   } catch (error) {
     throw new Error(`Failed to create campaign update: ${parseContractError(error)}`);
   }

--- a/src/lib/offchainApiClient.ts
+++ b/src/lib/offchainApiClient.ts
@@ -1,0 +1,218 @@
+import { getAddress, signTransaction } from "@stellar/freighter-api";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+const OFFCHAIN_API_BASE_URL = (process.env.NEXT_PUBLIC_API_URL ?? "").trim().replace(/\/+$/, "");
+const NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_RETRIES = 2;
+
+export class OffchainApiError extends Error {
+  status?: number;
+  details?: unknown;
+
+  constructor(message: string, options?: { status?: number; details?: unknown }) {
+    super(message);
+    this.name = "OffchainApiError";
+    this.status = options?.status;
+    this.details = options?.details;
+  }
+}
+
+export interface OffchainRequestAuth {
+  purpose: string;
+  payload?: unknown;
+}
+
+export interface OffchainRequestOptions extends Omit<RequestInit, "body"> {
+  auth?: OffchainRequestAuth;
+  retries?: number;
+  body?: unknown;
+}
+
+export interface SignedOffchainPayload {
+  walletAddress: string;
+  signature: string;
+  timestamp: number;
+}
+
+export function hasOffchainApiBaseUrl(): boolean {
+  return OFFCHAIN_API_BASE_URL.length > 0;
+}
+
+function resolveOffchainUrl(path: string): string {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  if (!hasOffchainApiBaseUrl()) {
+    throw new OffchainApiError("NEXT_PUBLIC_API_URL is not configured.");
+  }
+
+  return `${OFFCHAIN_API_BASE_URL}${normalizedPath}`;
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildAuthEnvelope(path: string, method: string, payload: unknown, timestamp: number) {
+  return {
+    purpose: "offchain-request",
+    path,
+    method,
+    timestamp,
+    payload,
+  };
+}
+
+export async function signOffchainPayload(
+  payload: unknown,
+  purpose: string,
+): Promise<SignedOffchainPayload> {
+  const { address: walletAddress } = await getAddress();
+  const timestamp = Math.floor(Date.now() / 1000);
+  const envelope = {
+    purpose,
+    timestamp,
+    payload,
+  };
+  const payloadString = JSON.stringify(envelope);
+  const payloadHash = StellarSdk.hash(Buffer.from(payloadString));
+
+  const { signedTxXdr } = await signTransaction(
+    new StellarSdk.TransactionBuilder(new StellarSdk.Account(walletAddress, "0"), {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        StellarSdk.Operation.manageData({
+          name: `offchain_${purpose}`,
+          value: payloadHash,
+        }),
+      )
+      .setTimeout(30)
+      .build()
+      .toXDR(),
+    {
+      networkPassphrase: NETWORK_PASSPHRASE,
+    },
+  );
+
+  const signedTx = StellarSdk.TransactionBuilder.fromXDR(
+    signedTxXdr,
+    NETWORK_PASSPHRASE,
+  ) as StellarSdk.Transaction;
+
+  const signature = signedTx.signatures[0]?.signature();
+  if (!signature) {
+    throw new OffchainApiError("No wallet signature was generated.");
+  }
+
+  return {
+    walletAddress,
+    signature: signature.toString("hex"),
+    timestamp,
+  };
+}
+
+export async function requestOffchainJson<T>(
+  path: string,
+  options: OffchainRequestOptions = {},
+): Promise<T> {
+  const url = resolveOffchainUrl(path);
+  const retries = options.retries ?? DEFAULT_RETRIES;
+  const method = (options.method ?? "GET").toUpperCase();
+
+  const headers = new Headers(options.headers);
+  headers.set("Accept", "application/json");
+
+  let body: BodyInit | undefined;
+  if (options.body !== undefined) {
+    body = typeof options.body === "string" ? options.body : JSON.stringify(options.body);
+    headers.set("Content-Type", "application/json");
+  }
+
+  if (options.auth) {
+    const authEnvelope = buildAuthEnvelope(path, method, options.auth.payload ?? options.body, Math.floor(Date.now() / 1000));
+    const signed = await signOffchainPayload(authEnvelope, options.auth.purpose);
+    headers.set("X-Wallet-Address", signed.walletAddress);
+    headers.set("X-Request-Signature", signed.signature);
+    headers.set("X-Request-Timestamp", String(signed.timestamp));
+    headers.set("X-Request-Purpose", options.auth.purpose);
+  }
+
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        method,
+        headers,
+        body,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        const details = errorText ? (() => {
+          try {
+            return JSON.parse(errorText) as unknown;
+          } catch {
+            return errorText;
+          }
+        })() : undefined;
+        const errorMessage =
+          details && typeof details === "object" && details !== null && "message" in details
+            ? String((details as { message?: unknown }).message ?? response.statusText)
+            : response.statusText || "Off-chain request failed.";
+        const error = new OffchainApiError(errorMessage, {
+          status: response.status,
+          details,
+        });
+
+        if (attempt < retries && isRetryableStatus(response.status)) {
+          lastError = error;
+          await sleep(250 * (attempt + 1));
+          continue;
+        }
+
+        throw error;
+      }
+
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await sleep(250 * (attempt + 1));
+        continue;
+      }
+      if (error instanceof OffchainApiError) {
+        throw error;
+      }
+      throw new OffchainApiError("Failed to contact off-chain service.", {
+        details: error,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw new OffchainApiError("Failed to contact off-chain service.", {
+    details: lastError,
+  });
+}

--- a/src/lib/transactionLog.ts
+++ b/src/lib/transactionLog.ts
@@ -9,6 +9,10 @@ export interface WalletTransactionLogEntry {
 }
 
 import { normalizeAddress } from "./stellar";
+import {
+  hasOffchainApiBaseUrl,
+  requestOffchainJson,
+} from "./offchainApiClient";
 
 const STORAGE_KEY = "proof_of_heart_wallet_tx_log_v1";
 
@@ -40,6 +44,23 @@ function writeAllEntries(entries: WalletTransactionLogEntry[]): void {
   }
 }
 
+async function syncWalletTransaction(entry: WalletTransactionLogEntry): Promise<void> {
+  if (!hasOffchainApiBaseUrl()) return;
+
+  try {
+    await requestOffchainJson("/wallet-transactions", {
+      method: "POST",
+      auth: {
+        purpose: "wallet_transaction",
+        payload: entry,
+      },
+      body: entry,
+    });
+  } catch {
+    // Local history remains the source of truth if the backend is offline.
+  }
+}
+
 export function appendWalletTransaction(entry: Omit<WalletTransactionLogEntry, "timestamp">): void {
   const allEntries = readAllEntries();
   const normalizedEntry: WalletTransactionLogEntry = {
@@ -50,6 +71,7 @@ export function appendWalletTransaction(entry: Omit<WalletTransactionLogEntry, "
 
   allEntries.push(normalizedEntry);
   writeAllEntries(allEntries.slice(-1000));
+  void syncWalletTransaction(normalizedEntry);
 }
 
 export function getWalletTransactions(walletAddress: string): WalletTransactionLogEntry[] {


### PR DESCRIPTION
Adds a shared off-chain client with wallet-signature auth, retries, and backend sync for comments, updates, reports, and wallet transaction history.

Closes #351
Closes #360
Closes #357
Closes #359