### PR TITLE
docs: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,10 @@ description: Report something that isn't working correctly
 title: "[Bug]: "
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please search existing issues and PRs first, then review `CONTRIBUTING.md` before opening a fix.
   - type: textarea
     id: description
     attributes:
@@ -26,6 +30,8 @@ body:
     attributes:
       label: Expected vs Actual Behavior
       description: What you expected to happen vs what actually happened
+    validations:
+      required: true
   - type: textarea
     id: screenshots
     attributes:
@@ -36,8 +42,26 @@ body:
     attributes:
       label: Environment
       description: OS, browser, version numbers, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What should be true when this is fixed?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
   - type: textarea
     id: additional
     attributes:
       label: Additional Context
       description: Add any other context about the problem here
+  - type: checkboxes
+    id: contribution-flow
+    attributes:
+      label: Contribution Flow
+      options:
+        - label: I searched existing issues and PRs for duplicates.
+        - label: I reviewed `CONTRIBUTING.md`.
+        - label: I will follow the Stellar Wave flow for bounty-related work, if applicable.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,56 @@
+name: Chore / Maintenance
+description: Track documentation, tooling, CI, cleanup, or maintenance work
+title: "[Chore]: "
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping maintain ProofOfHeart. Please review `CONTRIBUTING.md` before starting implementation or opening a PR.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What maintenance task should be completed?
+      placeholder: Add or update templates, CI, docs, tooling, configuration, or cleanup work.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this useful for contributors, maintainers, users, or the Stellar Wave flow?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the concrete checks that make this chore complete.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area is affected?
+      options:
+        - Documentation
+        - Issue or PR workflow
+        - CI / automation
+        - Tooling / dependencies
+        - Tests
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: contribution-flow
+    attributes:
+      label: Contribution Flow
+      options:
+        - label: I searched existing issues and PRs for duplicates.
+        - label: I reviewed `CONTRIBUTING.md`.
+        - label: I will link this issue from the PR.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,10 @@ description: Suggest a new feature or improvement
 title: "[Feature]: "
 labels: ["feature"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please search existing issues and PRs first, then review `CONTRIBUTING.md` before opening a PR.
   - type: textarea
     id: description
     attributes:
@@ -15,11 +19,23 @@ body:
     attributes:
       label: Problem Solved
       description: What problem does this feature solve?
+    validations:
+      required: true
   - type: textarea
     id: solution
     attributes:
       label: Proposed Solution
       description: Describe your proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What should be true when this feature is complete?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
   - type: textarea
     id: alternatives
     attributes:
@@ -30,3 +46,11 @@ body:
     attributes:
       label: Additional Context
       description: Add any other context or screenshots about the feature request here
+  - type: checkboxes
+    id: contribution-flow
+    attributes:
+      label: Contribution Flow
+      options:
+        - label: I searched existing issues and PRs for duplicates.
+        - label: I reviewed `CONTRIBUTING.md`.
+        - label: I will follow the Stellar Wave flow for bounty-related work, if applicable.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -3,6 +3,10 @@ description: Ask a question or seek clarification
 title: "[Question]: "
 labels: ["question"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking. For implementation work, please review `CONTRIBUTING.md` and link the related issue from your PR.
   - type: textarea
     id: question
     attributes:
@@ -15,6 +19,8 @@ body:
     attributes:
       label: Context
       description: Provide any relevant context for your question
+    validations:
+      required: true
   - type: input
     id: version
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- Briefly describe what changed and why. -->
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Chore / maintenance
+- [ ] Documentation
+- [ ] Test coverage
+
+## Contributor Checklist
+
+- [ ] Linked the related issue above.
+- [ ] Reviewed `CONTRIBUTING.md` for branch, commit, and PR title conventions.
+- [ ] Confirmed this follows the current Stellar Wave contribution flow, if applicable.
+- [ ] Added or updated tests when behavior changed.
+- [ ] Updated docs, examples, or translations when needed.
+
+## Validation
+
+- [ ] `npm run lint`
+- [ ] `npm run format:check`
+- [ ] `npm run typecheck`
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] Not run; reason:
+
+## Notes for Reviewers
+
+<!-- Add screenshots, rollout notes, known limitations, or anything that helps review. -->


### PR DESCRIPTION
## Summary

Adds the missing pull request template and rounds out the issue workflow for the bounty-driven contribution process.

Closes #509

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE.md` with issue linking, contributor checklist, validation checklist, and Stellar Wave flow reminder.
- Add a `chore.yml` issue form for docs/tooling/CI/maintenance work.
- Update bug, feature, and question templates with duplicate-search/contribution guidance and clearer required fields.

## Validation

- `ruby -ryaml -e "Dir[".github/ISSUE_TEMPLATE/*.yml"].sort.each { |f| YAML.load_file(f); puts "#{f}: ok" }"`
- `node -e` basic file checks for trailing newlines
- `git diff --check`

Not run: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm test`, or `npm run build` because this is a docs/template-only change and dependencies are not installed in this local clone.