### PR TITLE
perf: share a single countdown timer and reduce far-deadline re-renders

### DIFF
--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useLocale } from "next-intl";
+import { subscribeToCountdownTick } from "@/hooks/useCountdownTick";
 
 interface DeadlineCountdownProps {
   deadline: number; // Unix timestamp in seconds
@@ -24,31 +25,50 @@ function getTimeLeft(deadline: number): TimeLeft | null {
   };
 }
 
+const ClockIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+    />
+  </svg>
+);
+
 export default function DeadlineCountdown({ deadline }: DeadlineCountdownProps) {
   const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(() => getTimeLeft(deadline));
   const locale = useLocale();
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      const remaining = getTimeLeft(deadline);
-      setTimeLeft(remaining);
-      if (!remaining) clearInterval(interval);
-    }, 60_000); // update every minute
+    return subscribeToCountdownTick(() => {
+      setTimeLeft((prev) => {
+        // Already ended — cheap no-op on future ticks
+        if (prev === null) return null;
 
-    return () => clearInterval(interval);
+        const next = getTimeLeft(deadline);
+        if (!next) return null;
+
+        // When days ≥ 1, the display shows "Xd Xh" only (no minutes).
+        // Skip re-render unless days or hours actually changed.
+        const farDeadline = next.days >= 1;
+        if (
+          prev.days === next.days &&
+          prev.hours === next.hours &&
+          (farDeadline || prev.minutes === next.minutes)
+        ) {
+          return prev; // bail out — React won't schedule a re-render
+        }
+
+        return next;
+      });
+    });
   }, [deadline]);
 
   if (!timeLeft) {
     return (
       <div className="flex items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400">
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
+        <ClockIcon />
         <span>Campaign ended</span>
       </div>
     );
@@ -71,7 +91,13 @@ export default function DeadlineCountdown({ deadline }: DeadlineCountdownProps) 
           </>
         )}
         <strong>{new Intl.NumberFormat(locale).format(timeLeft.hours)}</strong>h{" "}
-        <strong>{new Intl.NumberFormat(locale).format(timeLeft.minutes)}</strong>m remaining
+        {/* Show minutes only when < 1 day remains; far deadlines only need hourly updates */}
+        {timeLeft.days === 0 && (
+          <>
+            <strong>{new Intl.NumberFormat(locale).format(timeLeft.minutes)}</strong>m{" "}
+          </>
+        )}
+        remaining
       </span>
     </div>
   );

--- a/src/hooks/useCountdownTick.ts
+++ b/src/hooks/useCountdownTick.ts
@@ -1,0 +1,25 @@
+// Single shared 60-second timer for all DeadlineCountdown instances.
+// Prevents N×setInterval when many countdown cards are mounted simultaneously.
+
+type Unsubscribe = () => void;
+
+const subscribers = new Set<() => void>();
+let timerId: ReturnType<typeof setInterval> | null = null;
+
+function tick() {
+  subscribers.forEach((cb) => cb());
+}
+
+export function subscribeToCountdownTick(callback: () => void): Unsubscribe {
+  subscribers.add(callback);
+  if (timerId === null) {
+    timerId = setInterval(tick, 60_000);
+  }
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0 && timerId !== null) {
+      clearInterval(timerId);
+      timerId = null;
+    }
+  };
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,4 +14,5 @@ jest.mock("next-intl", () => ({
     () =>
     (key: string, values?: Record<string, string | number>) =>
       values?.count === 1 ? `${key}_one` : key,
+  useLocale: () => "en",
 }));


### PR DESCRIPTION
[perf] Avoid per-second re-renders from DeadlineCountdown timers

closes #437 

  Summary

  - src/hooks/useCountdownTick.ts — new module-level subscription timer. A single setInterval is shared across every mounted
  DeadlineCountdown instance. The interval starts when the first subscriber registers and clears automatically when the last
  one unmounts. On a list of 20 cause cards, this reduces 20 independent timers to 1, and all components update within the
  same synchronous tick so React can batch the re-renders.
  - src/components/DeadlineCountdown.tsx — three changes:
    - Swapped the per-component setInterval for subscribeToCountdownTick.
    - Functional setState compares the incoming TimeLeft against the previous value and returns the same reference if the
  display would not change — React bails out of re-rendering entirely for those ticks.
    - Display adapts to deadline distance: days ≥ 1 shows Xd Xh (minutes dropped), meaning far-deadline campaigns re-render at
   most once per hour instead of every minute. days === 0 keeps the original Xh Xm precision.
  - src/setupTests.ts — added the missing useLocale: () => "en" entry to the next-intl global mock; all 4 existing
  DeadlineCountdown unit tests were failing with TypeError due to this gap.

  Test plan

  - Run npx jest --testPathPatterns="DeadlineCountdown" — all 4 tests pass.
  - Open the causes list page with multiple active campaigns. In browser DevTools → Performance, record a 2-minute trace and
  confirm only one setInterval callback fires per minute (not N callbacks where N = number of cards).
  - For a campaign with days remaining, confirm the display shows Xd Xh remaining (no minutes) and does not re-render between
  hour boundaries (React DevTools Profiler → no highlight on non-hour ticks).
  - For a campaign within 24 hours, confirm Xh Xm remaining updates every minute as before.
  - Unmount all countdown cards (navigate away) and confirm no interval remains active (DevTools → Sources → Event Listeners
  shows no setInterval).