### PR TITLE
test: add scenarios for voting component accessibility and interaction

### DIFF
--- a/src/__tests__/components/VotingComponent.test.tsx
+++ b/src/__tests__/components/VotingComponent.test.tsx
@@ -109,4 +109,85 @@ describe("VotingComponent Accessibility & Interaction", () => {
     await userEvent.click(rejectBtn);
     expect(mockOnVote).toHaveBeenCalledWith(campaign.id, "downvote");
   });
+
+  it("disables voting and shows voted message when user has already voted", () => {
+    const userVote = {
+      causeId: "1",
+      voter: "GUSER1",
+      voteType: "upvote" as const,
+      timestamp: new Date(),
+      transactionHash: "tx123",
+    };
+
+    render(
+      <VotingComponent
+        campaign={campaign}
+        userWalletAddress="GUSER1"
+        onVote={mockOnVote}
+        isVoting={false}
+        userVote={userVote}
+      />
+    );
+
+    const approveBtn = screen.getByRole("button", { name: "approveCampaignAria" });
+    const rejectBtn = screen.getByRole("button", { name: "rejectCampaignAria" });
+
+    expect(approveBtn).toBeDisabled();
+    expect(rejectBtn).toBeDisabled();
+    expect(screen.getByText("votedUpvote")).toBeInTheDocument();
+  });
+
+  it("disables voting and shows prompt when user is not a token holder", () => {
+    render(
+      <VotingComponent
+        campaign={campaign}
+        userWalletAddress="GUSER1"
+        onVote={mockOnVote}
+        isVoting={false}
+        isTokenHolder={false}
+      />
+    );
+
+    const approveBtn = screen.getByRole("button", { name: "approveCampaignAria" });
+    const rejectBtn = screen.getByRole("button", { name: "rejectCampaignAria" });
+
+    expect(approveBtn).toBeDisabled();
+    expect(rejectBtn).toBeDisabled();
+    expect(screen.getByText("tokenHoldersOnlyPrompt")).toBeInTheDocument();
+  });
+
+  it("disables voting when voting is in progress", () => {
+    render(
+      <VotingComponent
+        campaign={campaign}
+        userWalletAddress="GUSER1"
+        onVote={mockOnVote}
+        isVoting={true}
+      />
+    );
+
+    const approveBtn = screen.getByRole("button", { name: "approveCampaignAria" });
+    const rejectBtn = screen.getByRole("button", { name: "rejectCampaignAria" });
+
+    expect(approveBtn).toBeDisabled();
+    expect(rejectBtn).toBeDisabled();
+  });
+
+  it("disables voting and shows prompt when no wallet is connected", () => {
+    render(
+      <VotingComponent
+        campaign={campaign}
+        userWalletAddress={null}
+        onVote={mockOnVote}
+        isVoting={false}
+      />
+    );
+
+    const approveBtn = screen.getByRole("button", { name: "approveCampaignAria" });
+    const rejectBtn = screen.getByRole("button", { name: "rejectCampaignAria" });
+
+    expect(approveBtn).toBeDisabled();
+    expect(rejectBtn).toBeDisabled();
+    expect(screen.getByText("connectWalletPrompt")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
I have enhanced the VotingComponent test suite to ensure full coverage of the community validation logic.

  Test Coverage Summary

  I updated src/__tests__/components/VotingComponent.test.tsx with the following
  test cases:

   1. Vote Casting: Verified that clicking "Approve" or "Reject" correctly
      invokes the onVote handler with the expected parameters (campaign ID and
      vote type).
   2. hasVoted State: Confirmed that if a user has already cast a vote (passed
      via userVote), the voting buttons are disabled, and a confirmation message
      (e.g., "You voted to approve this cause") is displayed.
   3. Non-Token-Holder State: Verified that if isTokenHolder is false, the
      voting buttons are disabled, and the "Only governance token holders can
      vote" prompt is shown.
   4. Wallet Connection: Added coverage to ensure that users without a connected
      wallet see the "Connect your wallet to vote" prompt and cannot interact
  The test suite now contains 8 comprehensive tests, all of which are passing.
  This ensures that the central community validation component behaves correctly
  under all user states and prevents invalid interactions.

Closes #408 