### PR TITLE
feat: add campaign milestones support with metadata serialization and progress visualization

### DIFF
--- a/src/__tests__/utils_contractErrors.test.ts
+++ b/src/__tests__/utils_contractErrors.test.ts
@@ -1,0 +1,25 @@
+import { parseContractError, ContractError, ContractErrorException } from '../utils/contractErrors';
+
+describe('parseContractError', () => {
+  it('handles Error(Contract, #n) format', () => {
+    expect(parseContractError(new Error("Error(Contract, #1)"))).toBe("ContractErrors.NotAuthorized");
+    expect(parseContractError(new Error("Something failed: Error(Contract, #19)"))).toBe("ContractErrors.VotingThresholdNotMet");
+  });
+
+  it('handles string errors', () => {
+    expect(parseContractError("Error(Contract, #15)")).toBe("ContractErrors.ValidationFailed");
+    expect(parseContractError("contract error 12")).toBe("ContractErrors.FundingGoalNotReached");
+  });
+
+  it('handles RPC object errors', () => {
+    expect(parseContractError({ message: "HostError: Error(Contract, #3)" })).toBe("ContractErrors.CampaignNotActive");
+    expect(parseContractError({ error: { message: "contractError: 4" } })).toBe("ContractErrors.FundingGoalMustBePositive");
+  });
+
+  it('falls back gracefully for unknown errors', () => {
+    expect(parseContractError(new Error("Some unknown error string"))).toBe("Some unknown error string");
+    expect(parseContractError("Just a string")).toBe("Just a string");
+    expect(parseContractError({})).toBe("ContractErrors.UnexpectedError");
+    expect(parseContractError(null)).toBe("ContractErrors.UnexpectedError");
+  });
+});

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -24,6 +24,7 @@ import UpdatesSection from '@/components/UpdatesSection';
 import { useToast } from '@/components/ToastProvider';
 import VotingComponent from '@/components/VotingComponent';
 import { useWallet } from '@/components/WalletContext';
+import { useSavedCampaigns } from '@/hooks/useSavedCampaigns';
 import { useLiveCampaignFunding } from '@/hooks/useLiveCampaignFunding';
 import { useLiveVoteTallies } from '@/hooks/useLiveVoteTallies';
 import { usePlatformFee } from '@/hooks/usePlatformFee';
@@ -65,7 +66,9 @@ export default function CauseDetailClient({ id }: { id: string }) {
   });
   const [isDonationModalOpen, setIsDonationModalOpen] = useState(false);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const { showError, showSuccess, showWarning } = useToast();
+  const { isSaved, toggleSaved } = useSavedCampaigns();
 
   // Quorum / threshold state
   const [minVotesQuorum, setMinVotesQuorum] = useState<number | undefined>(undefined);
@@ -301,23 +304,73 @@ export default function CauseDetailClient({ id }: { id: string }) {
                   />
                 </div>
               )}
-              <h1 className="text-2xl sm:text-3xl font-bold text-zinc-900 dark:text-zinc-50 mb-4 leading-tight">
+              <h1 className="text-2xl sm:text-3xl font-bold text-zinc-900 dark:text-zinc-50 mb-4 leading-tight break-words">
                 {campaign.title}
               </h1>
-              <SafeMarkdown className="prose prose-zinc dark:prose-invert max-w-none">
-                {campaign.description}
-              </SafeMarkdown>
+              <div className="relative">
+                <div className={`overflow-hidden transition-all duration-300 ${!isDescriptionExpanded ? 'max-h-[250px] relative' : ''}`}>
+                  <SafeMarkdown className="prose prose-zinc dark:prose-invert max-w-none break-words">
+                    {campaign.description}
+                  </SafeMarkdown>
+                  {!isDescriptionExpanded && (
+                    <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-zinc-800 to-transparent pointer-events-none" />
+                  )}
+                </div>
+                {campaign.description && campaign.description.length > 500 && (
+                  <div className="mt-2 text-center">
+                    <button
+                      type="button"
+                      onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
+                      className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded px-3 py-1 transition-colors"
+                      aria-expanded={isDescriptionExpanded}
+                      aria-controls="campaign-description"
+                    >
+                      {isDescriptionExpanded ? 'Show less' : 'Read more'}
+                    </button>
+                  </div>
+                )}
+              </div>
 
               {/* Share + Report toolbar */}
               <div className="flex items-center justify-between flex-wrap gap-3 pt-4 mt-4 border-t border-zinc-100 dark:border-zinc-700">
