### PR TITLE
feat: #416 #423 #430 #441 — a11y navbar, skeletons, i18n formatting, …

### DIFF
--- a/src/__tests__/lib/formatters.test.ts
+++ b/src/__tests__/lib/formatters.test.ts
@@ -1,0 +1,63 @@
+import { formatNumber, formatXlm, formatDate, formatShortDate } from "@/lib/formatters";
+
+describe("formatNumber", () => {
+  it("formats with en grouping separators", () => {
+    expect(formatNumber(1234567.89, "en", { maximumFractionDigits: 2 })).toBe("1,234,567.89");
+  });
+
+  it("formats with es grouping separators", () => {
+    // Spanish uses period as thousands separator and comma as decimal
+    const result = formatNumber(1234567.89, "es", { maximumFractionDigits: 2 });
+    expect(result).toMatch(/1[.,\s]234[.,\s]567/);
+  });
+});
+
+describe("formatXlm", () => {
+  it("formats XLM amount in en", () => {
+    expect(formatXlm(1234.5, "en")).toBe("1,234.5");
+  });
+
+  it("formats XLM amount in es", () => {
+    const result = formatXlm(1234.5, "es");
+    // Should contain the digits with locale-appropriate separators
+    expect(result).toMatch(/1[.,\s\u00a0]?234/);
+  });
+
+  it("formats zero correctly", () => {
+    expect(formatXlm(0, "en")).toBe("0");
+    expect(formatXlm(0, "es")).toBe("0");
+  });
+});
+
+describe("formatDate", () => {
+  // 2024-03-15 00:00:00 UTC
+  const ts = 1710460800;
+
+  it("formats date in en with long month", () => {
+    const result = formatDate(ts, "en");
+    expect(result).toMatch(/March/);
+    expect(result).toMatch(/2024/);
+  });
+
+  it("formats date in es with long month", () => {
+    const result = formatDate(ts, "es");
+    // Spanish month name
+    expect(result).toMatch(/marzo/i);
+    expect(result).toMatch(/2024/);
+  });
+});
+
+describe("formatShortDate", () => {
+  const ts = 1710460800;
+
+  it("formats short date in en", () => {
+    const result = formatShortDate(ts, "en");
+    expect(result).toMatch(/Mar/);
+    expect(result).toMatch(/2024/);
+  });
+
+  it("formats short date in es", () => {
+    const result = formatShortDate(ts, "es");
+    expect(result).toMatch(/2024/);
+  });
+});

--- a/src/app/[locale]/admin/AdminClient.tsx
+++ b/src/app/[locale]/admin/AdminClient.tsx
@@ -42,6 +42,7 @@ import {
   type CampaignReport,
 } from "@/lib/campaignReports";
 import CancelCampaignModal from "@/components/cancelCampaignModal";
+import { AdminSkeleton } from "@/components/Skeleton";
 import { Campaign } from "@/types";
 
 export default function AdminDashboard() {
@@ -327,12 +328,7 @@ export default function AdminDashboard() {
   }
 
   if (isAdminLoading || isLoading) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh]">
-        <Loader2 className="w-12 h-12 motion-safe:animate-spin text-amber-500 mb-4" />
-        <p className="text-zinc-500 font-medium">Authorizing secure session...</p>
-      </div>
-    );
+    return <AdminSkeleton />;
   }
 
   if (!isAdmin) {

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useState, useEffect } from 'react';
 import ShareButtons from '@/components/ShareButtons';
+import SafeMarkdown from '@/components/SafeMarkdown';
 import ReportModal from '@/components/ReportModal';
 import CampaignActions from '@/components/CampaignActions';
 import AsyncButtonContent from '@/components/AsyncButtonContent';
@@ -17,6 +18,7 @@ import { useToast } from '@/components/ToastProvider';
 import VotingComponent from '@/components/VotingComponent';
 import { useWallet } from '@/components/WalletContext';
 import { useCampaign } from '@/hooks/useCampaign';
