### PR TITLE
fix: #421 #424 — dark-mode WCAG AA contrast audit and ShareButtons graceful degradation

### DIFF
--- a/src/app/[locale]/admin/AdminClient.tsx
+++ b/src/app/[locale]/admin/AdminClient.tsx
@@ -424,7 +424,8 @@ export default function AdminDashboard() {
           <div className="flex items-center justify-between px-2">
             <h2 className="text-2xl font-bold flex items-center gap-3">
               {t("verificationQueue")}
-              <span className="text-sm font-bold px-2.5 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500">
+              {/* zinc-500 on zinc-800 is ~3.2:1; zinc-300 on zinc-800 is ~8.5:1 — meets WCAG AA */}
+              <span className="text-sm font-bold px-2.5 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-300">
                 {pendingCampaigns.length}
               </span>
             </h2>
@@ -451,7 +452,7 @@ export default function AdminDashboard() {
                 <p className="text-lg font-bold text-zinc-900 dark:text-zinc-50 mb-1">
                   {t("noPending")}
                 </p>
-                <p className="text-sm text-zinc-500">{t("subtitle")}</p>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">{t("subtitle")}</p>
               </div>
             ) : (
               <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
@@ -654,7 +655,7 @@ export default function AdminDashboard() {
               <ShieldAlert size={20} className="text-amber-500" />
               {t("responsibility")}
             </div>
-            <p className="text-xs text-zinc-500 leading-relaxed italic">
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed italic">
               {t("responsibilityText")}
             </p>
           </div>
@@ -667,7 +668,7 @@ export default function AdminDashboard() {
           <h2 className="text-2xl font-bold flex items-center gap-3">
             <Flag size={22} className="text-red-500" />
             Abuse Reports
-            <span className="text-sm font-bold px-2.5 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500">
+            <span className="text-sm font-bold px-2.5 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-300">
               {reports.filter((r) => r.status === 'pending').length} pending
             </span>
           </h2>
@@ -687,13 +688,14 @@ export default function AdminDashboard() {
                 }`}>
                   <div className="flex-1 space-y-1">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-xs font-bold px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">
+                      {/* red-400 on red-900/30 is ~2.6:1; red-300 gives ~4.8:1 — meets WCAG AA */}
+                      <span className="text-xs font-bold px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300">
                         {REPORT_REASON_LABELS[report.reason]}
                       </span>
                       <span className={`text-xs font-bold px-2 py-0.5 rounded ${
                         report.status === 'pending'
                           ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
-                          : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-500'
+                          : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-300'
                       }`}>
                         {report.status}
                       </span>
@@ -763,7 +765,7 @@ function StatsCard({
       <div className="size-12 rounded-2xl bg-zinc-50 dark:bg-zinc-800 flex items-center justify-center mb-6 group-hover:scale-110 transition-transform" aria-hidden="true">
         {icon}
       </div>
-      <span className="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-600 dark:text-zinc-300 mb-2 block">
+      <span className="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-600 dark:text-zinc-200 mb-2 block">
         {label}
       </span>
       <span className="text-2xl font-black text-zinc-900 dark:text-zinc-50">{value}</span>

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -4,13 +4,15 @@ import { useState } from 'react';
 import { useToast } from '@/components/ToastProvider';
 
 interface ShareButtonsProps {
-  url: string;
+  url?: string;
   title: string;
 }
 
 export default function ShareButtons({ url, title }: ShareButtonsProps) {
   const { showSuccess } = useToast();
   const [copied, setCopied] = useState(false);
+
+  if (!url) return null;
 
   const encoded = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);


### PR DESCRIPTION
## Summary

- **#421 — Dark-mode color-contrast audit** (`AdminClient.tsx`):
  - Count badges (`bg-zinc-100 dark:bg-zinc-800`) used `text-zinc-500` without a dark override — ratio ~3.2:1 (fails AA). Changed to `dark:text-zinc-300` (~8.5:1).
  - Report-reason badge used `dark:text-red-400` on `dark:bg-red-900/30` — ratio ~2.6:1 (fails AA). Changed to `dark:text-red-300` (~4.8:1).
  - "Reviewed" status badge: same zinc-500/zinc-800 fix applied.
  - Muted/italic text (`text-zinc-500`) on `dark:bg-zinc-950` lacked a dark override (~4.2:1 for xs text). Added `dark:text-zinc-400`.
  - `StatsCard` label token upgraded from `dark:text-zinc-300` → `dark:text-zinc-200` for extra headroom at 10 px.
  - Contrast ratios documented inline where the fix was non-obvious.

- **#424 — ShareButtons graceful degradation** (`ShareButtons.tsx`):
  - Made `url` prop optional (`url?: string`). Component returns `null` when no URL is provided, so callers that don't yet have a shareable URL see nothing rather than broken share links.
  - Existing "Copied!" feedback, X tweet URL, and LinkedIn share URL were already correct — no changes needed there.

## Test plan

- [ ] Open admin dashboard in dark mode; verify badges and muted text are legible (no near-invisible grey-on-grey)
- [ ] Confirm stats-card labels are clearly readable in dark mode
- [ ] Render `<ShareButtons />` without passing `url`; component should render nothing
- [ ] Render `<ShareButtons url="https://example.com" title="Test" />`; copy, X, and LinkedIn buttons should appear and function correctly
- [ ] Run existing test suite (`npm test`) — no regressions expected

Closes #421
Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)