### PR TITLE
feat: implement contract version management and display in admin components

### DIFF
--- a/docs/CONTRACT_INTEGRATION.md
+++ b/docs/CONTRACT_INTEGRATION.md
@@ -189,7 +189,7 @@ editing `contractClient.ts`.
 | `get_approve_votes(campaign_id)`                | _pending_                                    | _pending_                                        | `/causes/[id]` (community vote UI)              |
 | `get_reject_votes(campaign_id)`                 | _pending_                                    | _pending_                                        | `/causes/[id]` (community vote UI)              |
 | `has_voted(campaign_id, voter)`                 | _pending_                                    | _pending_                                        | `/causes/[id]` (community vote UI)              |
-| `get_version()`                                 | _pending_                                    | —                                                | admin / debug                                   |
+| `get_version()`                                 | `getVersion()`                               | —                                                | admin / debug / footer                          |
 
 ### Write functions
 

--- a/src/app/[locale]/admin/AdminClient.tsx
+++ b/src/app/[locale]/admin/AdminClient.tsx
@@ -13,6 +13,7 @@ import {
   RefreshCw,
   Smartphone,
   Flag,
+  AlertTriangle,
 } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
 import { FormEvent, useEffect, useMemo, useState } from "react";
@@ -52,11 +53,14 @@ const CancelCampaignModal = dynamic(() => import("@/components/cancelCampaignMod
 });
 import { AdminSkeleton } from "@/components/Skeleton";
 import { Campaign } from "@/types";