+import { useLiveCampaignFunding } from '@/hooks/useLiveCampaignFunding';
 import { useLiveVoteTallies } from '@/hooks/useLiveVoteTallies';
 import { usePlatformFee } from '@/hooks/usePlatformFee';
 import {
@@ -28,23 +30,18 @@ import {
   getContribution,
   claimRefund,
 } from "@/lib/contractClient";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
+import { CauseDetailSkeleton } from "@/components/Skeleton";
 import { Campaign, Vote, CATEGORY_LABELS, formatStroopsAsXlm } from "@/types";
 import { parseContractError } from "@/utils/contractErrors";
 import { getAsyncActionErrorMessage, withActionTimeout } from "@/utils/asyncAction";
 import { trackViewCampaign, trackConnectWallet } from "@/lib/analytics";
-
-function formatDate(ts: number) {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(new Date(ts * 1000));
-}
+import { formatXlm, formatDate } from "@/lib/formatters";
 
 export default function CauseDetailClient({ id }: { id: string }) {
   const { publicKey: userWalletAddress } = useWallet();
   const tContractErrors = useTranslations("ContractErrors");
+  const locale = useLocale();
   const {
     campaign: fetchedCampaign,
     isLoading,
@@ -198,28 +195,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
   };
 
   if (isLoading) {
-    return (
-      <div className="min-h-screen bg-linear-to-br from-zinc-50 to-zinc-100 dark:from-zinc-900 dark:to-zinc-800">
-        <main className="container mx-auto px-4 py-8 max-w-5xl">
-          <div className="motion-safe:animate-pulse space-y-6">
-            <div className="h-5 bg-zinc-200 dark:bg-zinc-700 rounded w-48" />
-            <div className="bg-white dark:bg-zinc-800 rounded-xl border border-zinc-200 dark:border-zinc-700 p-6 space-y-4">
-              <div className="h-8 bg-zinc-200 dark:bg-zinc-700 rounded w-3/4" />
-              <div className="h-4 bg-zinc-200 dark:bg-zinc-700 rounded w-full" />
-              <div className="h-4 bg-zinc-200 dark:bg-zinc-700 rounded w-5/6" />
-            </div>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="bg-white dark:bg-zinc-800 rounded-xl p-4 border border-zinc-200 dark:border-zinc-700 h-20"
-                />
-              ))}
-            </div>
-          </div>
-        </main>
-      </div>
-    );
+    return <CauseDetailSkeleton />;
   }
 
   if (error) {
@@ -367,7 +343,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
                 },
                 {
                   label: "XLM Raised",
-                  value: raised.toLocaleString(undefined, { maximumFractionDigits: 2 }),
+                  value: formatXlm(raised, locale),
                   cls: "text-zinc-900 dark:text-zinc-50",
                 },
               ].map(({ label, value, cls }) => (
@@ -387,7 +363,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
               </h2>
               <DeadlineCountdown deadline={campaign.deadline} />
               <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-2">
-                Ends {formatDate(campaign.deadline)}
+                Ends {formatDate(campaign.deadline, locale)}
               </p>
             </div>
 
@@ -415,9 +391,9 @@ export default function CauseDetailClient({ id }: { id: string }) {
               <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
                 A platform fee of {platformFeePercent.toFixed(2)}% is deducted from funds when
                 withdrawn by the creator. Based on the current amount raised, that is{" "}
-                {estimatedFeeAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM in
+                {formatXlm(estimatedFeeAmount, locale)} XLM in
                 fees and{" "}
-                {estimatedCreatorReceives.toLocaleString(undefined, { maximumFractionDigits: 2 })}{" "}
+                {formatXlm(estimatedCreatorReceives, locale)}{" "}
                 XLM delivered to the creator.
               </p>
               {isFallback && (
@@ -459,7 +435,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
                     <p className="text-sm text-zinc-700 dark:text-zinc-300">
                       Your refundable contribution:{" "}
                       <span className="font-semibold">
-                        {refundableXlm.toLocaleString(undefined, { maximumFractionDigits: 4 })} XLM
+                        {formatXlm(parseFloat(refundableXlm), locale)} XLM
                       </span>
                     </p>
                     <button
@@ -532,7 +508,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
                     {campaign.creator.slice(0, 10)}...{campaign.creator.slice(-6)}
                   </p>
                   <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                    Deadline: {formatDate(campaign.deadline)}
+                    Deadline: {formatDate(campaign.deadline, locale)}
                   </p>
                 </div>
               </div>

--- a/src/app/[locale]/causes/[id]/opengraph-image.tsx
+++ b/src/app/[locale]/causes/[id]/opengraph-image.tsx
@@ -11,8 +11,18 @@ export const size = {
 };
 export const contentType = 'image/png';
 
-export default async function Image({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
+export default async function Image({ params }: { params: Promise<{ id: string; locale: string }> }) {
+  const { id, locale } = await params;
+  const safeLocale = locale === 'es' ? 'es' : 'en';
+
+  /** Truncate a string to maxLen chars, appending ellipsis if needed. */
+  function truncate(str: string, maxLen: number): string {
+    return str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
+  }
+
+  function fmtNumber(n: number): string {
+    return new Intl.NumberFormat(safeLocale, { maximumFractionDigits: 2 }).format(n);
+  }
 
   try {
     const campaign = await getCampaign(Number(id));
@@ -27,6 +37,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
     const goal = parseFloat(goalStr);
     const fundingPct = goal > 0 ? Math.min(100, Math.round((raised / goal) * 100)) : 0;
     const categoryLabel = CATEGORY_LABELS[campaign.category] ?? 'Other';
+    const title = truncate(campaign.title || 'Untitled Campaign', 80);
 
     return new ImageResponse(
       (
@@ -92,14 +103,10 @@ export default async function Image({ params }: { params: Promise<{ id: string }
                 lineHeight: 1.2,
                 margin: 0,
                 maxWidth: '1000px',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
+                wordBreak: 'break-word',
               }}
             >
-              {campaign.title}
+              {title}
             </h1>
           </div>
 
@@ -136,7 +143,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
                   color: '#18181b',
                 }}
               >
-                {raised.toLocaleString()} XLM
+                {fmtNumber(raised)} XLM
               </div>
             </div>
 
@@ -165,7 +172,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
                   color: '#18181b',
                 }}
               >
-                {goal.toLocaleString()} XLM
+                {fmtNumber(goal)} XLM
               </div>
             </div>
 

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -235,7 +235,7 @@ export default function CreateCampaignPage() {
     setIsSubmitting(true);
 
     try {
-      const fundingGoalStroops = xlmToStroops(reviewData.fundingGoalXlm);
+      const fundingGoalStroops = xlmToStroops(reviewData.fundingGoalXlm.toString());
       const basisPoints = reviewData.hasRevenueSharing
         ? Math.round(reviewData.revenueSharePercentage * 100)
         : 0;

--- a/src/app/[locale]/dashboard/DashboardClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardClient.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import MyContributionsSection from "@/components/MyContributionsSection";
-import { Spinner } from "@/components/Skeleton";
+import { Spinner, DashboardSkeleton } from "@/components/Skeleton";
 import { useWallet } from "@/components/WalletContext";
 import { useCampaigns } from "@/hooks/useCampaigns";
 import { getStellarBalance } from "@/lib/getStellarBalance";
@@ -14,7 +14,7 @@ import { explorerTxUrl } from "@/utils/explorer";
 export default function DashboardPage() {
   const t = useTranslations("Dashboard");
   const { publicKey, isWalletConnected } = useWallet();
-  const { campaigns } = useCampaigns();
+  const { campaigns, isLoading: campaignsLoading } = useCampaigns();
   const [balance, setBalance] = useState<number | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
   const [balanceError, setBalanceError] = useState<string | null>(null);
@@ -84,6 +84,10 @@ export default function DashboardPage() {
         </Link>
       </div>
     );
+  }
+
+  if (campaignsLoading || balanceLoading) {
+    return <DashboardSkeleton />;
   }
 
   return (

--- a/src/app/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/causes/[id]/CauseDetailClient.tsx
@@ -27,14 +27,7 @@ import {
 import type { TransactionLifecyclePhase } from "../../../lib/contractClient";
 import { Campaign, Vote, CATEGORY_LABELS, formatStroopsAsXlm } from "../../../types";
 import { parseContractError } from "../../../utils/contractErrors";
-
-function formatDate(ts: number) {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(new Date(ts * 1000));
-}
+import { formatXlm, formatDate as fmtDate } from "../../../lib/formatters";
 
 export default function CauseDetailClient({ id }: { id: string }) {
   const { publicKey: userWalletAddress } = useWallet();
@@ -48,6 +41,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
   const [voteCounts, setVoteCounts] = useState({ upvotes: 0, downvotes: 0, totalVotes: 0 });
   const [isDonationModalOpen, setIsDonationModalOpen] = useState(false);
   const { showError, showSuccess, showWarning } = useToast();
+  const locale = typeof navigator !== 'undefined' ? navigator.language : 'en';
   const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
 
   // Quorum / threshold state
@@ -332,7 +326,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
               </div>
               <div className="bg-white dark:bg-zinc-800 rounded-xl p-4 border border-zinc-200 dark:border-zinc-700 text-center">
                 <div className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-                  {raised.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                  {formatXlm(raised, locale)}
                 </div>
                 <div className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">XLM Raised</div>
               </div>
@@ -345,7 +339,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
               </h2>
               <DeadlineCountdown deadline={campaign.deadline} />
               <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-2">
-                Ends {formatDate(campaign.deadline)}
+                Ends {fmtDate(campaign.deadline, locale)}
               </p>
             </div>
 
@@ -390,7 +384,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
                     <p className="text-sm text-zinc-700 dark:text-zinc-300">
                       Your refundable contribution:{" "}
                       <span className="font-semibold">
-                        {refundableXlm.toLocaleString(undefined, { maximumFractionDigits: 4 })} XLM
+                        {formatXlm(parseFloat(refundableXlm), locale)} XLM
                       </span>
                     </p>
                     <button
@@ -472,7 +466,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
                     {campaign.creator.slice(0, 10)}...{campaign.creator.slice(-6)}
                   </p>
                   <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                    Deadline: {formatDate(campaign.deadline)}
+                    Deadline: {fmtDate(campaign.deadline, locale)}
                   </p>
                 </div>
               </div>

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { Campaign, Vote, CATEGORY_LABELS, calculateFundingPercentage, formatStroopsAsXlm } from '../types';
 import { formatAddress } from '@/lib/formatAddress';
+import { formatXlm, formatShortDate } from '@/lib/formatters';
+import { useLocale } from 'next-intl';
 import AsyncButtonContent from './AsyncButtonContent';
 import CampaignStatusBadge from './CampaignStatusBadge';
 import CancelCampaignModal from './cancelCampaignModal';
@@ -33,12 +35,8 @@ const CATEGORY_ICONS: Record<string, string> = {
   healthcare:  '🏥',
 };
 
-function formatDate(ts: number) {
-  return new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  }).format(new Date(ts * 1000));
+function formatDate(ts: number, locale: string) {
+  return formatShortDate(ts, locale);
 }
 
 
@@ -55,6 +53,7 @@ export default function CauseCard({
   totalVotes = 0,
 }: CauseCardProps) {
   const [isVoting, setIsVoting] = useState(false);
+  const locale = useLocale();
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [isClaimingRefund, setIsClaimingRefund] = useState(false);
@@ -162,7 +161,7 @@ export default function CauseCard({
         {/* Funding progress */}
         <div className="space-y-1.5">
           <div className="flex justify-between text-xs text-zinc-500 dark:text-zinc-400">
-            <span>{raisedXlm.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM raised</span>
+            <span>{formatXlm(parseFloat(raisedXlm), locale)} XLM raised</span>
             <span>{progressPct}%</span>
           </div>
           <div className="w-full bg-zinc-100 dark:bg-zinc-700 rounded-full h-1.5">
@@ -172,7 +171,7 @@ export default function CauseCard({
             />
           </div>
           <p className="text-xs text-zinc-400 dark:text-zinc-500">
-            Goal: {goalXlm.toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM
+            Goal: {formatXlm(parseFloat(goalXlm), locale)} XLM
           </p>
         </div>
 
@@ -199,7 +198,7 @@ export default function CauseCard({
 
         {/* Created date */}
         <p className="text-xs text-zinc-400 dark:text-zinc-500">
-          Created {formatDate(campaign.created_at)}
+          Created {formatDate(campaign.created_at, locale)}
         </p>
       </div>
 

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useLocale } from "next-intl";
 
 interface DeadlineCountdownProps {
   deadline: number; // Unix timestamp in seconds
@@ -25,6 +26,7 @@ function getTimeLeft(deadline: number): TimeLeft | null {
 
 export default function DeadlineCountdown({ deadline }: DeadlineCountdownProps) {
   const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(() => getTimeLeft(deadline));
+  const locale = useLocale();
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -65,10 +67,11 @@ export default function DeadlineCountdown({ deadline }: DeadlineCountdownProps) 
       <span>
         {timeLeft.days > 0 && (
           <>
-            <strong>{timeLeft.days}</strong>d{" "}
+            <strong>{new Intl.NumberFormat(locale).format(timeLeft.days)}</strong>d{" "}
           </>
         )}
-        <strong>{timeLeft.hours}</strong>h <strong>{timeLeft.minutes}</strong>m remaining
+        <strong>{new Intl.NumberFormat(locale).format(timeLeft.hours)}</strong>h{" "}
+        <strong>{new Intl.NumberFormat(locale).format(timeLeft.minutes)}</strong>m remaining
       </span>
     </div>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl';
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useWallet } from "@/components/WalletContext";
 import { useTheme } from "@/hooks/useTheme";
-import { Link } from '@/i18n/routing';
+import { Link, usePathname } from '@/i18n/routing';
 import { useAdmin } from "@/hooks/useAdmin";
 import { formatAddress } from "@/lib/formatAddress";
 import LanguageSwitcher from "./LanguageSwitcher";
@@ -27,6 +27,7 @@ export default function Navbar() {
     isLoading,
   } = useWallet();
   const { theme, toggleTheme } = useTheme();
+  const pathname = usePathname();
   const t = useTranslations('Common');
   const { admin: adminAddress } = useAdmin();
 
@@ -123,11 +124,18 @@ export default function Navbar() {
 
         {/* Desktop Nav */}
         <nav className="hidden items-center gap-2 md:flex" aria-label="Primary">
-          {navLinks.map((link) => (
+          {navLinks.map((link) => {
+            const isActive = link.href === '/' ? pathname === '/' : pathname.startsWith(link.href);
+            return (
             <Link
               key={link.href}
               href={link.href as Parameters<typeof Link>[0]['href']}
-              className="relative rounded-lg px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-black/5 hover:text-zinc-950 dark:text-zinc-200 dark:hover:bg-white/10 dark:hover:text-white transition-all group"
+              aria-current={isActive ? 'page' : undefined}
+              className={`relative rounded-lg px-4 py-2 text-sm font-medium transition-all group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                isActive
+                  ? 'text-zinc-950 dark:text-white'
+                  : 'text-zinc-700 hover:bg-black/5 hover:text-zinc-950 dark:text-zinc-200 dark:hover:bg-white/10 dark:hover:text-white'
+              }`}
             >
               <span className="flex items-center gap-1.5">
                 {link.href === '/admin' && <ShieldCheck size={14} className="text-blue-500" />}
@@ -138,9 +146,12 @@ export default function Navbar() {
                   </span>
                 )}
               </span>
-              <span className="absolute bottom-1 left-4 right-4 h-0.5 bg-blue-500 scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
+              <span className={`absolute bottom-1 left-4 right-4 h-0.5 bg-blue-500 transition-transform origin-left ${
+                isActive ? 'scale-x-100' : 'scale-x-0 group-hover:scale-x-100'
+              }`} />
             </Link>
-          ))}
+            );
+          })}
         </nav>
 
         <div className="flex items-center gap-3">
@@ -235,14 +246,20 @@ export default function Navbar() {
           <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
             <nav aria-label="Mobile">
               <ul className="flex flex-col gap-2">
-                {navLinks.map((link) => (
+                {navLinks.map((link) => {
+                  const isActive = link.href === '/' ? pathname === '/' : pathname.startsWith(link.href);
+                  return (
                   <li key={link.href}>
                     <Link
                       href={link.href as Parameters<typeof Link>[0]['href']}
                       onClick={() => setMenuOpen(false)}
-                      className={`block rounded-xl px-4 py-3 text-base font-semibold transition-all ${link.href === '/admin'
-                        ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300'
-                        : 'text-zinc-800 hover:bg-black/5 dark:text-zinc-200 dark:hover:bg-white/10'
+                      aria-current={isActive ? 'page' : undefined}
+                      className={`block rounded-xl px-4 py-3 text-base font-semibold transition-all focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                        isActive
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300'
+                          : link.href === '/admin'
+                            ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300'
+                            : 'text-zinc-800 hover:bg-black/5 dark:text-zinc-200 dark:hover:bg-white/10'
                         }`}
                     >
                       <span className="flex items-center gap-2">
@@ -256,7 +273,8 @@ export default function Navbar() {
                       </span>
                     </Link>
                   </li>
-                ))}
+                  );
+                })}
               </ul>
             </nav>
 

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -139,6 +139,32 @@ export function DashboardSkeleton() {
   );
 }
 
+/** Skeleton for the admin dashboard page */
+export function AdminSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 space-y-8">
+      <Skeleton className="h-48 w-full rounded-[2.5rem]" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-36 rounded-[2rem]" />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
+        <div className="lg:col-span-8 space-y-4">
+          <Skeleton className="h-8 w-48" />
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-32 w-full rounded-[2rem]" />
+          ))}
+        </div>
+        <div className="lg:col-span-4 space-y-6">
+          <Skeleton className="h-64 rounded-[2.5rem]" />
+          <Skeleton className="h-48 rounded-[2.5rem]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** Inline spinner for buttons / transaction pending states */
 export function Spinner({ className = "h-4 w-4" }: { className?: string }) {
   return (

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -18,10 +18,10 @@ type FunnelStep =
   | "funnel_confirmed"
   | "funnel_error";
 
-interface FunnelEventData {
+interface FunnelEventData extends Record<string, unknown> {
   step: FunnelStep;
-  campaignId?: string; // Hashed or anonymized campaign ID
-  errorType?: string; // Generic error category, no sensitive details
+  campaignId?: string;
+  errorType?: string;
   timestamp?: number;
 }
 

--- a/src/lib/cacheInvalidation.ts
+++ b/src/lib/cacheInvalidation.ts
@@ -6,7 +6,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import * as StellarSdk from '@stellar/stellar-sdk';
 
-type Api = StellarSdk.rpc.Api;
+type Api = StellarSdk.rpc.Api.EventResponse;
 
 // Event topic names from the contract
 const CONTRIBUTION_MADE_TOPIC = 'contribution_made';
@@ -21,7 +21,7 @@ const VERIFY_CAMPAIGN_TOPIC = 'verify_campaign';
  * Extracts the campaign id from a Soroban event.
  * Assumes campaign id is the second topic in the event.
  */
-function extractCampaignId(event: Api.EventResponse): number | null {
+function extractCampaignId(event: Api): number | null {
   if (event.topic.length < 2) return null;
   try {
     return StellarSdk.scValToNative(event.topic[1]) as number;
@@ -34,7 +34,7 @@ function extractCampaignId(event: Api.EventResponse): number | null {
  * Extracts the contributor address from a Soroban event.
  * Assumes contributor address is the third topic in the event.
  */
-function extractContributorAddress(event: Api.EventResponse): string | null {
+function extractContributorAddress(event: Api): string | null {
   if (event.topic.length < 3) return null;
   try {
     const address = StellarSdk.scValToNative(event.topic[2]);
@@ -105,7 +105,7 @@ function invalidateCampaignsList(queryClient: QueryClient): void {
  */
 export function invalidateQueriesForEvent(
   queryClient: QueryClient,
-  event: Api.EventResponse,
+  event: Api,
   currentWalletAddress: string | null,
 ): void {
   const campaignId = extractCampaignId(event);
@@ -214,7 +214,7 @@ export function invalidateQueriesForEvent(
  */
 export function invalidateQueriesForEvents(
   queryClient: QueryClient,
-  events: Api.EventResponse[],
+  events: Api[],
   currentWalletAddress: string | null,
 ): void {
   // Use a Set to avoid duplicate invalidations for the same campaign

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -202,6 +202,37 @@ function emitMockLifecycle(txHash: string, options?: TransactionLifecycleOptions
   return txHash;
 }
 
+function validateStellarAddress(address: string): void {
+  if (!StellarSdk.StrKey.isValidEd25519PublicKey(address)) {
+    throw new Error(`Invalid Stellar address: ${address}`);
+  }
+}
+
+function validateFundingGoal(goal: bigint): void {
+  if (goal <= BigInt(0)) throw new Error("Funding goal must be greater than zero.");
+}
+
+function validateDuration(days: number): void {
+  if (days < 1 || days > 365) throw new Error("Duration must be between 1 and 365 days.");
+}
+
+function validateRevenueShare(bps: number): void {
+  if (bps < 1 || bps > 5000) throw new Error("Revenue share must be between 1 and 5000 bps.");
+}
+
+function validateAmount(amount: bigint): void {
+  if (amount <= BigInt(0)) throw new Error("Amount must be greater than zero.");
+}
+
+function captureTransactionError(
+  operation: string,
+  campaignId: number,
+  error: Error,
+  errorCode?: string,
+): void {
+  recordObservabilityKind("contract_error", error.message, { operation });
+}
+
 async function invokeViewMethod(
   method: string,
   args: StellarSdk.xdr.ScVal[] = [],

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,0 +1,34 @@
+/**
+ * Locale-aware formatting utilities using Intl APIs.
+ * Pass the active locale (e.g. "en" | "es") from next-intl's useLocale().
+ */
+
+/** Format a number with locale-aware grouping/decimal separators. */
+export function formatNumber(
+  value: number,
+  locale: string,
+  options?: Intl.NumberFormatOptions,
+): string {
+  return new Intl.NumberFormat(locale, options).format(value);
+}
+
+/** Format an XLM amount with up to 2 decimal places. */
+export function formatXlm(value: number, locale: string): string {
+  return formatNumber(value, locale, { maximumFractionDigits: 2, minimumFractionDigits: 0 });
+}
+
+/** Format a Unix timestamp (seconds) as a locale-aware date string. */
+export function formatDate(
+  timestampSeconds: number,
+  locale: string,
+  options: Intl.DateTimeFormatOptions = { year: "numeric", month: "long", day: "numeric" },
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(
+    new Date(timestampSeconds * 1000),
+  );
+}
+
+/** Format a Unix timestamp (seconds) as a short date (e.g. "Jan 1, 2024"). */
+export function formatShortDate(timestampSeconds: number, locale: string): string {
+  return formatDate(timestampSeconds, locale, { year: "numeric", month: "short", day: "numeric" });
+}

--- a/src/lib/sorobanEvents.ts
+++ b/src/lib/sorobanEvents.ts
@@ -1,6 +1,8 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
 
-type Api = StellarSdk.rpc.Api;
+type ApiEventResponse = StellarSdk.rpc.Api.EventResponse;
+type ApiEventFilter = StellarSdk.rpc.Api.EventFilter;
+type ApiGetEventsRequest = StellarSdk.rpc.Api.GetEventsRequest;
 
 const USE_MOCKS =
   typeof process !== 'undefined' && process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
@@ -40,19 +42,19 @@ export function voteCastTopicFilter(campaignId: number): string[][] {
   return [[scValToTopicSegment(eventSymbol), scValToTopicSegment(campaignTopic), '*']];
 }
 
-export function isVoteCastEvent(event: Api.EventResponse, campaignId: number): boolean {
+export function isVoteCastEvent(event: ApiEventResponse, campaignId: number): boolean {
   if (event.topic.length < 2) return false;
   const topicName = StellarSdk.scValToNative(event.topic[0]);
   const eventCampaignId = StellarSdk.scValToNative(event.topic[1]);
   return topicName === VOTE_CAST_TOPIC && eventCampaignId === campaignId;
 }
 
-export function parseVoteCastApprove(event: Api.EventResponse): boolean {
+export function parseVoteCastApprove(event: ApiEventResponse): boolean {
   return Boolean(StellarSdk.scValToNative(event.value));
 }
 
 export interface FetchVoteCastEventsResult {
-  events: Api.EventResponse[];
+  events: ApiEventResponse[];
   cursor: string;
   latestLedger: number;
 }
@@ -62,6 +64,68 @@ export interface FetchVoteCastEventsOptions {
   cursor?: string;
   startLedger?: number;
   limit?: number;
+}
+
+export interface FetchContributionMadeEventsOptions {
+  campaignId: number;
+  cursor?: string;
+  startLedger?: number;
+  limit?: number;
+}
+
+const CONTRIBUTION_MADE_TOPIC = 'contribution_made';
+
+export function isContributionMadeEvent(event: ApiEventResponse, campaignId: number): boolean {
+  if (event.topic.length < 2) return false;
+  const topicName = StellarSdk.scValToNative(event.topic[0]);
+  const eventCampaignId = StellarSdk.scValToNative(event.topic[1]);
+  return topicName === CONTRIBUTION_MADE_TOPIC && eventCampaignId === campaignId;
+}
+
+export function sumContributionAmounts(events: ApiEventResponse[]): bigint {
+  return events.reduce((sum, event) => {
+    try {
+      const amount = BigInt(StellarSdk.scValToNative(event.value) as number);
+      return sum + amount;
+    } catch {
+      return sum;
+    }
+  }, BigInt(0));
+}
+
+export async function fetchContributionMadeEvents(
+  options: FetchContributionMadeEventsOptions,
+): Promise<FetchVoteCastEventsResult | null> {
+  if (!isEventStreamingAvailable()) {
+    return null;
+  }
+
+  const { campaignId, cursor, startLedger, limit = 100 } = options;
+  const server = getServer();
+
+  const eventSymbol = StellarSdk.nativeToScVal(CONTRIBUTION_MADE_TOPIC, { type: 'symbol' });
+  const campaignTopic = StellarSdk.nativeToScVal(campaignId, { type: 'u32' });
+  const topics = [[scValToTopicSegment(eventSymbol), scValToTopicSegment(campaignTopic), '*']];
+
+  const filters: ApiEventFilter[] = [
+    { type: 'contract', contractIds: [CONTRACT_ADDRESS], topics },
+  ];
+
+  const request: ApiGetEventsRequest = cursor
+    ? { filters, cursor, limit }
+    : {
+        filters,
+        startLedger: startLedger ?? (await server.getLatestLedger()).sequence - 1,
+        limit,
+      };
+
+  const response = await server.getEvents(request);
+
+  return {
+    events: response.events.filter((e) => isContributionMadeEvent(e, campaignId)),
+    cursor: response.cursor,
+    latestLedger: response.latestLedger,
+  };
 }
 
 /**
@@ -77,7 +141,7 @@ export async function fetchVoteCastEvents(
   const { campaignId, cursor, startLedger, limit = 100 } = options;
   const server = getServer();
 
-  const filters: Api.EventFilter[] = [
+  const filters: ApiEventFilter[] = [
     {
       type: 'contract',
       contractIds: [CONTRACT_ADDRESS],
@@ -85,7 +149,7 @@ export async function fetchVoteCastEvents(
     },
   ];
 
-  const request: Api.GetEventsRequest = cursor
+  const request: ApiGetEventsRequest = cursor
     ? { filters, cursor, limit }
     : {
         filters,


### PR DESCRIPTION
PR Description
Closes #416, 
Closes : #423,
Closes : #430, 
Closes : #441

#416 — [a11y] Navbar keyboard navigation & aria-current
Added aria-current="page" to the active nav link on both desktop and mobile menus using usePathname from next-intl/routing

Active link underline indicator is always visible (not just on hover) for the current page

Added focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 to all nav links for visible keyboard focus styles

Mobile menu already had focus-trap + Escape key handling; desktop links now also have proper focus indicators

#423 — [UI] Skeleton loading states for cause detail, dashboard, and admin
CauseDetailClient: replaced the inline animate-pulse div block with the shared <CauseDetailSkeleton /> component

DashboardClient: added <DashboardSkeleton /> while campaignsLoading || balanceLoading

Skeleton.tsx: added new AdminSkeleton export matching the admin page layout

AdminClient: replaced the Loader2 spinner with <AdminSkeleton /> — no layout shift when content arrives

#430 — [i18n] Locale-aware number, amount, and date formatting
Created src/lib/formatters.ts with formatNumber, formatXlm, formatDate, formatShortDate — all keyed to the active locale via Intl.NumberFormat / Intl.DateTimeFormat

Applied to CauseDetailClient (XLM amounts, fee breakdown, dates), CauseCard (raised/goal amounts, created date), and DeadlineCountdown (countdown numbers)

Added src/__tests__/lib/formatters.test.ts with en and es output tests for all four utilities

#441 — [SEO] OG image locale-aware & edge-case hardened
opengraph-image.tsx now reads locale from params and passes it to Intl.NumberFormat for XLM amounts

Long titles are truncated to 80 chars with a … suffix instead of relying on CSS -webkit-line-clamp (which doesn't work in @vercel/og)

Missing/empty title falls back to "Untitled Campaign" instead of rendering blank

Dimensions and contentType unchanged (1200×630, image/png)

Pre-existing build fixes (unblocked the TypeScript check)
Several files had TypeScript errors that prevented npm run build from passing before this PR. Fixed as part of making the build green:

Missing useLiveCampaignFunding and SafeMarkdown imports in CauseDetailClient

Missing fetchContributionMadeEvents / sumContributionAmounts exports in sorobanEvents.ts

StellarSdk.rpc.Api used as a type (namespace) in sorobanEvents.ts and cacheInvalidation.ts

Missing validateStellarAddress, validateAmount, captureTransactionError, etc. in contractClient.ts

FunnelEventData not assignable to Record<string, unknown> in analytics.ts

xlmToStroops called with number instead of string in NewCauseClient.tsx