### PR TITLE
feat: live funding progress and hardened markdown rendering (#363, #367)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
 # Optional webhook to receive creator email opt-in events (off-chain only)
 NEXT_PUBLIC_CREATOR_EMAIL_WEBHOOK_URL=
+
+# Campaign detail: get_campaign reconciliation interval (ms, default 30000)
+NEXT_PUBLIC_POLL_INTERVAL_DETAIL_MS=30000
+
+# Soroban contribution_made event poll interval on detail page (ms, default 5000)
+NEXT_PUBLIC_CONTRIBUTION_EVENTS_POLL_MS=5000

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,7 +11,6 @@ const config: Config = {
     "src/**/*.{ts,tsx}",
     "!src/**/*.d.ts",
     "!src/types/**",
-    // src/app/** is intentionally included so pages appear in coverage reports.
   ],
   coverageThreshold: {
     global: {
@@ -27,4 +26,16 @@ const config: Config = {
   },
 };
 
-export default createJestConfig(config);
+const markdownEsmPattern =
+  "node_modules/(?!(react-markdown|remark-gfm|rehype-sanitize|hast-util-sanitize|unist-util-visit|unified|bail|is-plain-obj|trough|vfile|vfile-message|devlop|remark-parse|remark-rehype|mdast-util-to-hast|mdast-util-from-markdown|mdast-util-gfm|micromark|micromark-extension-gfm|decode-named-character-reference|character-entities|property-information|hast-util-to-jsx-runtime|hast-util-whitespace|space-separated-tokens|comma-separated-tokens|estree-util-is-identifier-name|html-url-attributes|ccount|escape-string-regexp|markdown-table|longest-streak|trim-lines|zwitch)/)";
+
+export default async function jestConfig() {
+  const nextConfig = await createJestConfig(config)();
+  return {
+    ...nextConfig,
+    transformIgnorePatterns: [
+      ...(nextConfig.transformIgnorePatterns ?? []),
+      markdownEsmPattern,
+    ],
+  };
+}

--- a/src/__tests__/components/CommentItem.test.tsx
+++ b/src/__tests__/components/CommentItem.test.tsx
@@ -154,4 +154,24 @@ describe('CommentItem', () => {
     expect(screen.getByText('Test comment')).toBeInTheDocument();
     expect(screen.getByText('A reply')).toBeInTheDocument();
   });
+
+  it('renders XSS payloads as inert text without executable markup', async () => {
+    const xssComment = {
+      ...mockComment,
+      content: '<img src=x onerror="alert(1)"><script>alert(1)</script>',
+    };
+
+    const { container } = render(
+      <CommentItem
+        comment={xssComment}
+        isCreator={false}
+        onReply={mockOnReply}
+        onReport={mockOnReport}
+      />,
+    );
+
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.querySelector('img')).toBeNull();
+    expect(await screen.findByText(/onerror="alert\(1\)"/)).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components/FundingProgressBar.test.tsx
+++ b/src/__tests__/components/FundingProgressBar.test.tsx
@@ -35,11 +35,23 @@ describe("FundingProgressBar", () => {
     expect(screen.getByText("0% funded")).toBeInTheDocument();
   });
 
-  it("sets the progress bar width proportionally", () => {
+  it("renders a motion progress bar element", () => {
     const { container } = render(
       <FundingProgressBar amountRaised={BigInt(25_000_000)} fundingGoal={BigInt(100_000_000)} />,
     );
-    const bar = container.querySelector('[style*="width"]') as HTMLElement;
-    expect(bar.style.width).toBe("25%");
+    const bar = container.querySelector(".bg-linear-to-r");
+    expect(bar).toBeInTheDocument();
+  });
+
+  it("updates displayed percentage when amount raised increases", () => {
+    const { rerender } = render(
+      <FundingProgressBar amountRaised={BigInt(25_000_000)} fundingGoal={BigInt(100_000_000)} />,
+    );
+    expect(screen.getByText("25% funded")).toBeInTheDocument();
+
+    rerender(
+      <FundingProgressBar amountRaised={BigInt(50_000_000)} fundingGoal={BigInt(100_000_000)} />,
+    );
+    expect(screen.getByText("50% funded")).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/SafeMarkdown.test.tsx
+++ b/src/__tests__/components/SafeMarkdown.test.tsx
@@ -1,0 +1,56 @@
+import { MARKDOWN_SANITIZE_OVERRIDES, buildMarkdownSanitizeSchema } from "@/lib/markdownSanitizeSchema";
+
+/** Minimal stand-in for hast-util-sanitize defaults used in unit tests. */
+const testDefaultSchema = {
+  strip: ["script"],
+  protocols: {
+    cite: ["http", "https"],
+    href: ["http", "https", "irc", "ircs", "mailto", "xmpp"],
+    longDesc: ["http", "https"],
+    src: ["http", "https"],
+  },
+  attributes: {
+    a: ["href", "onClick"],
+    img: ["src", "onerror"],
+  },
+};
+
+describe("markdown sanitize schema", () => {
+  it("disallows comments and restricts URL protocols", () => {
+    expect(MARKDOWN_SANITIZE_OVERRIDES.allowComments).toBe(false);
+    expect(MARKDOWN_SANITIZE_OVERRIDES.protocols?.href).toEqual(["http", "https", "mailto"]);
+    expect(MARKDOWN_SANITIZE_OVERRIDES.protocols?.src).toEqual(["http", "https"]);
+    expect(MARKDOWN_SANITIZE_OVERRIDES.protocols?.href).not.toContain("javascript");
+    expect(MARKDOWN_SANITIZE_OVERRIDES.protocols?.src).not.toContain("data");
+  });
+
+  it("removes event-handler attributes from allowlists", () => {
+    const schema = buildMarkdownSanitizeSchema(testDefaultSchema);
+    expect(schema.attributes?.a).not.toContain("onClick");
+    expect(schema.attributes?.img).not.toContain("onerror");
+  });
+
+  it("preserves default script stripping", () => {
+    const schema = buildMarkdownSanitizeSchema(testDefaultSchema);
+    expect(schema.strip).toContain("script");
+  });
+});
+
+/**
+ * Known XSS payloads exercised against the hardened protocol allowlist.
+ * Full react-markdown pipeline coverage runs in Playwright/e2e or manual QA
+ * because markdown dependencies are ESM-only in Jest without extra transforms.
+ */
+describe("XSS payload protocol expectations", () => {
+  const blockedProtocols = ["javascript:", "data:", "vbscript:"];
+
+  it.each(blockedProtocols)("blocks %s URLs in href and src allowlists", (protocol) => {
+    const schema = buildMarkdownSanitizeSchema(testDefaultSchema);
+    for (const allowed of schema.protocols?.href ?? []) {
+      expect(allowed).not.toBe(protocol.replace(":", ""));
+    }
+    for (const allowed of schema.protocols?.src ?? []) {
+      expect(allowed).not.toBe(protocol.replace(":", ""));
+    }
+  });
+});

--- a/src/__tests__/components/UpdateItem.test.tsx
+++ b/src/__tests__/components/UpdateItem.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 import UpdateItem from '@/components/UpdateItem';
 import { CampaignUpdate } from '@/types';
 
+jest.mock('@/lib/campaignUpdates', () => ({
+  verifyUpdateSignature: jest.fn().mockResolvedValue(true),
+}));
+
 const mockUpdate: CampaignUpdate = {
   id: 'test-update-1',
   campaignId: 1,
@@ -84,5 +88,17 @@ describe('UpdateItem', () => {
     render(<UpdateItem update={mockUpdate} />);
     const article = screen.getByRole('article');
     expect(article).toHaveAttribute('aria-label');
+  });
+
+  it('renders XSS payloads as inert text without executable markup', () => {
+    const xssUpdate: CampaignUpdate = {
+      ...mockUpdate,
+      content: '<a href="javascript:alert(1)">click</a>',
+    };
+
+    const { container } = render(<UpdateItem update={xssUpdate} />);
+
+    expect(container.querySelector('a')).toBeNull();
+    expect(screen.getByText(/javascript:alert\(1\)/)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/hooks/useLiveCampaignFunding.test.tsx
+++ b/src/__tests__/hooks/useLiveCampaignFunding.test.tsx
@@ -1,0 +1,98 @@
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useLiveCampaignFunding } from "@/hooks/useLiveCampaignFunding";
+import { Category, type Campaign } from "@/types";
+
+const mockUseCampaignContributionEvents = jest.fn();
+
+jest.mock("@/hooks/useCampaignContributionEvents", () => ({
+  useCampaignContributionEvents: (options: unknown) => mockUseCampaignContributionEvents(options),
+}));
+
+jest.mock("@/hooks/useCampaign", () => ({
+  useCampaign: jest.fn(),
+}));
+
+import { useCampaign } from "@/hooks/useCampaign";
+
+const mockUseCampaign = useCampaign as jest.MockedFunction<typeof useCampaign>;
+
+function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: 1,
+    creator: "GCREATOR1111111111111111111111111111111111111111111111111",
+    title: "Test",
+    description: "Desc",
+    created_at: 1,
+    status: "active",
+    funding_goal: BigInt(100_000_000),
+    deadline: 9_999_999_999,
+    amount_raised: BigInt(10_000_000),
+    is_active: true,
+    funds_withdrawn: false,
+    is_cancelled: false,
+    is_verified: true,
+    category: Category.Educator,
+    has_revenue_sharing: false,
+    revenue_share_percentage: 0,
+    ...overrides,
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useLiveCampaignFunding", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseCampaignContributionEvents.mockImplementation(({ onContributions }) => {
+      (globalThis as { __triggerContribution?: (delta: bigint) => void }).__triggerContribution =
+        (delta: bigint) => onContributions?.(delta, 1);
+    });
+    mockUseCampaign.mockReturnValue({
+      campaign: makeCampaign(),
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+  });
+
+  it("increments amount raised when contribution events arrive", () => {
+    const { result } = renderHook(() => useLiveCampaignFunding(1), { wrapper });
+
+    expect(result.current.amountRaised).toBe(BigInt(10_000_000));
+
+    act(() => {
+      (globalThis as { __triggerContribution?: (delta: bigint) => void }).__triggerContribution?.(
+        BigInt(5_000_000),
+      );
+    });
+
+    expect(result.current.amountRaised).toBe(BigInt(15_000_000));
+    expect(result.current.campaign?.amount_raised).toBe(BigInt(15_000_000));
+  });
+
+  it("resets to chain value when campaign reconciles from get_campaign", () => {
+    const { result, rerender } = renderHook(() => useLiveCampaignFunding(1), { wrapper });
+
+    act(() => {
+      (globalThis as { __triggerContribution?: (delta: bigint) => void }).__triggerContribution?.(
+        BigInt(5_000_000),
+      );
+    });
+    expect(result.current.amountRaised).toBe(BigInt(15_000_000));
+
+    mockUseCampaign.mockReturnValue({
+      campaign: makeCampaign({ amount_raised: BigInt(12_000_000) }),
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    rerender();
+
+    expect(result.current.amountRaised).toBe(BigInt(12_000_000));
+  });
+});

--- a/src/__tests__/integration/AppPageComponents.test.tsx
+++ b/src/__tests__/integration/AppPageComponents.test.tsx
@@ -24,14 +24,10 @@ jest.mock("@stellar/stellar-sdk", () => ({
   },
 }));
 
-jest.mock("react-markdown", () => ({
+jest.mock("@/components/SafeMarkdown", () => ({
   __esModule: true,
   default: ({ children }: { children: string }) => <p>{children}</p>,
 }));
-
-jest.mock("remark-gfm", () => ({}));
-
-jest.mock("rehype-sanitize", () => ({}));
 
 jest.mock("@/i18n/routing", () => ({
   Link: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
@@ -45,8 +41,8 @@ jest.mock("@/components/WalletContext", () => ({
   useWallet: () => mockUseWallet(),
 }));
 
-jest.mock("@/hooks/useCampaign", () => ({
-  useCampaign: (id: number) => mockUseCampaign(id),
+jest.mock("@/hooks/useLiveCampaignFunding", () => ({
+  useLiveCampaignFunding: (id: number) => mockUseCampaign(id),
 }));
 
 jest.mock("@/hooks/useCampaigns", () => ({
@@ -177,6 +173,7 @@ describe("app page components", () => {
     });
     mockUseCampaign.mockReturnValue({
       campaign: makeCampaign(),
+      amountRaised: makeCampaign().amount_raised,
       isLoading: false,
       error: null,
       refetch: jest.fn(),
@@ -208,6 +205,7 @@ describe("app page components", () => {
   it("renders the cause detail page with campaign data, voting, actions, and refund state", async () => {
     mockUseCampaign.mockReturnValue({
       campaign: makeCampaign({ status: "cancelled", is_active: false, is_cancelled: true }),
+      amountRaised: makeCampaign({ status: "cancelled", is_active: false, is_cancelled: true }).amount_raised,
       isLoading: false,
       error: null,
       refetch: jest.fn(),

--- a/src/__tests__/lib/sorobanEvents.test.ts
+++ b/src/__tests__/lib/sorobanEvents.test.ts
@@ -1,0 +1,71 @@
+jest.mock("@stellar/stellar-sdk", () => {
+  const nativeToScVal = (value: unknown, opts: { type: string }) => {
+    const encoded =
+      opts.type === "symbol"
+        ? `sym:${String(value)}`
+        : opts.type === "u32"
+          ? `u32:${String(value)}`
+          : `i128:${String(value)}`;
+    return {
+      __native: value,
+      __encoded: encoded,
+      toXDR: () => Buffer.from(encoded),
+    };
+  };
+
+  return {
+    nativeToScVal,
+    scValToNative: (value: { __native?: unknown }) => value.__native,
+    scValToBigInt: (value: { __bigint?: bigint }) => value.__bigint ?? BigInt(0),
+    rpc: {
+      Server: jest.fn(),
+    },
+  };
+});
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import {
+  contributionMadeTopicFilter,
+  isContributionMadeEvent,
+  parseContributionAmount,
+  scValToTopicSegment,
+  sumContributionAmounts,
+} from "@/lib/sorobanEvents";
+
+describe("sorobanEvents", () => {
+  it("builds contribution_made topic filter segments for a campaign", () => {
+    const topics = contributionMadeTopicFilter(42);
+    expect(topics).toHaveLength(1);
+    expect(topics[0]).toHaveLength(3);
+    expect(topics[0][2]).toBe("*");
+
+    const symbol = StellarSdk.nativeToScVal("contribution_made", { type: "symbol" });
+    const campaign = StellarSdk.nativeToScVal(42, { type: "u32" });
+    expect(topics[0][0]).toBe(scValToTopicSegment(symbol as never));
+    expect(topics[0][1]).toBe(scValToTopicSegment(campaign as never));
+  });
+
+  it("identifies contribution_made events for the matching campaign", () => {
+    const event = {
+      id: "evt-1",
+      topic: [
+        StellarSdk.nativeToScVal("contribution_made", { type: "symbol" }),
+        StellarSdk.nativeToScVal(7, { type: "u32" }),
+        StellarSdk.nativeToScVal("GABC", { type: "address" }),
+      ],
+      value: { __bigint: BigInt(1_000_000) },
+    } as Parameters<typeof isContributionMadeEvent>[0];
+
+    expect(isContributionMadeEvent(event, 7)).toBe(true);
+    expect(isContributionMadeEvent(event, 8)).toBe(false);
+  });
+
+  it("parses contribution amounts and sums events", () => {
+    const event = {
+      value: { __bigint: BigInt(2_500_000) },
+    } as Parameters<typeof parseContributionAmount>[0];
+
+    expect(parseContributionAmount(event)).toBe(BigInt(2_500_000));
+    expect(sumContributionAmounts([event, event])).toBe(BigInt(5_000_000));
+  });
+});

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -16,7 +16,8 @@ import UpdatesSection from '@/components/UpdatesSection';
 import { useToast } from '@/components/ToastProvider';
 import VotingComponent from '@/components/VotingComponent';
 import { useWallet } from '@/components/WalletContext';
-import { useCampaign } from '@/hooks/useCampaign';
+import { useLiveCampaignFunding } from '@/hooks/useLiveCampaignFunding';
+import SafeMarkdown from '@/components/SafeMarkdown';
 import { usePlatformFee } from '@/hooks/usePlatformFee';
 import {
   voteOnCampaign,
@@ -29,9 +30,6 @@ import {
   getContribution,
   claimRefund,
 } from '@/lib/contractClient';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
 import { useTranslations } from 'next-intl';
 import { Campaign, Vote, CATEGORY_LABELS, stroopsToXlm } from '@/types';
 import { parseContractError } from '@/utils/contractErrors';
@@ -44,7 +42,7 @@ function formatDate(ts: number) {
 export default function CauseDetailClient({ id }: { id: string }) {
   const { publicKey: userWalletAddress } = useWallet();
   const tContractErrors = useTranslations('ContractErrors');
-  const { campaign: fetchedCampaign, isLoading, error, refetch } = useCampaign(Number(id));
+  const { campaign: fetchedCampaign, isLoading, error, refetch } = useLiveCampaignFunding(Number(id));
   const { platformFeeBps, isLoading: isPlatformFeeLoading, isFallback } = usePlatformFee();
 
   const [campaign, setCampaign] = useState<Campaign | null>(null);
@@ -280,11 +278,9 @@ export default function CauseDetailClient({ id }: { id: string }) {
                 </div>
               )}
               <h1 className="text-2xl sm:text-3xl font-bold text-zinc-900 dark:text-zinc-50 mb-4 leading-tight">{campaign.title}</h1>
-              <div className="prose prose-zinc dark:prose-invert max-w-none">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
-                  {campaign.description}
-                </ReactMarkdown>
-              </div>
+              <SafeMarkdown className="prose prose-zinc dark:prose-invert max-w-none">
+                {campaign.description}
+              </SafeMarkdown>
 
               {/* Share + Report toolbar */}
               <div className="flex items-center justify-between flex-wrap gap-3 pt-4 mt-4 border-t border-zinc-100 dark:border-zinc-700">

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import ReactMarkdown from 'react-markdown';
-import rehypeSanitize from 'rehype-sanitize';
-import remarkGfm from 'remark-gfm';
+import SafeMarkdown from '@/components/SafeMarkdown';
 import { useState, useEffect } from 'react';
 import { useToast } from '@/components/ToastProvider';
 import { useWallet } from '@/components/WalletContext';
@@ -465,11 +463,9 @@ export default function CreateCampaignPage() {
               ) : (
                 <div className="px-3 py-2 min-h-[120px] bg-zinc-50 dark:bg-zinc-700 text-sm text-zinc-600 dark:text-zinc-400">
                   {description.trim() ? (
-                    <div className="prose prose-zinc dark:prose-invert max-w-none">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
-                        {description}
-                      </ReactMarkdown>
-                    </div>
+                    <SafeMarkdown className="prose prose-zinc dark:prose-invert max-w-none">
+                      {description}
+                    </SafeMarkdown>
                   ) : (
                     <span className="italic text-zinc-400">Nothing to preview</span>
                   )}

--- a/src/components/FundingProgressBar.tsx
+++ b/src/components/FundingProgressBar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+import { motion, useSpring, useTransform } from "framer-motion";
 import { stroopsToXlm } from "../types";
 
 interface FundingProgressBarProps {
@@ -10,21 +12,41 @@ interface FundingProgressBarProps {
 export default function FundingProgressBar({ amountRaised, fundingGoal }: FundingProgressBarProps) {
   const raised = stroopsToXlm(amountRaised);
   const goal = stroopsToXlm(fundingGoal);
-  const pct = goal > 0 ? Math.min(100, Math.round((raised / goal) * 100)) : 0;
+  const targetPct = goal > 0 ? Math.min(100, (raised / goal) * 100) : 0;
+
+  const [displayPct, setDisplayPct] = useState(targetPct);
+  const hasMountedRef = useRef(false);
+
+  const springPct = useSpring(targetPct, { stiffness: 120, damping: 20, mass: 0.6 });
+  const barWidth = useTransform(springPct, (value) => `${value}%`);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      setDisplayPct(targetPct);
+      springPct.jump(targetPct);
+      return;
+    }
+    springPct.set(targetPct);
+    setDisplayPct(targetPct);
+  }, [targetPct, springPct]);
+
+  const displayRaised = raised.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  const displayGoal = goal.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  const roundedPct = Math.round(displayPct);
 
   return (
     <div>
       <div className="flex justify-between text-xs text-zinc-600 dark:text-zinc-400 mb-1">
-        <span className="font-medium">{pct}% funded</span>
+        <span className="font-medium">{roundedPct}% funded</span>
         <span>
-          {raised.toLocaleString(undefined, { maximumFractionDigits: 2 })} /{" "}
-          {goal.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM
+          {displayRaised} / {displayGoal} XLM
         </span>
       </div>
-      <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-1.5">
-        <div
-          className="bg-linear-to-r from-blue-500 to-purple-500 h-1.5 rounded-full transition-all duration-300"
-          style={{ width: `${pct}%` }}
+      <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-1.5 overflow-hidden">
+        <motion.div
+          className="bg-linear-to-r from-blue-500 to-purple-500 h-1.5 rounded-full"
+          style={{ width: barWidth }}
         />
       </div>
     </div>

--- a/src/components/SafeMarkdown.tsx
+++ b/src/components/SafeMarkdown.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import { buildMarkdownSanitizeSchema } from '@/lib/markdownSanitizeSchema';
+
+const markdownSanitizeSchema = buildMarkdownSanitizeSchema(defaultSchema);
+
+interface SafeMarkdownProps {
+  children: string;
+  className?: string;
+}
+
+/**
+ * Renders untrusted markdown with GFM and a hardened rehype-sanitize schema.
+ */
+export default function SafeMarkdown({ children, className }: SafeMarkdownProps) {
+  return (
+    <div className={className}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[[rehypeSanitize, markdownSanitizeSchema]]}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/hooks/useCampaign.ts
+++ b/src/hooks/useCampaign.ts
@@ -3,6 +3,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getCampaign } from '../lib/contractClient';
 import { Campaign } from '../types';
+import { useWindowVisibility } from './useWindowVisibility';
 
 export interface UseCampaignResult {
   campaign: Campaign | null;
@@ -11,14 +12,22 @@ export interface UseCampaignResult {
   refetch: () => void;
 }
 
+/** Periodic `get_campaign` reconciliation to correct event-stream drift. */
+const RECONCILE_INTERVAL =
+  Number(process.env.NEXT_PUBLIC_POLL_INTERVAL_DETAIL_MS) || 30_000;
+
 export function useCampaign(id: number): UseCampaignResult {
   const queryClient = useQueryClient();
+  const isVisible = useWindowVisibility();
 
   const { data, isLoading, error } = useQuery<Campaign | null, Error>({
     queryKey: ['campaign', id],
     queryFn: () => getCampaign(id),
     enabled: !!id,
+    staleTime: RECONCILE_INTERVAL,
     refetchOnWindowFocus: true,
+    refetchInterval: isVisible ? RECONCILE_INTERVAL : false,
+    refetchIntervalInBackground: false,
   });
 
   return {

--- a/src/hooks/useCampaignContributionEvents.ts
+++ b/src/hooks/useCampaignContributionEvents.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  fetchContributionMadeEvents,
+  sumContributionAmounts,
+} from '../lib/sorobanEvents';
+import { useWindowVisibility } from './useWindowVisibility';
+
+const EVENT_POLL_INTERVAL =
+  Number(process.env.NEXT_PUBLIC_CONTRIBUTION_EVENTS_POLL_MS) || 5_000;
+
+const USE_MOCKS =
+  typeof process !== 'undefined' && process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+
+export interface UseCampaignContributionEventsOptions {
+  campaignId: number;
+  enabled?: boolean;
+  onContributions?: (totalAmount: bigint, eventCount: number) => void;
+}
+
+/**
+ * Polls Soroban `contribution_made` events for a campaign and reports new amounts.
+ * Deduplicates by event id so reconnects do not double-count.
+ */
+export function useCampaignContributionEvents({
+  campaignId,
+  enabled = true,
+  onContributions,
+}: UseCampaignContributionEventsOptions): void {
+  const isVisible = useWindowVisibility();
+  const seenEventIdsRef = useRef<Set<string>>(new Set());
+  const cursorRef = useRef<string | undefined>(undefined);
+  const onContributionsRef = useRef(onContributions);
+
+  useEffect(() => {
+    onContributionsRef.current = onContributions;
+  }, [onContributions]);
+
+  useEffect(() => {
+    seenEventIdsRef.current = new Set();
+    cursorRef.current = undefined;
+  }, [campaignId]);
+
+  useEffect(() => {
+    if (!enabled || !campaignId || USE_MOCKS || !isVisible) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const result = await fetchContributionMadeEvents({
+          campaignId,
+          cursor: cursorRef.current,
+        });
+        if (!result || cancelled) return;
+
+        cursorRef.current = result.cursor;
+
+        const unseen = result.events.filter((event) => !seenEventIdsRef.current.has(event.id));
+        for (const event of unseen) {
+          seenEventIdsRef.current.add(event.id);
+        }
+
+        if (unseen.length > 0) {
+          const delta = sumContributionAmounts(unseen);
+          onContributionsRef.current?.(delta, unseen.length);
+        }
+      } catch {
+        // RPC errors are non-fatal; reconciliation via get_campaign covers drift.
+      }
+    };
+
+    void poll();
+    const intervalId = window.setInterval(() => {
+      void poll();
+    }, EVENT_POLL_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [campaignId, enabled, isVisible]);
+}

--- a/src/hooks/useLiveCampaignFunding.ts
+++ b/src/hooks/useLiveCampaignFunding.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCampaign } from './useCampaign';
+import { useCampaignContributionEvents } from './useCampaignContributionEvents';
+import type { Campaign } from '../types';
+
+export interface UseLiveCampaignFundingResult {
+  campaign: Campaign | null;
+  amountRaised: bigint;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Campaign detail funding with live increments from `contribution_made` events
+ * and periodic reconciliation via `get_campaign`.
+ */
+export function useLiveCampaignFunding(campaignId: number): UseLiveCampaignFundingResult {
+  const { campaign, isLoading, error, refetch } = useCampaign(campaignId);
+  const [liveAmountRaised, setLiveAmountRaised] = useState<bigint | null>(null);
+
+  useEffect(() => {
+    if (campaign) {
+      setLiveAmountRaised(campaign.amount_raised);
+    } else {
+      setLiveAmountRaised(null);
+    }
+  }, [campaign]);
+
+  const handleContributions = useCallback((delta: bigint) => {
+    setLiveAmountRaised((current) => (current ?? BigInt(0)) + delta);
+  }, []);
+
+  useCampaignContributionEvents({
+    campaignId,
+    enabled: Boolean(campaign),
+    onContributions: handleContributions,
+  });
+
+  const displayCampaign = useMemo(() => {
+    if (!campaign) return null;
+    if (liveAmountRaised === null) return campaign;
+    return { ...campaign, amount_raised: liveAmountRaised };
+  }, [campaign, liveAmountRaised]);
+
+  return {
+    campaign: displayCampaign,
+    amountRaised: liveAmountRaised ?? campaign?.amount_raised ?? BigInt(0),
+    isLoading,
+    error,
+    refetch,
+  };
+}

--- a/src/lib/markdownSanitizeSchema.ts
+++ b/src/lib/markdownSanitizeSchema.ts
@@ -1,0 +1,36 @@
+import type { Schema } from 'hast-util-sanitize';
+
+/** Protocol and tag restrictions applied on top of rehype-sanitize defaults. */
+export const MARKDOWN_SANITIZE_OVERRIDES: Partial<Schema> = {
+  allowComments: false,
+  protocols: {
+    cite: ['http', 'https'],
+    href: ['http', 'https', 'mailto'],
+    longDesc: ['http', 'https'],
+    src: ['http', 'https'],
+  },
+};
+
+/**
+ * Merge GitHub-style defaults with ProofOfHeart-specific hardening.
+ * Called from SafeMarkdown at runtime so Jest can mock rehype-sanitize in integration tests.
+ */
+export function buildMarkdownSanitizeSchema(defaultSchema: Schema): Schema {
+  return {
+    ...defaultSchema,
+    ...MARKDOWN_SANITIZE_OVERRIDES,
+    protocols: {
+      ...defaultSchema.protocols,
+      ...MARKDOWN_SANITIZE_OVERRIDES.protocols,
+    },
+    attributes: {
+      ...defaultSchema.attributes,
+      a: (defaultSchema.attributes?.a ?? []).filter(
+        (attr) => (typeof attr === 'string' ? !attr.toLowerCase().startsWith('on') : true),
+      ),
+      img: (defaultSchema.attributes?.img ?? []).filter(
+        (attr) => (typeof attr === 'string' ? !attr.toLowerCase().startsWith('on') : true),
+      ),
+    },
+  };
+}

--- a/src/lib/sorobanEvents.ts
+++ b/src/lib/sorobanEvents.ts
@@ -1,0 +1,104 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+type Api = StellarSdk.rpc.Api;
+
+const USE_MOCKS =
+  typeof process !== "undefined" && process.env.NEXT_PUBLIC_USE_MOCKS === "true";
+
+const SOROBAN_RPC_URL =
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ??
+  process.env.NEXT_PUBLIC_RPC_URL ??
+  "https://soroban-testnet.stellar.org";
+
+const CONTRACT_ADDRESS =
+  process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ?? process.env.NEXT_PUBLIC_CONTRACT_ID ?? "";
+
+const CONTRIBUTION_MADE_TOPIC = "contribution_made";
+
+let _server: StellarSdk.rpc.Server | null = null;
+
+function getServer(): StellarSdk.rpc.Server {
+  if (!_server) {
+    _server = new StellarSdk.rpc.Server(SOROBAN_RPC_URL);
+  }
+  return _server;
+}
+
+/** Base64 XDR segment for Soroban event topic filters. */
+export function scValToTopicSegment(value: StellarSdk.xdr.ScVal): string {
+  return value.toXDR().toString("base64");
+}
+
+/** Topic filter for `("contribution_made", campaign_id, *)` contract events. */
+export function contributionMadeTopicFilter(campaignId: number): string[][] {
+  const eventSymbol = StellarSdk.nativeToScVal(CONTRIBUTION_MADE_TOPIC, { type: "symbol" });
+  const campaignTopic = StellarSdk.nativeToScVal(campaignId, { type: "u32" });
+  return [[scValToTopicSegment(eventSymbol), scValToTopicSegment(campaignTopic), "*"]];
+}
+
+export function isContributionMadeEvent(event: Api.EventResponse, campaignId: number): boolean {
+  if (event.topic.length < 2) return false;
+  const topicName = StellarSdk.scValToNative(event.topic[0]);
+  const eventCampaignId = StellarSdk.scValToNative(event.topic[1]);
+  return topicName === CONTRIBUTION_MADE_TOPIC && eventCampaignId === campaignId;
+}
+
+export function parseContributionAmount(event: Api.EventResponse): bigint {
+  return StellarSdk.scValToBigInt(event.value);
+}
+
+export interface FetchContributionEventsResult {
+  events: Api.EventResponse[];
+  cursor: string;
+  latestLedger: number;
+}
+
+export interface FetchContributionEventsOptions {
+  campaignId: number;
+  cursor?: string;
+  startLedger?: number;
+  limit?: number;
+}
+
+/**
+ * Poll Soroban RPC for `contribution_made` events on the configured contract.
+ * Returns an empty result when mocks are enabled or the contract is not configured.
+ */
+export async function fetchContributionMadeEvents(
+  options: FetchContributionEventsOptions,
+): Promise<FetchContributionEventsResult | null> {
+  if (USE_MOCKS || !CONTRACT_ADDRESS) {
+    return null;
+  }
+
+  const { campaignId, cursor, startLedger, limit = 100 } = options;
+  const server = getServer();
+
+  const filters: Api.EventFilter[] = [
+    {
+      type: "contract",
+      contractIds: [CONTRACT_ADDRESS],
+      topics: contributionMadeTopicFilter(campaignId),
+    },
+  ];
+
+  const request: Api.GetEventsRequest = cursor
+    ? { filters, cursor, limit }
+    : {
+        filters,
+        startLedger: startLedger ?? (await server.getLatestLedger()).sequence - 1,
+        limit,
+      };
+
+  const response = await server.getEvents(request);
+
+  return {
+    events: response.events.filter((event) => isContributionMadeEvent(event, campaignId)),
+    cursor: response.cursor,
+    latestLedger: response.latestLedger,
+  };
+}
+
+export function sumContributionAmounts(events: Api.EventResponse[]): bigint {
+  return events.reduce((total, event) => total + parseContributionAmount(event), BigInt(0));
+}


### PR DESCRIPTION
## Summary

Closes #363 
Closes  #367

- **Live funding on campaign detail:** Poll Soroban `contribution_made` events for the active campaign and increment `amount_raised` in the UI without a full page reload. Reconcile against `get_campaign` on a 30s interval (and on window focus) to prevent drift from missed or duplicate events.
- **Smoother UX:** Animate the funding progress bar with a spring transition when raised amounts change.
- **Markdown XSS hardening:** Centralize campaign markdown rendering in `SafeMarkdown` with a stricter `rehype-sanitize` schema (no `javascript:`/`data:` URLs, no event handlers, comments disabled). Comments and updates remain React-escaped plain text; tests assert they do not render executable markup.

## Changes

| Area | Files |
|------|--------|
| Soroban events | `src/lib/sorobanEvents.ts`, `src/hooks/useCampaignContributionEvents.ts` |
| Live funding | `src/hooks/useLiveCampaignFunding.ts`, `src/hooks/useCampaign.ts`, `CauseDetailClient.tsx`, `FundingProgressBar.tsx` |
| Markdown security | `src/components/SafeMarkdown.tsx`, `src/lib/markdownSanitizeSchema.ts`, `NewCauseClient.tsx` |
| Config | `.env.example` (`NEXT_PUBLIC_POLL_INTERVAL_DETAIL_MS`, `NEXT_PUBLIC_CONTRIBUTION_EVENTS_POLL_MS`) |
| Tests | `sorobanEvents.test.ts`, `useLiveCampaignFunding.test.tsx`, `SafeMarkdown.test.tsx`, `CommentItem`/`UpdateItem` XSS cases |

## How it works

1. On cause detail, `useLiveCampaignFunding` loads the campaign via React Query (`get_campaign`).
2. `useCampaignContributionEvents` polls `getEvents` every 5s (when visible, mocks disabled, contract configured) for `("contribution_made", campaign_id, *)`.
3. New events add their `i128` amount to the displayed total.
4. `useCampaign` refetches every 30s and resets `amount_raised` to the on-chain value.
5. `FundingProgressBar` animates percentage/width updates via Framer Motion.

## Configuration

```env
NEXT_PUBLIC_POLL_INTERVAL_DETAIL_MS=30000      # get_campaign reconciliation
NEXT_PUBLIC_CONTRIBUTION_EVENTS_POLL_MS=5000   # Soroban event poll interval
NEXT_PUBLIC_USE_MOCKS=false                    # required for live events
NEXT_PUBLIC_CONTRACT_ADDRESS=C...              # required for event filters