-                <ShareButtons
-                  url={
-                    typeof window !== "undefined"
-                      ? window.location.href
-                      : `https://proofofheart.org/causes/${campaign.id}`
-                  }
-                  title={campaign.title}
-                />
+                <div className="flex items-center gap-4">
+                  <ShareButtons
+                    url={
+                      typeof window !== "undefined"
+                        ? window.location.href
+                        : `https://proofofheart.org/causes/${campaign.id}`
+                    }
+                    title={campaign.title}
+                  />
+                  <button
+                    onClick={() => {
+                      if (!userWalletAddress) {
+                        showWarning('Please connect your wallet to save campaigns.');
+                        return;
+                      }
+                      toggleSaved(campaign.id);
+                    }}
+                    className={`flex items-center gap-1.5 text-sm font-medium transition-colors ${
+                      isSaved(campaign.id)
+                        ? 'text-blue-600 dark:text-blue-400'
+                        : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200'
+                    }`}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill={isSaved(campaign.id) ? "currentColor" : "none"}
+                      stroke="currentColor"
+                      className="w-4 h-4"
+                      strokeWidth={2}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+                    </svg>
+                    {isSaved(campaign.id) ? 'Saved' : 'Save'}
+                  </button>
+                </div>
                 <button
                   type="button"
                   onClick={() => setIsReportModalOpen(true)}

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -379,6 +379,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
                 <FundingProgressBar
                   amountRaised={campaign.amount_raised}
                   fundingGoal={campaign.funding_goal}
+                  milestones={campaign.milestones}
                 />
               </div>
             )}

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -36,6 +36,7 @@ interface ReviewData {
   estimatedDeadlineTimestamp: number;
   tags: string[];
   coverImageUrl: string;
+  milestones: { targetAmount: bigint; description: string }[];
 }
 
 const IMAGE_URL_RE = /^https?:\/\/.+\..+/;
@@ -114,6 +115,7 @@ export default function CreateCampaignPage() {
   const [isReviewOpen, setIsReviewOpen] = useState(false);
   const [reviewData, setReviewData] = useState<ReviewData | null>(null);
   const [tags, setTags] = useState<string[]>([]);
+  const [milestones, setMilestones] = useState<{ targetAmount: string; description: string }[]>([]);
   const [tagInput, setTagInput] = useState('');
   const [descriptionTab, setDescriptionTab] = useState<'write' | 'preview'>('write');
   const [coverImageUrl, setCoverImageUrl] = useState('');
@@ -139,6 +141,7 @@ export default function CreateCampaignPage() {
           setRevenueSharePercentage(parsed.revenueSharePercentage);
         if (parsed.tags) setTags(parsed.tags);
         if (parsed.coverImageUrl) setCoverImageUrl(parsed.coverImageUrl);
+        if (parsed.milestones) setMilestones(parsed.milestones);
       }
     } catch (e) {
       console.warn('Failed to load draft from localStorage:', e);
@@ -160,6 +163,7 @@ export default function CreateCampaignPage() {
           revenueSharePercentage,
           tags,
           coverImageUrl,
+          milestones,
         }),
       );
     } catch (e) {
@@ -175,6 +179,8 @@ export default function CreateCampaignPage() {
     hasRevenueSharing,
     revenueSharePercentage,
     tags,
+    coverImageUrl,
+    milestones,
   ]);
 
   const isStartup = category === Category.EducationalStartup;
@@ -252,6 +258,8 @@ export default function CreateCampaignPage() {
         reviewData.tags,
         {
           onStatus: ({ phase }) => setTxPhase(phase),
+          coverImageUrl: reviewData.coverImageUrl,
+          milestones: reviewData.milestones as any,
         },
       );
 
