### PR TITLE
Test contribution status actions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -45,6 +45,9 @@
     "loading": "Loading contribution history...",
     "empty": "No contributions found for this wallet yet.",
     "contributed": "Contributed {amount} XLM",
+    "statusActive": "Active",
+    "statusRefundable": "Refundable",
+    "statusRevenueClaimable": "Revenue claimable",
     "openCampaign": "Open Campaign",
     "claimRefund": "Claim Refund",
     "claimRevenue": "Claim Revenue ({amount} XLM)",
@@ -399,6 +402,7 @@
     "votedDownvote": "You voted to reject this cause",
     "verifyWithVotes": "✓ Verify Campaign with Votes",
     "verifying": "Verifying..."
+  },
   "Observability": {
     "loading": "Loading observability metrics…",
     "metricsRequestFailed": "Metrics request failed ({status})",

--- a/messages/es.json
+++ b/messages/es.json
@@ -45,6 +45,9 @@
     "loading": "Cargando historial de contribuciones...",
     "empty": "Aún no hay contribuciones para esta wallet.",
     "contributed": "Contribuyó {amount} XLM",
+    "statusActive": "Activa",
+    "statusRefundable": "Reembolsable",
+    "statusRevenueClaimable": "Ingresos reclamables",
     "openCampaign": "Abrir Campaña",
     "claimRefund": "Reclamar Reembolso",
     "claimRevenue": "Reclamar Ingresos ({amount} XLM)",
@@ -399,6 +402,7 @@
     "votedDownvote": "Votaste para rechazar esta causa",
     "verifyWithVotes": "✓ Verificar Campaña con Votos",
     "verifying": "Verificando..."
+  },
   "Observability": {
     "loading": "Cargando métricas de observabilidad…",
     "metricsRequestFailed": "Error al solicitar métricas ({status})",

--- a/src/__tests__/components/MyContributionsSection.test.tsx
+++ b/src/__tests__/components/MyContributionsSection.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, within } from "@testing-library/react";
+import MyContributionsSection from "@/components/MyContributionsSection";
+import { useContributions, type ContributionHistoryItem } from "@/hooks/useContributions";
+import { Category, type Campaign } from "@/types";
+
+jest.mock("@/hooks/useContributions", () => ({
+  useContributions: jest.fn(),
+}));
+
+jest.mock("@/lib/contractClient", () => ({
+  claimRefund: jest.fn(),
+  claimRevenue: jest.fn(),
+}));
+
+jest.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    showError: jest.fn(),
+    showSuccess: jest.fn(),
+  }),
+}));
+
+const mockUseContributions = useContributions as jest.MockedFunction<typeof useContributions>;
+
+const WALLET = "GCONTRIBUTOR";
+
+function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: 1,
+    creator: "GCREATOR",
+    title: "Active campaign",
+    description: "Campaign description",
+    created_at: 1_700_000_000,
+    status: "active",
+    funding_goal: BigInt(100_000_000),
+    deadline: Math.floor(Date.now() / 1000) + 86_400,
+    amount_raised: BigInt(50_000_000),
+    is_active: true,
+    funds_withdrawn: false,
+    is_cancelled: false,
+    is_verified: false,
+    category: Category.Learner,
+    has_revenue_sharing: false,
+    revenue_share_percentage: 0,
+    ...overrides,
+  };
+}
+
+function makeContribution(
+  overrides: Partial<ContributionHistoryItem> = {},
+): ContributionHistoryItem {
+  const campaign = overrides.campaign ?? makeCampaign();
+
+  return {
+    campaign,
+    contribution: BigInt(25_000_000),
+    status: campaign.status,
+    canClaimRefund: false,
+    canClaimRevenue: false,
+    claimableRevenue: BigInt(0),
+    transactions: [
+      {
+        walletAddress: WALLET,
+        campaignId: campaign.id,
+        action: "contribute",
+        txHash: `tx-${campaign.id}-abcdef1234567890`,
+        timestamp: 1_700_000_000 + campaign.id,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderSection(contributions: ContributionHistoryItem[]) {
+  mockUseContributions.mockReturnValue({
+    contributions,
+    isLoading: false,
+    isRefreshing: false,
+    error: null,
+    refetch: jest.fn(),
+  });
+
+  return render(<MyContributionsSection walletAddress={WALLET} />);
+}
+
+describe("MyContributionsSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows active, refundable, and revenue-claimable statuses per contribution", () => {
+    renderSection([
+      makeContribution({
+        campaign: makeCampaign({ id: 1, title: "Active campaign", status: "active" }),
+      }),
+      makeContribution({
+        campaign: makeCampaign({ id: 2, title: "Refundable campaign", status: "failed" }),
+        canClaimRefund: true,
+      }),
+      makeContribution({
+        campaign: makeCampaign({
+          id: 3,
+          title: "Revenue campaign",
+          status: "funded",
+          has_revenue_sharing: true,
+        }),
+        canClaimRevenue: true,
+        claimableRevenue: BigInt(5_000_000),
+      }),
+    ]);
+
+    expect(screen.getByText("statusActive")).toBeInTheDocument();
+    expect(screen.getByText("statusRefundable")).toBeInTheDocument();
+    expect(screen.getByText("statusRevenueClaimable")).toBeInTheDocument();
+  });
+
+  it("shows claim buttons only for eligible contributions", () => {
+    renderSection([
+      makeContribution({
+        campaign: makeCampaign({ id: 1, title: "Active campaign" }),
+      }),
+      makeContribution({
+        campaign: makeCampaign({ id: 2, title: "Refundable campaign", status: "cancelled" }),
+        canClaimRefund: true,
+      }),
+      makeContribution({
+        campaign: makeCampaign({ id: 3, title: "Revenue campaign", status: "funded" }),
+        canClaimRevenue: true,
+        claimableRevenue: BigInt(7_500_000),
+      }),
+    ]);
+
+    const activeCard = screen.getByText("Active campaign").closest("li");
+    const refundableCard = screen.getByText("Refundable campaign").closest("li");
+    const revenueCard = screen.getByText("Revenue campaign").closest("li");
+
+    expect(activeCard).not.toBeNull();
+    expect(refundableCard).not.toBeNull();
+    expect(revenueCard).not.toBeNull();
+
+    expect(
+      within(activeCard!).queryByRole("button", { name: "claimRefund" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(activeCard!).queryByRole("button", { name: "claimRevenue" }),
+    ).not.toBeInTheDocument();
+    expect(within(refundableCard!).getByRole("button", { name: "claimRefund" })).toBeInTheDocument();
+    expect(
+      within(refundableCard!).queryByRole("button", { name: "claimRevenue" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(revenueCard!).queryByRole("button", { name: "claimRefund" }),
+    ).not.toBeInTheDocument();
+    expect(within(revenueCard!).getByRole("button", { name: "claimRevenue" })).toBeInTheDocument();
+  });
+
+  it("renders Stellar explorer transaction links for contribution history", () => {
+    renderSection([
+      makeContribution({
+        campaign: makeCampaign({ id: 1, title: "Linked campaign" }),
+        transactions: [
+          {
+            walletAddress: WALLET,
+            campaignId: 1,
+            action: "contribute",
+            txHash: "abc123def4567890abc123def4567890",
+            timestamp: 1_700_000_000,
+          },
+          {
+            walletAddress: WALLET,
+            campaignId: 1,
+            action: "claim_revenue",
+            txHash: "revenue1234567890abcdef",
+            timestamp: 1_700_000_100,
+          },
+        ],
+      }),
+    ]);
+
+    expect(screen.getAllByRole("link", { name: /abc123def4.*f4567890/i })[0]).toHaveAttribute(
+      "href",
+      "https://stellar.expert/explorer/testnet/tx/abc123def4567890abc123def4567890",
+    );
+    expect(screen.getByRole("link", { name: /revenue123.*90abcdef/i })).toHaveAttribute(
+      "href",
+      "https://stellar.expert/explorer/testnet/tx/revenue1234567890abcdef",
+    );
+  });
+});

--- a/src/components/MyContributionsSection.tsx
+++ b/src/components/MyContributionsSection.tsx
@@ -5,12 +5,13 @@ import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useContributions } from "../hooks/useContributions";
 import { claimRefund, claimRevenue } from "../lib/contractClient";
-import { getStellarExplorerTxUrl } from "../lib/stellarExplorer";
-import { CampaignStatus, formatStroopsAsXlm } from "../types";
+import { explorerTxUrl } from "../utils/explorer";
+import { formatStroopsAsXlm } from "../types";
 import { useToast } from "./ToastProvider";
 import { parseContractError } from "../utils/contractErrors";
 import type { WalletTransactionAction } from "../lib/transactionLog";
 import { type TransactionLifecyclePhase } from "../lib/contractClient";
+import type { ContributionHistoryItem } from "../hooks/useContributions";
 
 interface MyContributionsSectionProps {
   walletAddress: string;
@@ -20,24 +21,38 @@ function formatXlmAmount(value: bigint): string {
   return formatStroopsAsXlm(value, { maximumFractionDigits: 7 });
 }
 
-function getStatusClasses(status: CampaignStatus): string {
+type ContributionDisplayStatus = "active" | "refundable" | "revenue-claimable";
+
+function getContributionDisplayStatus(item: ContributionHistoryItem): ContributionDisplayStatus {
+  if (item.canClaimRefund) return "refundable";
+  if (item.canClaimRevenue) return "revenue-claimable";
+  return "active";
+}
+
+function getStatusLabelKey(status: ContributionDisplayStatus): string {
   switch (status) {
-    case "active":
-      return "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300";
-    case "funded":
-      return "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300";
-    case "failed":
-      return "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300";
-    case "cancelled":
-      return "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300";
+    case "refundable":
+      return "statusRefundable";
+    case "revenue-claimable":
+      return "statusRevenueClaimable";
     default:
-      return "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
+      return "statusActive";
+  }
+}
+
+function getStatusClasses(status: ContributionDisplayStatus): string {
+  switch (status) {
+    case "refundable":
+      return "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300";
+    case "revenue-claimable":
+      return "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300";
+    default:
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300";
   }
 }
 
 export default function MyContributionsSection({ walletAddress }: MyContributionsSectionProps) {
   const t = useTranslations("MyContributions");
-  const tStatus = useTranslations("Status");
   const { showError, showSuccess } = useToast();
   const [pendingCampaignId, setPendingCampaignId] = useState<number | null>(null);
   const [pendingAction, setPendingAction] = useState<"refund" | "revenue" | null>(null);
@@ -137,6 +152,7 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
         <ul className="space-y-3">
           {contributions.map((item) => {
             const isPending = pendingCampaignId === item.campaign.id;
+            const displayStatus = getContributionDisplayStatus(item);
             const contributionTransactions = item.transactions.filter(
               (entry) => entry.action === "contribute",
             );
@@ -155,9 +171,9 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
                     </p>
                   </div>
                   <span
-                    className={`inline-flex w-fit rounded-full px-3 py-1 text-xs font-semibold ${getStatusClasses(item.status)}`}
+                    className={`inline-flex w-fit rounded-full px-3 py-1 text-xs font-semibold ${getStatusClasses(displayStatus)}`}
                   >
-                    {tStatus(item.status)}
+                    {t(getStatusLabelKey(displayStatus))}
                   </span>
                 </div>
 
@@ -200,7 +216,7 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
                       <div key={entry.txHash} className="flex items-center gap-2">
                         <span>{t("contributionTx")}</span>
                         <a
-                          href={getStellarExplorerTxUrl(entry.txHash)}
+                          href={explorerTxUrl(entry.txHash)}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="font-mono text-blue-600 hover:underline dark:text-blue-400"
@@ -226,7 +242,7 @@ export default function MyContributionsSection({ walletAddress }: MyContribution
                           >
                             <span>{getActionLabel(entry.action)}:</span>
                             <a
-                              href={getStellarExplorerTxUrl(entry.txHash)}
+                              href={explorerTxUrl(entry.txHash)}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="font-mono text-blue-600 hover:underline dark:text-blue-400"


### PR DESCRIPTION
Summary
- Added contribution-specific status display for active, refundable, and revenue-claimable contribution rows.
- Kept refund and revenue claim buttons gated by each contribution's eligibility flags.
- Switched contribution transaction links to the centralized Stellar explorer URL helper.
- Added tests for statuses, eligible action buttons, and explorer transaction links.

Issue
- Closes #412

Changes
- Updated MyContributionsSection.tsx to derive display status from contribution eligibility instead of raw campaign lifecycle status.
- Added localized status labels for contribution rows.
- Added focused component coverage in MyContributionsSection.test.tsx.
- Fixed the existing missing JSON block separator in locale message files so the updated message files parse correctly.

Validation
- Passed: 
pm test -- --runInBand MyContributionsSection.test.tsx (3 tests passed).
- Passed: 
px eslint src/components/MyContributionsSection.tsx src/__tests__/components/MyContributionsSection.test.tsx messages/en.json messages/es.json (changed TS/TSX files passed; JSON files are ignored by ESLint config).
- Failed: 
pm ci because package-lock.json is out of sync with package.json before these changes.
- Failed: 
px pnpm@9.15.5 install --frozen-lockfile because pnpm-lock.yaml is out of sync with package.json before these changes.
- Failed: 
pm run lint due unrelated existing errors outside this change, including src/app/[locale]/layout.tsx, src/components/Amount.tsx, src/components/CauseCard.tsx, src/components/DevMockPanel.tsx, src/components/DonationModal.tsx, src/components/LanguageSwitcher.tsx, and src/lib/devMockScenarios.ts.
- Failed: 
pm run typecheck due unrelated existing errors outside this change, including AdminClient.tsx, CauseDetailClient.tsx, layout.tsx, CauseCard.tsx, DonationModal.tsx, FundingProgressBar.tsx, and VotingComponent.tsx.
- Failed: 
pm run build due unrelated existing Next.js dynamic import errors in src/app/[locale]/admin/page.tsx and src/app/[locale]/admin/observability/page.tsx.

Notes
- Local install required 
pm install --legacy-peer-deps --ignore-scripts because both committed lockfiles are currently out of sync. No lockfile changes are included in this PR.