### PR TITLE
ci: add missing translations test for i18n parity enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Run tests with coverage
         run: >
           npm run test:coverage -- --ci --runInBand --runTestsByPath
+          src/__tests__/i18n/missingTranslations.test.ts
           src/__tests__/integration/AppPageComponents.test.tsx
           src/__tests__/integration/CausesFilterUrlSync.test.tsx
           src/__tests__/components/CauseCard.test.tsx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,9 +284,22 @@ For contract-layer work (`src/lib/contractClient.ts`):
 For UI work:
 
 - Add/adjust component or integration tests under `src/__tests__/`.
-- Ensure localization parity when adding translation keys (`messages/en.json` and `messages/es.json`).
+- Ensure localization parity when adding translation keys.
 
-## 9) Opening Issues and PRs
+### 9) Internationalization (i18n) Parity
+
+We support English (`en`) and Spanish (`es`).
+- **Parity is mandatory**: Every key added to `messages/en.json` **must** also be added to `messages/es.json`.
+- **No Empty Values**: Translation values must not be empty strings.
+- **CI Enforcement**: The `src/__tests__/i18n/missingTranslations.test.ts` test runs in CI to ensure parity. If parity is broken, the build will fail.
+
+To check parity locally:
+```bash
+npm run test src/__tests__/i18n/missingTranslations.test.ts
+```
+
+### 10) Opening Issues and PRs
+
 
 - Search existing issues/PRs first to avoid duplicates.
 - Link related issues in your PR body (`Closes #123`).


### PR DESCRIPTION
I have successfully integrated the i18n parity check into the CI pipeline and
  updated the project documentation.

  Key Improvements

 1. CI Enforcement: Updated .github/workflows/ci.yml to include
      src/__tests__/i18n/missingTranslations.test.ts in the primary test job.
      This ensures that any missing or empty translation keys in es.json
      relative to en.json will automatically fail the build and block pull
      requests.
2. Contributor Documentation: Added a new section to CONTRIBUTING.md titled
      "Internationalization (i18n) Parity". This section:
       * Explicitly states that parity between en.json and es.json is mandatory.
       * Prohibits empty translation values.
       * Provides the local command for contributors to verify parity before
         submitting a PR:

     `   npm run test src/__tests__/i18n/missingTranslations.test.ts`   
3. Validation: Verified locally that the parity test currently passes with
      all 3 test cases succeeding.
Closes #380 