### PR TITLE
feat[SEO]: Add per-cause JSON-LD structured data

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -399,6 +399,7 @@
     "votedDownvote": "You voted to reject this cause",
     "verifyWithVotes": "✓ Verify Campaign with Votes",
     "verifying": "Verifying..."
+  },
   "Observability": {
     "loading": "Loading observability metrics…",
     "metricsRequestFailed": "Metrics request failed ({status})",
@@ -416,5 +417,11 @@
     "noContractErrors": "No contract errors in the current window.",
     "recentEvents": "Recent events",
     "noRecentEvents": "No recent events recorded yet."
+  },
+  "CauseJsonLd": {
+    "donateActionName": "Support {title}",
+    "fundingGoalLabel": "Funding Goal",
+    "amountRaisedLabel": "Amount Raised",
+    "deadlineLabel": "Funding Deadline"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -399,6 +399,7 @@
     "votedDownvote": "Votaste para rechazar esta causa",
     "verifyWithVotes": "✓ Verificar Campaña con Votos",
     "verifying": "Verificando..."
+  },
   "Observability": {
     "loading": "Cargando métricas de observabilidad…",
     "metricsRequestFailed": "Error al solicitar métricas ({status})",
@@ -416,5 +417,11 @@
     "noContractErrors": "No hay errores de contrato en la ventana actual.",
     "recentEvents": "Eventos recientes",
     "noRecentEvents": "Aún no hay eventos recientes registrados."
+  },
+  "CauseJsonLd": {
+    "donateActionName": "Apoya {title}",
+    "fundingGoalLabel": "Meta de financiamiento",
+    "amountRaisedLabel": "Monto recaudado",
+    "deadlineLabel": "Fecha límite de financiamiento"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8305,6 +8305,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -11045,10 +11061,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/app/[locale]/admin/AdminPageClient.tsx
+++ b/src/app/[locale]/admin/AdminPageClient.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { AdminSkeleton } from "@/components/Skeleton";
+
+const AdminClient = dynamic(() => import("./AdminClient"), {
+  ssr: false,
+  loading: () => <AdminSkeleton />,
+});
+
+export default function AdminPageClient() {
+  return <AdminClient />;
+}

--- a/src/app/[locale]/admin/observability/page.tsx
+++ b/src/app/[locale]/admin/observability/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import dynamic from 'next/dynamic';
 
 const ObservabilityDashboard = dynamic(

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -1,12 +1,6 @@
 import { Metadata } from "next";
-import dynamic from "next/dynamic";
 import { buildAlternates } from "@/lib/seo";
-import { AdminSkeleton } from "@/components/Skeleton";
-
-const AdminClient = dynamic(() => import("./AdminClient"), {
-  ssr: false,
-  loading: () => <AdminSkeleton />,
-});
+import AdminPageClient from "./AdminPageClient";
 
 type Props = { params: Promise<{ locale: string }> };
 
@@ -32,5 +26,5 @@ export async function generateMetadata({ params }: Props) {
 }
 
 export default function Page() {
-  return <AdminClient />;
+  return <AdminPageClient />;
 }

--- a/src/app/[locale]/causes/[id]/page.tsx
+++ b/src/app/[locale]/causes/[id]/page.tsx
@@ -1,4 +1,5 @@
-import { absoluteUrl, buildAlternates } from "@/lib/seo";
+import { getTranslations } from "next-intl/server";
+import { absoluteUrl, buildAlternates, buildCauseJsonLd } from "@/lib/seo";
 import { getCampaign } from "@/lib/contractClient";
 import CauseDetailClient from "./CauseDetailClient";
 
@@ -57,6 +58,31 @@ export async function generateMetadata({ params }: Props) {
 }
 
 export default async function Page({ params }: Props) {
-  const { id } = await params;
-  return <CauseDetailClient id={id} />;
+  const { id, locale } = await params;
+
+  const [campaign, t] = await Promise.all([
+    getCampaign(Number(id)),
+    getTranslations({ locale, namespace: "CauseJsonLd" }),
+  ]);
+
+  const jsonLd = campaign
+    ? buildCauseJsonLd(campaign, locale, {
+        donateActionName: t("donateActionName", { title: campaign.title }),
+        fundingGoalLabel: t("fundingGoalLabel"),
+        amountRaisedLabel: t("amountRaisedLabel"),
+        deadlineLabel: t("deadlineLabel"),
+      })
+    : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+      <CauseDetailClient id={id} />
+    </>
+  );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -11,6 +11,7 @@ import { WalletProvider } from "@/components/WalletContext";
 import { DevMockPanel } from "@/components/DevMockPanel";
 import { routing } from "@/i18n/routing";
 import { absoluteUrl, buildAlternates } from "@/lib/seo";
+import { getThemeBlockingScript } from "@/lib/preferences";
 import type { Metadata } from "next";
 import "../globals.css";
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,6 @@
 import { routing } from "@/i18n/routing";
+import type { Campaign } from "@/types";
+import { stroopsToXlm } from "@/types";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://proofofheart.xyz";
 
@@ -17,4 +19,71 @@ export function buildAlternates(path: string, locale: string = routing.defaultLo
     canonical: `${SITE_URL}/${locale}${path}`,
     languages,
   };
+}
+
+interface CauseJsonLdStrings {
+  donateActionName: string;
+  fundingGoalLabel: string;
+  amountRaisedLabel: string;
+  deadlineLabel: string;
+}
+
+export function buildCauseJsonLd(
+  campaign: Campaign,
+  locale: string,
+  strings: CauseJsonLdStrings
+): object {
+  const url = absoluteUrl(`/${locale}/causes/${campaign.id}`);
+  const isAcceptingDonations = campaign.status === "active" || campaign.status === "verified";
+
+  const schema: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Project",
+    name: campaign.title,
+    description: campaign.description,
+    url,
+    inLanguage: locale,
+    dateCreated: new Date(campaign.created_at * 1000).toISOString(),
+    provider: {
+      "@type": "Organization",
+      name: "ProofOfHeart",
+      url: absoluteUrl("/"),
+    },
+    additionalProperty: [
+      {
+        "@type": "PropertyValue",
+        name: strings.fundingGoalLabel,
+        value: stroopsToXlm(campaign.funding_goal),
+        unitText: "XLM",
+      },
+      {
+        "@type": "PropertyValue",
+        name: strings.amountRaisedLabel,
+        value: stroopsToXlm(campaign.amount_raised),
+        unitText: "XLM",
+      },
+      {
+        "@type": "PropertyValue",
+        name: strings.deadlineLabel,
+        value: new Date(campaign.deadline * 1000).toISOString(),
+      },
+    ],
+  };
+
+  if (campaign.cover_image_url) {
+    schema.image = absoluteUrl(campaign.cover_image_url);
+  }
+
+  if (isAcceptingDonations) {
+    schema.potentialAction = {
+      "@type": "DonateAction",
+      name: strings.donateActionName,
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: url,
+      },
+    };
+  }
+
+  return schema;
 }