+import { useContractVersion } from "@/hooks/useContractVersion";
 
 export default function AdminDashboard() {
   const { campaigns, isLoading, refetch, isRefreshing } = useCampaigns();
   const { publicKey, isWalletConnected, connectWallet, isLoading: isWalletLoading } = useWallet();
+  const { version: contractVersion, isMismatch: isVersionMismatch, expectedVersion } = useContractVersion();
   const queryClient = useQueryClient();
+
   const { showSuccess, showError, showWarning } = useToast();
   const t = useTranslations("Admin");
   const locale = useLocale();
@@ -421,6 +425,24 @@ export default function AdminDashboard() {
             >
               {t("observabilityLink")}
             </Link>
+            <div className={`rounded-2xl border px-5 py-3 shadow-sm flex items-center gap-3 ${
+              isVersionMismatch 
+                ? "bg-red-50 border-red-200 text-red-900 dark:bg-red-950/20 dark:border-red-900/40 dark:text-red-200" 
+                : "bg-blue-50 border-blue-100 text-blue-900 dark:bg-blue-900/20 dark:border-blue-800/40 dark:text-blue-200"
+            }`}>
+              <div className="flex flex-col">
+                <span className="text-[10px] font-black uppercase tracking-widest opacity-60">Contract Version</span>
+                <span className="font-mono text-sm font-bold flex items-center gap-2">
+                  {isVersionMismatch && <AlertTriangle size={14} />}
+                  v{contractVersion ?? "..."}
+                  {isVersionMismatch && (
+                    <span className="text-[10px] font-normal opacity-70">
+                      (Expected v{expectedVersion})
+                    </span>
+                  )}
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,10 +3,13 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/routing";
+import { useContractVersion } from "@/hooks/useContractVersion";
+import { AlertTriangle } from "lucide-react";
 
 export default function Footer() {
   const t = useTranslations("Footer");
   const year = new Date().getFullYear();
+  const { version, isMismatch, isLoading } = useContractVersion();
 
   const productLinks = [
     { href: "/", label: t("home") },
@@ -86,11 +89,26 @@ export default function Footer() {
           <p>{t("rights", { year })}</p>
           <p className="flex items-center gap-3">
             <span>{t("builtWith")}</span>
-            {process.env.NEXT_PUBLIC_APP_VERSION && (
-              <span className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                v{process.env.NEXT_PUBLIC_APP_VERSION}
-              </span>
-            )}
+            <div className="flex items-center gap-1.5">
+              {process.env.NEXT_PUBLIC_APP_VERSION && (
+                <span className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] uppercase font-bold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400" title="App Version">
+                  v{process.env.NEXT_PUBLIC_APP_VERSION}
+                </span>
+              )}
+              {!isLoading && version !== null && (
+                <span 
+                  className={`flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[10px] uppercase font-bold ${
+                    isMismatch 
+                      ? "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400 border border-amber-200 dark:border-amber-800" 
+                      : "bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 border border-blue-100/50 dark:border-blue-800/50"
+                  }`}
+                  title={isMismatch ? "Contract version mismatch! Unexpected behavior may occur." : "Contract Version"}
+                >
+                  {isMismatch && <AlertTriangle size={10} />}
+                  c{version}
+                </span>
+              )}
+            </div>
           </p>
         </div>
       </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Menu, X, Moon, Sun, ShieldCheck, Plus } from "lucide-react";
+import { Menu, X, Moon, Sun, ShieldCheck, Plus, AlertTriangle } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from 'next-intl';
 import { useState, useEffect, useRef, useMemo } from "react";
@@ -12,6 +12,7 @@ import { formatAddress } from "@/lib/formatAddress";
 import LanguageSwitcher from "./LanguageSwitcher";
 import NotificationBell from "./NotificationBell";
 import { useCampaigns } from "@/hooks/useCampaigns";
+import { useContractVersion } from "@/hooks/useContractVersion";
 import { IS_MOCK_MODE } from "@/lib/runtimeEnv";
 
 export default function Navbar() {
@@ -35,6 +36,7 @@ export default function Navbar() {
   const pathname = usePathname();
   const t = useTranslations('Common');
   const { admin: adminAddress } = useAdmin();
+  const { isMismatch, version, expectedVersion } = useContractVersion();
 
   const { campaigns } = useCampaigns();
   const pendingCount = useMemo(() => {
@@ -107,6 +109,15 @@ export default function Navbar() {
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/5 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-zinc-900/80 transition-all duration-300">
+      {isMismatch && (
+        <div className="border-b border-red-200 bg-red-50 px-4 py-2 text-center text-xs font-bold text-red-900 dark:border-red-900/40 dark:bg-red-950/60 dark:text-red-200 flex items-center justify-center gap-2">
+          <AlertTriangle size={14} className="shrink-0" />
+          <span>
+            Contract version mismatch: Found <strong>c{version}</strong> but the app expects <strong>c{expectedVersion}</strong>. 
+            Some features may be disabled or behave unexpectedly.
+          </span>
+        </div>
+      )}
       {walletNetworkWarning && (
         <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-center text-xs font-semibold text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-200">
           {walletNetworkWarning}

--- a/src/hooks/useContractVersion.ts
+++ b/src/hooks/useContractVersion.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getVersion, EXPECTED_CONTRACT_VERSION } from '../lib/contractClient';
+
+export interface UseContractVersionResult {
+  version: number | null;
+  expectedVersion: number;
+  isMismatch: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useContractVersion(): UseContractVersionResult {
+  const { data, isLoading, error } = useQuery<number, Error>({
+    queryKey: ['contractVersion'],
+    queryFn: () => getVersion(),
+    staleTime: Infinity, // Version rarely changes
+    retry: 2,
+  });
+
+  const version = data ?? null;
+  const isMismatch = version !== null && version !== EXPECTED_CONTRACT_VERSION;
+
+  return {
+    version,
+    expectedVersion: EXPECTED_CONTRACT_VERSION,
+    isMismatch,
+    isLoading,
+    error: error?.message ?? null,
+  };
+}

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -518,6 +518,23 @@ export async function getAdmin(): Promise<string> {
   }
 }
 
+export const EXPECTED_CONTRACT_VERSION = 1;
+
+/**
+ * Fetches the contract version.
+ */
+export async function getVersion(): Promise<number> {
+  if (USE_MOCKS) return 1;
+
+  try {
+    const result = await invokeViewMethod("get_version");
+    if (!result) return 0;
+    return result.u32();
+  } catch (err) {
+    throw new Error(parseContractError(err));
+  }
+}
+
 /**
  * Fetches the platform fee in basis points.
  */


### PR DESCRIPTION
Closes #387 

I have implemented a robust contract version detection and warning system to
  handle potential upgrade mismatches.

  Key Implementation Details

   1. Contract Integration:
       * Added getVersion() to src/lib/contractClient.ts to fetch the current
         version from the Soroban contract.
       * Defined EXPECTED_CONTRACT_VERSION = 1 as the baseline for comparison.
       * Updated docs/CONTRACT_INTEGRATION.md to reflect that get_version() is
         now fully implemented.
   2. Version Logic:
       * Created a new hook, useContractVersion(), which handles fetching,
         caching (via React Query), and comparing the contract version. It
         provides isMismatch, version, and expectedVersion states.
   3. User Warnings (Soft-Block):
       * Integrated a high-visibility warning banner into Navbar.tsx. If a
         version mismatch is detected, users are alerted immediately with a
         message like: "Contract version mismatch: Found c2 but the app expects
         c1."
   4. System Visibility:
       * Footer: Added the contract version (e.g., c1) next to the app version.
         If there's a mismatch, it turns amber with a warning icon.
       * Admin Console: Added a version status block to the header of the Admin
         Dashboard, allowing administrators to quickly verify the contract state
         and see expected vs. actual versions.
  This system ensures that after any mainnet contract upgrade, the frontend will
  proactively notify users and admins of potential incompatibilities rather than
  failing silently.