@@ -323,6 +331,13 @@ export default function CreateCampaignPage() {
     const parsedGoal = parseFloat(fundingGoal);
     const parsedDays = parseInt(durationDays, 10);
 
+    const parsedMilestones = milestones
+      .filter((m) => m.targetAmount.trim() && m.description.trim())
+      .map((m) => ({
+        targetAmount: xlmToStroops(m.targetAmount),
+        description: m.description.trim(),
+      }));
+
     setReviewData({
       title: title.trim(),
       description: description.trim(),
@@ -335,6 +350,7 @@ export default function CreateCampaignPage() {
       estimatedDeadlineTimestamp: Math.floor(Date.now() / 1000) + parsedDays * 86400,
       tags,
       coverImageUrl: coverImageUrl.trim(),
+      milestones: parsedMilestones,
     });
     setIsReviewOpen(true);
   };
@@ -797,6 +813,72 @@ export default function CreateCampaignPage() {
               />
             )}
           </div>
+
+          {/* Milestones */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Milestones (Stretch Goals) <span className="text-xs font-normal text-zinc-400">(optional)</span>
+              </label>
+              <button
+                type="button"
+                onClick={() => setMilestones([...milestones, { targetAmount: '', description: '' }])}
+                className="text-xs text-blue-600 dark:text-blue-400 font-medium hover:underline"
+              >
+                + Add Milestone
+              </button>
+            </div>
+            
+            {milestones.length > 0 && (
+              <div className="space-y-3">
+                {milestones.map((m, idx) => (
+                  <div key={idx} className="flex gap-2 items-start p-3 bg-zinc-50 dark:bg-zinc-700/50 rounded-lg border border-zinc-200 dark:border-zinc-600">
+                    <div className="flex-1 space-y-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-medium text-zinc-500 w-24 shrink-0">Target (XLM)</span>
+                        <input
+                          type="number"
+                          value={m.targetAmount}
+                          onChange={(e) => {
+                            const newM = [...milestones];
+                            newM[idx].targetAmount = e.target.value;
+                            setMilestones(newM);
+                          }}
+                          placeholder="e.g. 1500"
+                          min="0"
+                          step="any"
+                          className="w-full px-2 py-1.5 rounded-md border text-sm bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 border-zinc-200 dark:border-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-medium text-zinc-500 w-24 shrink-0">Description</span>
+                        <input
+                          type="text"
+                          value={m.description}
+                          onChange={(e) => {
+                            const newM = [...milestones];
+                            newM[idx].description = e.target.value;
+                            setMilestones(newM);
+                          }}
+                          placeholder="What will this unlock?"
+                          className="w-full px-2 py-1.5 rounded-md border text-sm bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 border-zinc-200 dark:border-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        />
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setMilestones(milestones.filter((_, i) => i !== idx))}
+                      className="text-zinc-400 hover:text-red-500 p-1 transition-colors"
+                      aria-label="Remove milestone"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
 
           {/* Actions */}
           <div className="flex items-center justify-between pt-2 border-t border-zinc-100 dark:border-zinc-700">

--- a/src/app/[locale]/dashboard/DashboardClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardClient.tsx
@@ -8,6 +8,7 @@ import { Spinner, DashboardSkeleton } from "@/components/Skeleton";
 import { useWallet } from "@/components/WalletContext";
 import { useCampaigns } from "@/hooks/useCampaigns";
 import { useStellarBalance } from "@/hooks/useStellarBalance";
+import { useSavedCampaigns } from "@/hooks/useSavedCampaigns";
 import { isSameAddress } from "@/lib/stellar";
 import { explorerTxUrl } from "@/utils/explorer";
 
@@ -21,6 +22,12 @@ export default function DashboardPage() {
     error: balanceQueryError,
   } = useStellarBalance(publicKey);
   const balanceError = balanceQueryError ? t("balanceFetchError") : null;
+  const { savedIds } = useSavedCampaigns();
+
+  const savedCampaigns = useMemo(
+    () => campaigns.filter((c) => savedIds.includes(c.id)),
+    [campaigns, savedIds]
+  );
 
   const mockVotes = useMemo(
     () => [
@@ -89,6 +96,28 @@ export default function DashboardPage() {
           <span className="text-red-500">{balanceError}</span>
         ) : (
           <span className="text-zinc-900 dark:text-zinc-50 font-mono">{balance} XLM</span>
+        )}
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Saved Campaigns</h2>
+        {savedCampaigns.length === 0 ? (
+          <span className="text-zinc-500 dark:text-zinc-400">You haven't saved any campaigns yet.</span>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {savedCampaigns.map((campaign) => (
+              <Link
+                key={campaign.id}
+                href={`/causes/${campaign.id}`}
+                className="border rounded-xl p-4 bg-zinc-50 dark:bg-zinc-900 hover:border-blue-300 dark:hover:border-blue-700 transition-colors"
+              >
+                <div className="font-medium text-zinc-900 dark:text-zinc-50">{campaign.title}</div>
+                <div className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 line-clamp-2 break-words">
+                  {campaign.description}
+                </div>
+              </Link>
+            ))}
+          </div>
         )}
       </section>
 

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -21,6 +21,7 @@ import DeadlineCountdown from './DeadlineCountdown';
 import FundingProgressBar from './FundingProgressBar';
 import { useToast } from './ToastProvider';
 import VotingComponent from './VotingComponent';
+import { useSavedCampaigns } from '@/hooks/useSavedCampaigns';
 
 interface CauseCardProps {
   campaign: Campaign;
@@ -63,7 +64,8 @@ function CauseCard({
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [isClaimingRefund, setIsClaimingRefund] = useState(false);
-  const { showError } = useToast();
+  const { showError, showWarning } = useToast();
+  const { isSaved, toggleSaved } = useSavedCampaigns();
 
   const progressPct = calculateFundingPercentage(campaign.amount_raised, campaign.funding_goal);
 
@@ -138,6 +140,32 @@ function CauseCard({
             {categoryIcon || '💡'}
           </div>
         )}
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!userWalletAddress) {
+              showWarning('Please connect your wallet to save campaigns.');
+              return;
+            }
+            toggleSaved(campaign.id);
+          }}
+          className="absolute top-2 right-2 p-2 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-sm rounded-full text-zinc-700 dark:text-zinc-200 hover:bg-white dark:hover:bg-zinc-800 transition-colors shadow-sm"
+          title={isSaved(campaign.id) ? "Remove from saved" : "Save campaign"}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill={isSaved(campaign.id) ? "currentColor" : "none"}
+            stroke="currentColor"
+            className={`w-5 h-5 ${isSaved(campaign.id) ? 'text-blue-500' : ''}`}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+          </svg>
+        </button>
       </div>
 
       {/* ── Card body ── */}
@@ -152,12 +180,12 @@ function CauseCard({
         </div>
 
         {/* Title */}
-        <h3 className="font-semibold text-zinc-900 dark:text-zinc-50 leading-snug line-clamp-2">
+        <h3 className="font-semibold text-zinc-900 dark:text-zinc-50 leading-snug line-clamp-2 break-words h-[3rem]">
           {campaign.title}
         </h3>
 
         {/* Description */}
-        <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-3 leading-relaxed">
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-3 leading-relaxed break-words h-[4.5rem]">
           {campaign.description}
         </p>
 

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -183,6 +183,7 @@ function CauseCard({
           <FundingProgressBar
             amountRaised={campaign.amount_raised}
             fundingGoal={campaign.funding_goal}
+            milestones={campaign.milestones}
           />
         )}
 

--- a/src/components/FundingProgressBar.tsx
+++ b/src/components/FundingProgressBar.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useId } from "react";
 import { useLocale } from "next-intl";
 import { motion, useSpring, useTransform } from "framer-motion";
-import { calculateFundingPercentage } from "../types";
+import { calculateFundingPercentage, Milestone } from "../types";
 import { formatAmount } from "@/lib/formatters";
 
 interface FundingProgressBarProps {
   amountRaised: bigint;
   fundingGoal: bigint;
+  milestones?: Milestone[];
 }
 
-export default function FundingProgressBar({ amountRaised, fundingGoal }: FundingProgressBarProps) {
+export default function FundingProgressBar({ amountRaised, fundingGoal, milestones }: FundingProgressBarProps) {
   const locale = useLocale();
   const targetPct = calculateFundingPercentage(amountRaised, fundingGoal);
 
@@ -63,6 +64,37 @@ export default function FundingProgressBar({ amountRaised, fundingGoal }: Fundin
           style={{ width: barWidth }}
         />
       </div>
+
+      {milestones && milestones.length > 0 && fundingGoal > 0n && (
+        <div className="relative mt-2 w-full h-4">
+          {milestones.map((m, idx) => {
+            const mPct = calculateFundingPercentage(m.targetAmount, fundingGoal);
+            const visualPct = Math.min(100, Math.max(0, mPct));
+            const isReached = amountRaised >= m.targetAmount;
+            
+            return (
+              <div 
+                key={idx}
+                className="absolute top-0 flex flex-col items-center -translate-x-1/2 group cursor-help z-10"
+                style={{ left: `${visualPct}%` }}
+              >
+                {/* Marker dot */}
+                <div className={`w-3 h-3 rounded-full border-2 border-white dark:border-zinc-800 shadow-sm transition-colors ${
+                  isReached ? 'bg-emerald-500' : 'bg-zinc-300 dark:bg-zinc-600'
+                }`} />
+                
+                {/* Tooltip on hover */}
+                <div className="opacity-0 group-hover:opacity-100 transition-opacity absolute top-5 w-max max-w-[150px] bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 text-[10px] p-1.5 rounded-md pointer-events-none z-20 text-center shadow-lg">
+                  <p className="font-semibold">{formatAmount(m.targetAmount, locale, { maximumFractionDigits: 0 })} XLM</p>
+                  <p className="line-clamp-2">{m.description}</p>
+                  {/* Arrow */}
+                  <div className="absolute -top-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-b-zinc-900 dark:border-b-zinc-100" />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useSavedCampaigns.ts
+++ b/src/hooks/useSavedCampaigns.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { useWallet } from '@/components/WalletContext';
+
+const SAVED_CAMPAIGNS_KEY_PREFIX = 'poh_saved_campaigns_';
+
+export function useSavedCampaigns() {
+  const { publicKey } = useWallet();
+  const [savedIds, setSavedIds] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!publicKey) {
+      setSavedIds([]);
+      return;
+    }
+    const key = `${SAVED_CAMPAIGNS_KEY_PREFIX}${publicKey}`;
+    try {
+      const data = localStorage.getItem(key);
+      if (data) {
+        setSavedIds(JSON.parse(data));
+      } else {
+        setSavedIds([]);
+      }
+    } catch {
+      setSavedIds([]);
+    }
+  }, [publicKey]);
+
+  const toggleSaved = (campaignId: number) => {
+    if (!publicKey) return;
+    
+    setSavedIds((prev) => {
+      const newIds = prev.includes(campaignId)
+        ? prev.filter((id) => id !== campaignId)
+        : [...prev, campaignId];
+      
+      const key = `${SAVED_CAMPAIGNS_KEY_PREFIX}${publicKey}`;
+      try {
+        localStorage.setItem(key, JSON.stringify(newIds));
+      } catch (e) {
+        console.error('Failed to save bookmarks', e);
+      }
+      return newIds;
+    });
+  };
+
+  const isSaved = (campaignId: number) => savedIds.includes(campaignId);
+
+  return { savedIds, toggleSaved, isSaved };
+}

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -10,7 +10,7 @@ import {
 } from "./observability";
 import { assertProductionContractConfig } from "./runtimeEnv";
 import { appendWalletTransaction } from "./transactionLog";
-import { Campaign, Category, deriveStatus, CampaignStatus } from "../types";
+import { Campaign, Category, deriveStatus, CampaignStatus, Milestone } from "../types";
 import { parseContractError, getContractErrorCode, ContractError } from "../utils/contractErrors";
 import {
   validateStellarAddress,
@@ -272,11 +272,33 @@ function decodeCampaign(val: StellarSdk.xdr.ScVal): Campaign {
   const is_cancelled = fields["is_cancelled"].b();
   const is_verified = fields["is_verified"].b();
 
+  let rawDescription = fields["description"].str().toString();
+  let cover_image_url: string | undefined = undefined;
+  let milestones: any[] | undefined = undefined;
+  
+  const EXT_MARKER = "\n\n===POH_EXT===\n";
+  const extIndex = rawDescription.indexOf(EXT_MARKER);
+  if (extIndex !== -1) {
+    try {
+      const extData = JSON.parse(rawDescription.substring(extIndex + EXT_MARKER.length));
+      cover_image_url = extData.coverImageUrl;
+      if (extData.milestones && Array.isArray(extData.milestones)) {
+        milestones = extData.milestones.map((m: any) => ({
+          targetAmount: BigInt(m.targetAmount),
+          description: m.description
+        }));
+      }
+    } catch (e) {
+      console.warn("Failed to parse campaign extension data", e);
+    }
+    rawDescription = rawDescription.substring(0, extIndex);
+  }
+
   return {
     id: fields["id"].u32(),
     creator: StellarSdk.Address.fromScVal(fields["creator"]).toString(),
     title: fields["title"].str().toString(),
-    description: fields["description"].str().toString(),
+    description: rawDescription,
     funding_goal,
     deadline,
     amount_raised,
@@ -298,6 +320,8 @@ function decodeCampaign(val: StellarSdk.xdr.ScVal): Campaign {
     has_revenue_sharing: fields["has_revenue_sharing"].b(),
     revenue_share_percentage: fields["revenue_share_percentage"].u32(),
     tags: fields["tags"] ? (fields["tags"] as any).vec().map((v: any) => v.str().toString()) : [],
+    cover_image_url,
+    milestones,
   };
 }
 
@@ -335,6 +359,11 @@ const MOCK_CAMPAIGNS: Campaign[] = [
     created_at: Math.floor(Date.now() / 1000),
     revenue_share_percentage: 0,
     tags: ["water", "rural", "health"],
+    milestones: [
+      { targetAmount: BigInt(25_000_000_000), description: "First 100 families connected" },
+      { targetAmount: BigInt(50_000_000_000), description: "Next 200 families connected" },
+      { targetAmount: BigInt(75_000_000_000), description: "Final 200 families connected" },
+    ],
   }),
   makeMockCampaign({
     id: 2,
@@ -571,13 +600,22 @@ export async function createCampaign(
   hasRevenueSharing: boolean,
   revenueSharePercentage: number,
   tags: string[],
-  options?: TransactionLifecycleOptions,
+  options?: TransactionLifecycleOptions & { coverImageUrl?: string; milestones?: Milestone[] },
 ): Promise<string> {
   validateStellarAddress(creator);
   validateFundingGoal(fundingGoal);
   validateDuration(durationDays);
   if (hasRevenueSharing) {
     validateRevenueShare(revenueSharePercentage);
+  }
+
+  let finalDescription = description;
+  if (options?.coverImageUrl || (options?.milestones && options.milestones.length > 0)) {
+    const ext = {
+      coverImageUrl: options.coverImageUrl,
+      milestones: options.milestones?.map(m => ({ targetAmount: m.targetAmount.toString(), description: m.description }))
+    };
+    finalDescription = `${description}\n\n===POH_EXT===\n${JSON.stringify(ext)}`;
   }
 
   if (USE_MOCKS) {
@@ -587,7 +625,7 @@ export async function createCampaign(
         id: MOCK_CAMPAIGNS.length + 1,
         creator,
         title,
-        description,
+        description: finalDescription,
         funding_goal: fundingGoal,
         deadline: Math.floor(Date.now() / 1000) + durationDays * 86400,
         amount_raised: BigInt(0),
@@ -600,6 +638,8 @@ export async function createCampaign(
         has_revenue_sharing: hasRevenueSharing,
         revenue_share_percentage: revenueSharePercentage,
         tags,
+        cover_image_url: options?.coverImageUrl,
+        milestones: options?.milestones,
       }),
     );
     return txHash;
@@ -609,7 +649,7 @@ export async function createCampaign(
     "create_campaign",
     new StellarSdk.Address(creator).toScVal(),
     StellarSdk.nativeToScVal(title, { type: "string" }),
-    StellarSdk.nativeToScVal(description, { type: "string" }),
+    StellarSdk.nativeToScVal(finalDescription, { type: "string" }),
     StellarSdk.nativeToScVal(fundingGoal, { type: "i128" }),
     StellarSdk.nativeToScVal(durationDays, { type: "u64" }),
     StellarSdk.nativeToScVal(category, { type: "u32" }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,11 @@ export function deriveStatus(flags: RawCampaignFlags): CampaignStatus {
 // Campaign interface — mirrors the on-chain Campaign struct
 // ---------------------------------------------------------------------------
 
+export interface Milestone {
+  targetAmount: bigint;
+  description: string;
+}
+
 export interface Campaign {
   id: number;
   creator: string;
@@ -75,6 +80,7 @@ export interface Campaign {
   revenue_share_percentage: number; // basis points (e.g. 300 = 3%)
   tags?: string[];
   cover_image_url?: string;
+  milestones?: Milestone[];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/contractErrors.ts
+++ b/src/utils/contractErrors.ts
@@ -88,9 +88,18 @@ export function getContractErrorCode(error: unknown): ContractError | null {
     return error.code;
   }
 
+  let message = "";
   if (error instanceof Error) {
+    message = error.message;
+  } else if (typeof error === "string") {
+    message = error;
+  } else if (typeof error === "object" && error !== null) {
+    message = (error as any).message || (error as any).error?.message || JSON.stringify(error);
+  }
+
+  if (message) {
     // Soroban SDK typically formats contract errors as "Error(Contract, #N)"
-    const sorobanMatch = error.message.match(/Error\s*\(\s*Contract\s*,\s*#(\d+)\s*\)/i);
+    const sorobanMatch = message.match(/Error\s*\(\s*Contract\s*,\s*#(\d+)\s*\)/i);
     if (sorobanMatch) {
       const code = parseInt(sorobanMatch[1], 10);
       if (code in ContractError) {
@@ -99,7 +108,7 @@ export function getContractErrorCode(error: unknown): ContractError | null {
     }
 
     // Alternative formats: "contractError: N" or "contract error N"
-    const codeMatch = error.message.match(/contract\s*[Ee]rror[:\s]+(\d+)/);
+    const codeMatch = message.match(/contract\s*[Ee]rror[:\s]+(\d+)/i);
     if (codeMatch) {
       const code = parseInt(codeMatch[1], 10);
       if (code in ContractError) {
@@ -140,11 +149,18 @@ export function parseContractError(error: unknown): string {
     return errorTranslationKeys[code] ?? FALLBACK_KEY;
   }
 
+  let message = "";
   if (error instanceof Error) {
-    // Return the raw message if it looks human-readable (not a stack trace)
-    if (error.message && !error.message.includes("at ") && error.message.length < 200) {
-      return error.message;
-    }
+    message = error.message;
+  } else if (typeof error === "string") {
+    message = error;
+  } else if (typeof error === "object" && error !== null) {
+    message = (error as any).message || (error as any).error?.message || "";
+  }
+
+  // Return the raw message if it looks human-readable (not a stack trace)
+  if (message && !message.includes("at ") && message.length < 200) {
+    return message;
   }
 
   return FALLBACK_KEY;


### PR DESCRIPTION
I implemented the ability for creators to add funding milestones (stretch goals) to their campaigns. Since the smart contract could not be modified, I added a mechanism to serialize these milestones—along with the campaign's cover image URL—into a hidden JSON payload appended to the campaign's description during creation, which is then parsed out when the campaign is loaded. The `NewCauseClient` creation form was updated with a dynamic section to add target amounts and descriptions for these milestones. Finally, the `FundingProgressBar` component was enhanced to display these milestones as interactive visual markers along the funding track, complete with tooltips on hover and dynamic color highlighting to clearly indicate which stretch goals have been successfully reached.

Close #480
Close #496
Close #411
Close #477