### PR DESCRIPTION
## [SEO] Add per-cause JSON-LD structured data

closes #440 

 ### Summary

  - Adds buildCauseJsonLd() to src/lib/seo.ts — emits a schema.org/Project graph with name, description, url, inLanguage,
  dateCreated, funding goal, amount raised, and deadline as PropertyValue entries. A DonateAction potentialAction is included
  only when the campaign is active or verified.
  - Injects <script type="application/ld+json"> into /[locale]/causes/[id] via the server component; gracefully omitted when
  the campaign is not found.
  - Labels (fundingGoalLabel, amountRaisedLabel, deadlineLabel, donateActionName) are translated via a new CauseJsonLd
  namespace in messages/en.json and messages/es.json, satisfying the localisation requirement.
  - Fixes a pre-existing runtime crash: getThemeBlockingScript was called in layout.tsx but never imported — added the missing
   import from @/lib/preferences.
  - Fixes a pre-existing malformed JSON in both message files (missing }, closing the Voting namespace before Observability).

 ### Test plan

  - Open /en/causes/<id> and /es/causes/<id> in a browser; inspect page source for <script type="application/ld+json">
  containing "@type": "Project" with correct title, description, goal, raised, and deadline values.
  - Paste the page URL into Google's Rich Results Test — structured data should pass validation with no errors.
  - Visit a non-existent campaign (/en/causes/99999) — no <script type="application/ld+json"> tag should appear and the page
  should not crash.
  - Confirm active/verified campaigns include "potentialAction": { "@type": "DonateAction" } and cancelled/funded/failed
  campaigns do not.
  - Verify no regression on the root layout (/en, /es) — the theme-blocking script should apply correctly.