### PR TITLE
Cover revenue sharing panel actions

### DIFF
--- a/src/__tests__/components/RevenueSharingPanel.test.tsx
+++ b/src/__tests__/components/RevenueSharingPanel.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import RevenueSharingPanel from "@/components/RevenueSharingPanel";
+import { useWallet } from "@/components/WalletContext";
+import { claimRevenue, depositRevenue } from "@/lib/contractClient";
+import { useRevenueSharing } from "@/hooks/useRevenueSharing";
+import { Category, type Campaign } from "@/types";
+
+jest.mock("@/components/WalletContext", () => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    showError: jest.fn(),
+    showSuccess: jest.fn(),
+    showWarning: jest.fn(),
+  }),
+}));
+
+jest.mock("@/hooks/useRevenueSharing", () => ({
+  useRevenueSharing: jest.fn(),
+}));
+
+jest.mock("@/lib/contractClient", () => ({
+  claimRevenue: jest.fn(),
+  depositRevenue: jest.fn(),
+}));
+
+const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
+const mockUseRevenueSharing = useRevenueSharing as jest.MockedFunction<typeof useRevenueSharing>;
+const mockDepositRevenue = depositRevenue as jest.MockedFunction<typeof depositRevenue>;
+const mockClaimRevenue = claimRevenue as jest.MockedFunction<typeof claimRevenue>;
+
+const CREATOR = "GCREATOR1111111111111111111111111111111111111111111111111";
+const CONTRIBUTOR = "GCONTRIBUTOR11111111111111111111111111111111111111111111";
+
+function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: 7,
+    creator: CREATOR,
+    title: "Revenue Campaign",
+    description: "A startup campaign with revenue sharing.",
+    created_at: 1_700_000_000,
+    status: "funded",
+    funding_goal: BigInt(200_000_000),
+    deadline: Math.floor(Date.now() / 1000) - 3600,
+    amount_raised: BigInt(200_000_000),
+    is_active: false,
+    funds_withdrawn: true,
+    is_cancelled: false,
+    is_verified: true,
+    category: Category.EducationalStartup,
+    has_revenue_sharing: true,
+    revenue_share_percentage: 1000,
+    ...overrides,
+  };
+}
+
+function mockWallet(publicKey: string | null) {
+  mockUseWallet.mockReturnValue({
+    publicKey,
+    connectWallet: jest.fn(),
+    disconnectWallet: jest.fn(),
+    isWalletConnected: !!publicKey,
+    isLoading: false,
+    walletNetworkWarning: null,
+  });
+}
+
+function mockRevenueSharing(overrides = {}) {
+  mockUseRevenueSharing.mockReturnValue({
+    revenuePool: BigInt(100_000_000),
+    contribution: BigInt(20_000_000),
+    claimed: BigInt(2_500_000),
+    contributorShare: BigInt(10_000_000),
+    claimable: BigInt(7_500_000),
+    isLoading: false,
+    refetch: jest.fn(),
+    ...overrides,
+  });
+}
+
+describe("RevenueSharingPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDepositRevenue.mockResolvedValue("deposit-tx");
+    mockClaimRevenue.mockResolvedValue("claim-tx");
+    mockWallet(CONTRIBUTOR);
+    mockRevenueSharing();
+  });
+
+  it("renders pro-rata revenue sharing math from fixtures", () => {
+    render(<RevenueSharingPanel campaign={makeCampaign()} />);
+
+    expect(screen.getByText("Total Pool")).toBeInTheDocument();
+    expect(screen.getByText("10 XLM")).toBeInTheDocument();
+    expect(screen.getByText("Your Share")).toBeInTheDocument();
+    expect(screen.getByText("1 XLM")).toBeInTheDocument();
+    expect(screen.getByText("Already Claimed")).toBeInTheDocument();
+    expect(screen.getByText("0.25 XLM")).toBeInTheDocument();
+    expect(screen.getByText("Claimable Now")).toBeInTheDocument();
+    expect(screen.getByText("0.75 XLM")).toBeInTheDocument();
+    expect(
+      screen.getByText((_content, element) =>
+        element?.textContent === "2 XLM contribution × 10 XLM pool ÷ 20 XLM raised = 1 XLM",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("calls depositRevenue with the campaign id and stroop amount for creators", async () => {
+    mockWallet(CREATOR);
+    render(<RevenueSharingPanel campaign={makeCampaign()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Amount in XLM"), {
+      target: { value: "1.25" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Deposit Revenue" }));
+
+    await waitFor(() => {
+      expect(mockDepositRevenue).toHaveBeenCalledWith(
+        7,
+        BigInt(12_500_000),
+        expect.objectContaining({ onStatus: expect.any(Function) }),
+      );
+    });
+  });
+
+  it("calls claimRevenue with the campaign id and contributor wallet", async () => {
+    render(<RevenueSharingPanel campaign={makeCampaign()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Claim Revenue" }));
+
+    await waitFor(() => {
+      expect(mockClaimRevenue).toHaveBeenCalledWith(
+        7,
+        CONTRIBUTOR,
+        expect.objectContaining({ onStatus: expect.any(Function) }),
+      );
+    });
+  });
+
+  it("only renders for EducationalStartup campaigns with revenue sharing enabled", () => {
+    const { container, rerender } = render(
+      <RevenueSharingPanel
+        campaign={makeCampaign({
+          category: Category.Learner,
+          has_revenue_sharing: true,
+        })}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockUseRevenueSharing).toHaveBeenLastCalledWith(7, CONTRIBUTOR, BigInt(200_000_000), false);
+
+    rerender(
+      <RevenueSharingPanel
+        campaign={makeCampaign({
+          category: Category.EducationalStartup,
+          has_revenue_sharing: false,
+        })}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockUseRevenueSharing).toHaveBeenLastCalledWith(7, CONTRIBUTOR, BigInt(200_000_000), false);
+
+    rerender(<RevenueSharingPanel campaign={makeCampaign()} />);
+
+    expect(screen.getByRole("heading", { name: "Revenue Sharing" })).toBeInTheDocument();
+    expect(mockUseRevenueSharing).toHaveBeenLastCalledWith(7, CONTRIBUTOR, BigInt(200_000_000), true);
+  });
+});

--- a/src/components/RevenueSharingPanel.tsx
+++ b/src/components/RevenueSharingPanel.tsx
@@ -2,7 +2,13 @@
 
 import { FormEvent, useMemo, useState } from "react";
 import { claimRevenue, depositRevenue } from "../lib/contractClient";
-import { Campaign, basisPointsToPercentage, formatStroopsAsXlm, xlmToStroops } from "../types";
+import {
+  Campaign,
+  Category,
+  basisPointsToPercentage,
+  formatStroopsAsXlm,
+  xlmToStroops,
+} from "../types";
 import { useToast } from "./ToastProvider";
 import { useWallet } from "./WalletContext";
 import { useRevenueSharing } from "../hooks/useRevenueSharing";
@@ -35,9 +41,11 @@ export default function RevenueSharingPanel({
   const [depositAmount, setDepositAmount] = useState("");
   const [isPending, setIsPending] = useState(false);
   const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
+  const isRevenueSharingEligible =
+    campaign.category === Category.EducationalStartup && campaign.has_revenue_sharing;
 
   const { revenuePool, contribution, claimed, contributorShare, claimable, isLoading, refetch } =
-    useRevenueSharing(campaign.id, publicKey, campaign.amount_raised, campaign.has_revenue_sharing);
+    useRevenueSharing(campaign.id, publicKey, campaign.amount_raised, isRevenueSharingEligible);
 
   const isCreator = isSameAddress(publicKey, campaign.creator);
   const canShowCreatorControls = showCreatorControls && isCreator;
@@ -61,7 +69,7 @@ export default function RevenueSharingPanel({
     return percentage.toFixed(2);
   }, [campaign.amount_raised, contribution]);
 
-  if (!campaign.has_revenue_sharing) {
+  if (!isRevenueSharingEligible) {
     return null;
   }
 


### PR DESCRIPTION
Summary
- Added focused coverage for RevenueSharingPanel.tsx creator deposit, contributor claim, and pro-rata display behavior.
- Enforced that the panel only renders for EducationalStartup campaigns with revenue sharing enabled.
- Passed the same eligibility flag into useRevenueSharing so non-eligible campaigns do not fetch revenue data.

Issue
- Closes #407

Changes
- Added an EducationalStartup + has_revenue_sharing eligibility guard in RevenueSharingPanel.tsx.
- Added fixture-based tests for pro-rata math: contribution × pool ÷ amount raised = contributor share.
- Added tests that depositRevenue and claimRevenue receive the expected campaign id, wallet, and stroop amount.
- Added tests that non-startup or revenue-sharing-disabled campaigns render nothing.

Validation
- Passed: 
pm install --legacy-peer-deps --ignore-scripts for local dependency setup. It completed with Node 23 engine warnings and 2 moderate audit findings.
- Passed: 
px jest src/__tests__/components/RevenueSharingPanel.test.tsx --runInBand (4 tests passed).
- Passed: 
px eslint src/components/RevenueSharingPanel.tsx src/__tests__/components/RevenueSharingPanel.test.tsx.
- Passed: git diff --check.
- Failed: 
pm run lint due unrelated existing errors outside this change, including src/app/[locale]/layout.tsx, src/components/Amount.tsx, src/components/CauseCard.tsx, src/components/DevMockPanel.tsx, src/components/DonationModal.tsx, src/components/LanguageSwitcher.tsx, and src/lib/devMockScenarios.ts.
- Failed: 
pm run typecheck because base locale files messages/en.json and messages/es.json are invalid JSON around the Observability block.
- Failed: 
pm run build due the same invalid locale JSON plus unrelated 
ext/dynamic({ ssr: false }) usage in Server Components under src/app/[locale]/admin/page.tsx and src/app/[locale]/admin/observability/page.tsx.

Notes
- No lockfile changes are included. The local install used --legacy-peer-deps --ignore-scripts because the repo lockfiles are not currently suitable for a clean frozen install.