### PR TITLE
fix: cache and dedupe getStellarBalance wallet-balance fetches

### DIFF
--- a/src/__tests__/hooks/useStellarBalance.test.tsx
+++ b/src/__tests__/hooks/useStellarBalance.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useStellarBalance } from "@/hooks/useStellarBalance";
+
+jest.mock("@/lib/getStellarBalance", () => ({
+  getStellarBalance: jest.fn(),
+  getStellarNetworkKey: jest.fn(() => "testnet"),
+}));
+
+import { getStellarBalance } from "@/lib/getStellarBalance";
+
+const mockGetStellarBalance = getStellarBalance as jest.MockedFunction<typeof getStellarBalance>;
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useStellarBalance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not fetch when publicKey is null", () => {
+    const { result } = renderHook(() => useStellarBalance(null), { wrapper: createWrapper() });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.balance).toBeNull();
+    expect(mockGetStellarBalance).not.toHaveBeenCalled();
+  });
+
+  it("returns balance when fetch succeeds", async () => {
+    mockGetStellarBalance.mockResolvedValue(42.5);
+
+    const { result } = renderHook(() => useStellarBalance("GABC123"), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.balance).toBe(42.5);
+    expect(result.current.error).toBeNull();
+    expect(mockGetStellarBalance).toHaveBeenCalledWith("GABC123");
+  });
+
+  it("exposes error when fetch fails", async () => {
+    mockGetStellarBalance.mockRejectedValue(new Error("horizon unavailable"));
+
+    const { result } = renderHook(() => useStellarBalance("GABC123"), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.error?.message).toBe("horizon unavailable"), {
+      timeout: 5000,
+    });
+
+    expect(result.current.balance).toBeNull();
+  });
+
+  it("dedupes concurrent requests for the same wallet via shared query cache", async () => {
+    mockGetStellarBalance.mockResolvedValue(10);
+
+    const wrapper = createWrapper();
+    renderHook(() => useStellarBalance("GABC123"), { wrapper });
+    renderHook(() => useStellarBalance("GABC123"), { wrapper });
+
+    await waitFor(() => expect(mockGetStellarBalance).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/app/[locale]/dashboard/DashboardClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardClient.tsx
@@ -2,12 +2,12 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import MyContributionsSection from "@/components/MyContributionsSection";
 import { Spinner, DashboardSkeleton } from "@/components/Skeleton";
 import { useWallet } from "@/components/WalletContext";
 import { useCampaigns } from "@/hooks/useCampaigns";
-import { getStellarBalance } from "@/lib/getStellarBalance";
+import { useStellarBalance } from "@/hooks/useStellarBalance";
 import { isSameAddress } from "@/lib/stellar";
 import { explorerTxUrl } from "@/utils/explorer";
 
@@ -15,27 +15,12 @@ export default function DashboardPage() {
   const t = useTranslations("Dashboard");
   const { publicKey, isWalletConnected } = useWallet();
   const { campaigns, isLoading: campaignsLoading } = useCampaigns();
-  const [balance, setBalance] = useState<number | null>(null);
-  const [balanceLoading, setBalanceLoading] = useState(false);
-  const [balanceError, setBalanceError] = useState<string | null>(null);
-
-  const fetchBalance = useCallback(async () => {
-    if (!publicKey) return;
-    setBalanceLoading(true);
-    setBalanceError(null);
-    try {
-      const bal = await getStellarBalance(publicKey);
-      setBalance(bal);
-    } catch {
-      setBalanceError(t("balanceFetchError"));
-    } finally {
-      setBalanceLoading(false);
-    }
-  }, [publicKey]);
-
-  useEffect(() => {
-    if (publicKey) fetchBalance();
-  }, [publicKey, fetchBalance]);
+  const {
+    balance,
+    isLoading: balanceLoading,
+    error: balanceQueryError,
+  } = useStellarBalance(publicKey);
+  const balanceError = balanceQueryError ? t("balanceFetchError") : null;
 
   const mockVotes = useMemo(
     () => [

--- a/src/components/WalletContext.tsx
+++ b/src/components/WalletContext.tsx
@@ -114,6 +114,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     queryClient.invalidateQueries({ queryKey: ["admin"] });
     queryClient.invalidateQueries({ queryKey: ["contributions"] });
     queryClient.invalidateQueries({ queryKey: ["revenue"] });
+    queryClient.invalidateQueries({ queryKey: ["stellarBalance"] });
     // Note: campaigns query is not wallet-scoped, so we don't invalidate it
   };
 

--- a/src/hooks/useStellarBalance.ts
+++ b/src/hooks/useStellarBalance.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getStellarBalance, getStellarNetworkKey } from "@/lib/getStellarBalance";
+
+export const STELLAR_BALANCE_QUERY_KEY = "stellarBalance";
+
+interface UseStellarBalanceResult {
+  balance: number | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useStellarBalance(publicKey: string | null): UseStellarBalanceResult {
+  const network = getStellarNetworkKey();
+
+  const { data, isLoading, error } = useQuery<number, Error>({
+    queryKey: [STELLAR_BALANCE_QUERY_KEY, publicKey, network],
+    queryFn: () => getStellarBalance(publicKey!),
+    enabled: !!publicKey,
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  return {
+    balance: data ?? null,
+    isLoading,
+    error: error ?? null,
+  };
+}

--- a/src/lib/getStellarBalance.ts
+++ b/src/lib/getStellarBalance.ts
@@ -1,7 +1,19 @@
 import { Horizon } from "@stellar/stellar-sdk";
 
+export function getStellarNetworkKey(): string {
+  const passphrase =
+    process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
+  return passphrase.toLowerCase().includes("test") ? "testnet" : "mainnet";
+}
+
+function getHorizonServerUrl(): string {
+  return getStellarNetworkKey() === "testnet"
+    ? "https://horizon-testnet.stellar.org"
+    : "https://horizon.stellar.org";
+}
+
 export async function getStellarBalance(publicKey: string): Promise<number> {
-  const server = new Horizon.Server("https://horizon.stellar.org");
+  const server = new Horizon.Server(getHorizonServerUrl());
   const account = await server.loadAccount(publicKey);
   const xlmBalance = account.balances.find(
     (b: { asset_type: string; balance: string }) => b.asset_type === "native",


### PR DESCRIPTION
## Summary
Cache and dedupe Stellar wallet balance fetches with React Query so multiple components share one Horizon request per wallet/network.

## Purpose / Motivation
`getStellarBalance` was called directly from `DashboardClient` with local `useState`/`useEffect`, so any additional consumer would trigger duplicate Horizon requests. React Query provides shared caching, in-flight deduplication, and a consistent invalidation path when the wallet or network changes.

## Changes Made
- Added `useStellarBalance` hook keyed by `["stellarBalance", publicKey, network]` with a 60s stale time.
- Updated `DashboardClient` to use the hook instead of manual fetch state.
- Invalidated `stellarBalance` queries in `WalletContext` on wallet disconnect, account switch, and network mismatch (same pattern as contributions/revenue).
- Aligned `getStellarBalance` Horizon URL with the app network (testnet vs mainnet) so cache keys match the fetched network.

## How to Test
1. Connect Freighter on testnet and open `/dashboard`.
   - **Expected:** XLM balance loads once; no repeated Horizon calls on re-render.
2. Open React Query Devtools (if enabled) or Network tab and navigate away and back within 60s.
   - **Expected:** Balance is served from cache (no new Horizon request until stale).
3. Switch Freighter to a different account.
   - **Expected:** Balance refetches for the new public key.
4. Disconnect the wallet.
   - **Expected:** Stellar balance query is invalidated; reconnecting triggers a fresh fetch.
5. Run unit tests: `npm test -- useStellarBalance`

## Breaking Changes
- None.

## Related Issues
Closes Iris-IV/ProofOfHeart-frontend#438

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)