### PR TITLE
refactor: centralize stroops/XLM conversion in stellarAmount

### DIFF
--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -70,6 +70,14 @@ docker-compose down
 
 **Docs**: [DEV_MOCK_PANEL.md](./DEV_MOCK_PANEL.md)
 
+## Stellar XLM amounts
+
+**Conversion**: `@/lib/stellarAmount` (`stroopsToXlm`, `xlmToStroops`)
+
+**Display**: `@/lib/formatters` (`formatAmount` with `useLocale()`)
+
+**Docs**: [STELLAR_AMOUNT.md](./STELLAR_AMOUNT.md)
+
 ## Branch Naming
 
 ```

--- a/docs/STELLAR_AMOUNT.md
+++ b/docs/STELLAR_AMOUNT.md
@@ -1,0 +1,36 @@
+# Stellar amount formatting
+
+All XLM ↔ stroops conversion and display formatting lives in two modules:
+
+| Module | Purpose |
+|--------|---------|
+| `@/lib/stellarAmount` | Bigint-safe conversion (`stroopsToXlm`, `xlmToStroops`, `STROOPS_PER_XLM`) |
+| `@/lib/formatters` | Locale-aware display (`formatAmount` for stroops → formatted XLM string) |
+
+## Conversion (contract / validation)
+
+```ts
+import { xlmToStroops, stroopsToXlm, STROOPS_PER_XLM } from "@/lib/stellarAmount";
+
+const stroops = xlmToStroops("12.5"); // 125_000_000n
+const xlm = stroopsToXlm(stroops); // "12.5"
+```
+
+Use `stroopsToXlmNumber` only when you need a `number` for math/charts and values stay within safe IEEE range.
+
+## Display (UI)
+
+```tsx
+import { useLocale } from "next-intl";
+import { formatAmount } from "@/lib/formatters";
+
+const locale = useLocale();
+formatAmount(campaign.amount_raised, locale, { maximumFractionDigits: 2 });
+```
+
+Pass `locale` from `useLocale()` in client components. For non-UI helpers (e.g. env-based fee strings), use a fixed locale such as `"en"`.
+
+## Do not
+
+- Duplicate `10_000_000` conversion logic in components.
+- Import amount helpers from `@/types` (types are for domain models only).

--- a/src/__tests__/lib/formatters.test.ts
+++ b/src/__tests__/lib/formatters.test.ts
@@ -1,4 +1,4 @@
-import { formatNumber, formatXlm, formatDate, formatShortDate } from "@/lib/formatters";
+import { formatNumber, formatXlm, formatDate, formatShortDate, formatAmount } from "@/lib/formatters";
 
 describe("formatNumber", () => {
   it("formats with en grouping separators", () => {
@@ -26,6 +26,16 @@ describe("formatXlm", () => {
   it("formats zero correctly", () => {
     expect(formatXlm(0, "en")).toBe("0");
     expect(formatXlm(0, "es")).toBe("0");
+  });
+});
+
+describe("formatAmount", () => {
+  it("formats stroops as locale-aware XLM in en", () => {
+    expect(formatAmount(12_500_000n, "en", { maximumFractionDigits: 2 })).toBe("1.25");
+  });
+
+  it("formats zero stroops", () => {
+    expect(formatAmount(0n, "en")).toBe("0");
   });
 });
 

--- a/src/__tests__/lib/stellarAmount.test.ts
+++ b/src/__tests__/lib/stellarAmount.test.ts
@@ -1,0 +1,66 @@
+import {
+  STROOPS_PER_XLM,
+  stroopsToXlm,
+  stroopsToXlmNumber,
+  xlmToStroops,
+} from "@/lib/stellarAmount";
+
+describe("STROOPS_PER_XLM", () => {
+  it("equals 10 million stroops per XLM", () => {
+    expect(STROOPS_PER_XLM).toBe(10_000_000n);
+  });
+});
+
+describe("stroopsToXlm", () => {
+  it("converts zero", () => {
+    expect(stroopsToXlm(0n)).toBe("0");
+  });
+
+  it("converts sub-1 XLM amounts without trailing zeros", () => {
+    expect(stroopsToXlm(1n)).toBe("0.0000001");
+    expect(stroopsToXlm(10_000n)).toBe("0.001");
+  });
+
+  it("converts whole XLM amounts", () => {
+    expect(stroopsToXlm(STROOPS_PER_XLM)).toBe("1");
+    expect(stroopsToXlm(12_500_000n)).toBe("1.25");
+  });
+
+  it("handles large stroop values via string math", () => {
+    const large = 9_223_372_036_854_775_807n; // max i64 stroops
+    expect(stroopsToXlm(large)).toBe("922337203685.4775807");
+  });
+});
+
+describe("xlmToStroops", () => {
+  it("parses empty as zero", () => {
+    expect(xlmToStroops("")).toBe(0n);
+    expect(xlmToStroops("   ")).toBe(0n);
+  });
+
+  it("parses integers and decimals", () => {
+    expect(xlmToStroops("1")).toBe(STROOPS_PER_XLM);
+    expect(xlmToStroops("1.25")).toBe(12_500_000n);
+    expect(xlmToStroops("0.0000001")).toBe(1n);
+  });
+
+  it("pads and truncates fractional digits to 7 stroop decimals", () => {
+    expect(xlmToStroops("1.2")).toBe(12_000_000n);
+    expect(xlmToStroops("1.123456789")).toBe(11_234_567n);
+  });
+});
+
+describe("stroopsToXlmNumber", () => {
+  it("matches Number(stroopsToXlm()) for typical amounts", () => {
+    expect(stroopsToXlmNumber(12_500_000n)).toBe(1.25);
+  });
+});
+
+describe("round-trip", () => {
+  it.each(["0", "0.1", "1", "12.5", "999.0000001"])(
+    "preserves %s through stroopsToXlm and xlmToStroops",
+    (xlm) => {
+      expect(stroopsToXlm(xlmToStroops(xlm))).toBe(xlm);
+    },
+  );
+});

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -39,7 +39,8 @@ import {
 } from "@/lib/contractClient";
 import { useTranslations, useLocale } from "next-intl";
 import { CauseDetailSkeleton } from "@/components/Skeleton";
-import { Campaign, Vote, CATEGORY_LABELS, stroopsToXlm } from "@/types";
+import { Campaign, Vote, CATEGORY_LABELS } from "@/types";
+import { stroopsToXlmNumber } from "@/lib/stellarAmount";
 import { parseContractError } from "@/utils/contractErrors";
 import { getAsyncActionErrorMessage, withActionTimeout } from "@/utils/asyncAction";
 import { trackViewCampaign } from "@/lib/analytics";
@@ -247,8 +248,8 @@ export default function CauseDetailClient({ id }: { id: string }) {
     );
   }
 
-  const raised = Number(stroopsToXlm(campaign.amount_raised));
-  const goal = Number(stroopsToXlm(campaign.funding_goal));
+  const raised = stroopsToXlmNumber(campaign.amount_raised);
+  const goal = stroopsToXlmNumber(campaign.funding_goal);
   const fundingPct = goal > 0 ? Math.min(100, Math.round((raised / goal) * 100)) : 0;
   const approvalRate =
     voteCounts.totalVotes > 0 ? Math.round((voteCounts.upvotes / voteCounts.totalVotes) * 100) : 0;
@@ -264,7 +265,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
     campaign.is_cancelled ||
     (now > campaign.deadline && campaign.amount_raised < campaign.funding_goal);
 
-  const refundableXlm = parseFloat(Number(stroopsToXlm(refundableAmount)).toString()) || 0;
+  const refundableXlm = stroopsToXlmNumber(refundableAmount) || 0;
 
 
   return (

--- a/src/app/[locale]/causes/[id]/opengraph-image.tsx
+++ b/src/app/[locale]/causes/[id]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from 'next/og';
 import { getCampaign } from '@/lib/contractClient';
-import { CATEGORY_LABELS, stroopsToXlm } from '@/types';
+import { CATEGORY_LABELS } from '@/types';
+import { stroopsToXlmNumber } from '@/lib/stellarAmount';
 
 export const runtime = 'edge';
 export const revalidate = 300; // Cache for 5 minutes
@@ -31,8 +32,8 @@ export default async function Image({ params }: { params: Promise<{ id: string; 
       throw new Error('Campaign not found');
     }
 
-    const raised = Number(stroopsToXlm(campaign.amount_raised));
-    const goal = Number(stroopsToXlm(campaign.funding_goal));
+    const raised = stroopsToXlmNumber(campaign.amount_raised);
+    const goal = stroopsToXlmNumber(campaign.funding_goal);
     const fundingPct = goal > 0 ? Math.min(100, Math.round((raised / goal) * 100)) : 0;
     const categoryLabel = CATEGORY_LABELS[campaign.category] ?? 'Other';
     const title = truncate(campaign.title || 'Untitled Campaign', 80);

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -7,7 +7,8 @@ import { useToast } from '@/components/ToastProvider';
 import { useWallet } from '@/components/WalletContext';
 import { useRouter } from '@/i18n/routing';
 import { createCampaign, getCampaignCount, type TransactionLifecyclePhase } from '@/lib/contractClient';
-import { Category, CATEGORY_LABELS, xlmToStroops } from '@/types';
+import { Category, CATEGORY_LABELS } from '@/types';
+import { xlmToStroops } from '@/lib/stellarAmount';
 import { parseContractError } from '@/utils/contractErrors';
 
 // ---------------------------------------------------------------------------

--- a/src/components/CampaignActions.tsx
+++ b/src/components/CampaignActions.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState, useCallback } from "react";
 import { useLocale } from "next-intl";
-import { Campaign, basisPointsToPercentage, xlmToStroops } from "../types";
+import { Campaign, basisPointsToPercentage } from "../types";
+import { xlmToStroops } from "@/lib/stellarAmount";
 import { formatAmount } from "@/lib/formatters";
 import AsyncButtonContent from "./AsyncButtonContent";
 import { useToast } from "./ToastProvider";

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -12,7 +12,6 @@ import {
   Vote,
   CATEGORY_LABELS,
   calculateFundingPercentage,
-  formatStroopsAsXlm,
 } from '../types';
 import AsyncButtonContent from './AsyncButtonContent';
 import CampaignStatusBadge from './CampaignStatusBadge';

--- a/src/components/DonationModal.tsx
+++ b/src/components/DonationModal.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { contribute } from "../lib/contractClient";
 import { getEstimatedContributeNetworkFeeXlm } from "../lib/networkFee";
-import { Campaign, xlmToStroops, formatStroopsAsXlm, basisPointsToPercentage } from "../types";
+import { Campaign, basisPointsToPercentage } from "../types";
+import { xlmToStroops, stroopsToXlmNumber } from "@/lib/stellarAmount";
+import { formatAmount } from "@/lib/formatters";
 import { useToast } from "./ToastProvider";
 import { useWallet } from "./WalletContext";
 import { usePlatformFee } from "../hooks/usePlatformFee";
@@ -106,8 +108,8 @@ export default function DonationModal({ campaign, onClose, onSuccess }: Donation
   }, [step, onClose]);
 
   const locale = useLocale();
-  const goal = Number(stroopsToXlm(campaign.funding_goal));
-  const raised = Number(stroopsToXlm(campaign.amount_raised));
+  const goal = stroopsToXlmNumber(campaign.funding_goal);
+  const raised = stroopsToXlmNumber(campaign.amount_raised);
 
   const validateAmount = (
     value: string,

--- a/src/components/MyContributionsSection.tsx
+++ b/src/components/MyContributionsSection.tsx
@@ -2,11 +2,11 @@
 
 import { Link } from "@/i18n/routing";
 import { useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { useContributions } from "../hooks/useContributions";
 import { claimRefund, claimRevenue } from "../lib/contractClient";
 import { explorerTxUrl } from "../utils/explorer";
-import { formatStroopsAsXlm } from "../types";
+import { formatAmount } from "@/lib/formatters";
 import { useToast } from "./ToastProvider";
 import { parseContractError } from "../utils/contractErrors";
 import type { WalletTransactionAction } from "../lib/transactionLog";
@@ -15,10 +15,6 @@ import type { ContributionHistoryItem } from "../hooks/useContributions";
 
 interface MyContributionsSectionProps {
   walletAddress: string;
-}
-
-function formatXlmAmount(value: bigint): string {
-  return formatStroopsAsXlm(value, { maximumFractionDigits: 7 });
 }
 
 type ContributionDisplayStatus = "active" | "refundable" | "revenue-claimable";
@@ -53,6 +49,9 @@ function getStatusClasses(status: ContributionDisplayStatus): string {
 
 export default function MyContributionsSection({ walletAddress }: MyContributionsSectionProps) {
   const t = useTranslations("MyContributions");
+  const locale = useLocale();
+  const formatXlmAmount = (value: bigint) =>
+    formatAmount(value, locale, { maximumFractionDigits: 7 });
   const { showError, showSuccess } = useToast();
   const [pendingCampaignId, setPendingCampaignId] = useState<number | null>(null);
   const [pendingAction, setPendingAction] = useState<"refund" | "revenue" | null>(null);

--- a/src/components/RevenueSharingPanel.tsx
+++ b/src/components/RevenueSharingPanel.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { FormEvent, useMemo, useState } from "react";
+import { useLocale } from "next-intl";
 import { claimRevenue, depositRevenue } from "../lib/contractClient";
 import {
   Campaign,
   Category,
   basisPointsToPercentage,
-  formatStroopsAsXlm,
-  xlmToStroops,
 } from "../types";
+import { xlmToStroops } from "@/lib/stellarAmount";
+import { formatAmount } from "@/lib/formatters";
 import { useToast } from "./ToastProvider";
 import { useWallet } from "./WalletContext";
 import { useRevenueSharing } from "../hooks/useRevenueSharing";
@@ -25,8 +26,8 @@ interface RevenueSharingPanelProps {
   onActionSuccess?: () => void;
 }
 
-function formatXlmAmount(value: bigint): string {
-  return formatStroopsAsXlm(value, { maximumFractionDigits: 4 });
+function formatXlmAmount(value: bigint, locale: string): string {
+  return formatAmount(value, locale, { maximumFractionDigits: 4 });
 }
 
 export default function RevenueSharingPanel({
@@ -36,6 +37,8 @@ export default function RevenueSharingPanel({
   showContributorControls = true,
   onActionSuccess,
 }: RevenueSharingPanelProps) {
+  const locale = useLocale();
+  const formatXlm = (value: bigint) => formatXlmAmount(value, locale);
   const { publicKey, connectWallet, isWalletConnected } = useWallet();
   const { showError, showSuccess, showWarning } = useToast();
   const [depositAmount, setDepositAmount] = useState("");
@@ -57,8 +60,8 @@ export default function RevenueSharingPanel({
       return "No contributor share is available until the campaign has raised funds.";
     }
 
-    return `${formatXlmAmount(contribution)} XLM contribution × ${formatXlmAmount(revenuePool)} XLM pool ÷ ${formatXlmAmount(campaign.amount_raised)} XLM raised = ${formatXlmAmount(contributorShare)} XLM`;
-  }, [campaign.amount_raised, contribution, contributorShare, revenuePool]);
+    return `${formatXlm(contribution)} XLM contribution × ${formatXlm(revenuePool)} XLM pool ÷ ${formatXlm(campaign.amount_raised)} XLM raised = ${formatXlm(contributorShare)} XLM`;
+  }, [campaign.amount_raised, contribution, contributorShare, locale, revenuePool]);
 
   const contributorSharePercentage = useMemo(() => {
     if (campaign.amount_raised <= BigInt(0)) {
@@ -151,7 +154,7 @@ export default function RevenueSharingPanel({
             <Tooltip content="The total amount of revenue that has been deposited into this campaign's revenue pool available for all contributors to claim." />
           </div>
           <p className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-            {formatXlmAmount(revenuePool)} XLM
+            {formatXlm(revenuePool)} XLM
           </p>
         </div>
         <div className="rounded-2xl bg-white/80 p-4 ring-1 ring-zinc-200 dark:bg-zinc-900/60 dark:ring-zinc-700">
@@ -162,7 +165,7 @@ export default function RevenueSharingPanel({
             <Tooltip content={`Your proportional share of the revenue pool based on your ${contributorSharePercentage}% contribution to the campaign. Calculated as: (your contribution ÷ total raised) × total pool.`} />
           </div>
           <p className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-            {formatXlmAmount(contributorShare)} XLM
+            {formatXlm(contributorShare)} XLM
           </p>
         </div>
         <div className="rounded-2xl bg-white/80 p-4 ring-1 ring-zinc-200 dark:bg-zinc-900/60 dark:ring-zinc-700">
@@ -173,7 +176,7 @@ export default function RevenueSharingPanel({
             <Tooltip content="The total amount of revenue you have already claimed from your share. This is deducted from your total share to calculate the claimable amount." />
           </div>
           <p className="mt-2 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-            {formatXlmAmount(claimed)} XLM
+            {formatXlm(claimed)} XLM
           </p>
         </div>
         <div className="rounded-2xl bg-white/80 p-4 ring-1 ring-zinc-200 dark:bg-zinc-900/60 dark:ring-zinc-700">
@@ -184,7 +187,7 @@ export default function RevenueSharingPanel({
             <Tooltip content="The amount of revenue you can claim right now. This is your share minus what you've already claimed." />
           </div>
           <p className="mt-2 text-xl font-semibold text-emerald-700 dark:text-emerald-300">
-            {formatXlmAmount(claimable)} XLM
+            {formatXlm(claimable)} XLM
           </p>
         </div>
       </div>
@@ -226,7 +229,7 @@ export default function RevenueSharingPanel({
               </p>
               <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                 {hasContribution
-                  ? `You contributed ${formatXlmAmount(contribution)} XLM to this campaign.`
+                  ? `You contributed ${formatXlm(contribution)} XLM to this campaign.`
                   : "You have not contributed to this campaign yet, so your claimable share is currently 0 XLM."}
               </p>
             </div>

--- a/src/components/WithdrawFunds.tsx
+++ b/src/components/WithdrawFunds.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { withdrawFunds } from "../lib/contractClient";
-import { Campaign, basisPointsToPercentage, formatStroopsAsXlm } from "../types";
+import { Campaign, basisPointsToPercentage } from "../types";
+import { formatNumber } from "@/lib/formatters";
+import { stroopsToXlmNumber } from "@/lib/stellarAmount";
 import { useToast } from "./ToastProvider";
 import { isSameAddress } from "../lib/stellar";
 import { parseContractError } from "../utils/contractErrors";
@@ -25,6 +27,7 @@ export default function WithdrawFunds({
   onWithdrawSuccess,
 }: WithdrawFundsProps) {
   const t = useTranslations("WithdrawFunds");
+  const locale = useLocale();
   const tContractErrors = useTranslations("ContractErrors");
   const [showConfirm, setShowConfirm] = useState(false);
   const [txHash, setTxHash] = useState<string | null>(null);
@@ -60,14 +63,13 @@ export default function WithdrawFunds({
           ? t("disabledStillActive")
           : null;
 
-  const totalRaisedStr = formatStroopsAsXlm(campaign.amount_raised, { maximumFractionDigits: 7 });
-  const totalRaised = parseFloat(totalRaisedStr);
+  const totalRaised = stroopsToXlmNumber(campaign.amount_raised);
   const feeAmount = totalRaised * (platformFeeBps / 10000);
   const creatorAmount = totalRaised - feeAmount;
   const feePct = basisPointsToPercentage(platformFeeBps);
 
   const formatXlm = (value: number) =>
-    value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+    formatNumber(value, locale, { maximumFractionDigits: 2, minimumFractionDigits: 0 });
 
   const handleWithdraw = async () => {
     setTxPhase(null);

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,4 +1,4 @@
-import { stroopsToXlm } from "../types";
+import { stroopsToXlm } from "@/lib/stellarAmount";
 
 /**
  * Locale-aware formatting utilities using Intl APIs.

--- a/src/lib/networkFee.ts
+++ b/src/lib/networkFee.ts
@@ -1,6 +1,5 @@
-import { formatStroopsAsXlm } from "@/types";
-
-const STROOPS_PER_XLM = 10_000_000n;
+import { formatAmount } from "@/lib/formatters";
+import { STROOPS_PER_XLM } from "@/lib/stellarAmount";
 
 /**
  * Conservative default for a single Soroban `contribute` invocation (stroops).
@@ -31,5 +30,5 @@ export function getEstimatedContributeNetworkFeeXlm(): number {
 }
 
 export function formatEstimatedNetworkFeeXlm(maximumFractionDigits = 7): string {
-  return formatStroopsAsXlm(getEstimatedContributeNetworkFeeStroops(), { maximumFractionDigits });
+  return formatAmount(getEstimatedContributeNetworkFeeStroops(), "en", { maximumFractionDigits });
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import { routing } from "@/i18n/routing";
 import type { Campaign } from "@/types";
-import { stroopsToXlm } from "@/types";
+import { stroopsToXlm } from "@/lib/stellarAmount";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://proofofheart.xyz";
 

--- a/src/lib/stellarAmount.ts
+++ b/src/lib/stellarAmount.ts
@@ -1,0 +1,52 @@
+/**
+ * Stellar XLM amount conversion (1 XLM = 10_000_000 stroops).
+ *
+ * Use stroopsToXlm / xlmToStroops for contract-safe bigint math.
+ * Use formatAmount from `@/lib/formatters` for locale-aware UI display.
+ *
+ * @see docs/STELLAR_AMOUNT.md
+ */
+
+export const STROOPS_PER_XLM = 10_000_000n;
+
+/**
+ * Convert stroops (i128) to a decimal XLM string without floating-point loss.
+ */
+export function stroopsToXlm(stroops: bigint): string {
+  const stroopsStr = stroops.toString();
+  if (stroopsStr.length <= 7) {
+    const padded = stroopsStr.padStart(7, "0");
+    const integerPart = "0";
+    const fractionalPart = padded.slice(-7);
+    const trimmedFractional = fractionalPart.replace(/0+$/, "");
+    return trimmedFractional.length > 0 ? `${integerPart}.${trimmedFractional}` : "0";
+  }
+
+  const integerPart = stroopsStr.slice(0, -7);
+  const fractionalPart = stroopsStr.slice(-7);
+  const trimmedFractional = fractionalPart.replace(/0+$/, "");
+  return trimmedFractional.length > 0 ? `${integerPart}.${trimmedFractional}` : integerPart;
+}
+
+/**
+ * Convert an XLM string to stroops (bigint) for contract calls.
+ */
+export function xlmToStroops(xlm: string): bigint {
+  const trimmed = xlm.trim();
+  if (!trimmed) return BigInt(0);
+
+  const parts = trimmed.split(".");
+  const integerPart = parts[0] || "0";
+  const fractionalPart = parts[1] || "";
+  const paddedFractional = fractionalPart.padEnd(7, "0").slice(0, 7);
+
+  return BigInt(integerPart + paddedFractional);
+}
+
+/**
+ * Parse stroops to a JS number for charts or comparisons where IEEE precision is acceptable.
+ * Prefer stroopsToXlm when serializing exact values (e.g. structured data).
+ */
+export function stroopsToXlmNumber(stroops: bigint): number {
+  return Number(stroopsToXlm(stroops));
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -122,48 +122,6 @@ export function deriveCampaignStatus(campaign: Campaign): CampaignStatus {
 }
 
 /**
- * Convert stroops (i128) to a string XLM value for display purposes.
- * This avoids precision loss from number conversion above 2^53.
- */
-export function stroopsToXlm(stroops: bigint): string {
-  const stroopsStr = stroops.toString();
-  if (stroopsStr.length <= 7) {
-    // Value is less than 1 XLM, pad with leading zeros
-    const padded = stroopsStr.padStart(7, '0');
-    const integerPart = '0';
-    const fractionalPart = padded.slice(-7);
-    // Remove trailing zeros
-    const trimmedFractional = fractionalPart.replace(/0+$/, '');
-    return trimmedFractional.length > 0 ? `${integerPart}.${trimmedFractional}` : '0';
-  } else {
-    const integerPart = stroopsStr.slice(0, -7);
-    const fractionalPart = stroopsStr.slice(-7);
-    // Remove trailing zeros
-    const trimmedFractional = fractionalPart.replace(/0+$/, '');
-    return trimmedFractional.length > 0 ? `${integerPart}.${trimmedFractional}` : integerPart;
-  }
-}
-
-/**
- * Convert an XLM string value to stroops (bigint) for contract calls.
- * This avoids precision loss from number conversion above 2^53.
- */
-export function xlmToStroops(xlm: string): bigint {
-  const trimmed = xlm.trim();
-  if (!trimmed) return BigInt(0);
-  
-  const parts = trimmed.split('.');
-  const integerPart = parts[0] || '0';
-  const fractionalPart = parts[1] || '';
-  
-  // Pad or truncate fractional part to exactly 7 digits (stroops precision)
-  const paddedFractional = fractionalPart.padEnd(7, '0').slice(0, 7);
-  
-  const combined = integerPart + paddedFractional;
-  return BigInt(combined);
-}
-
-/**
  * Calculate funding percentage using bigint arithmetic to avoid precision loss.
  * Returns a number between 0 and 100.
  */
@@ -172,19 +130,6 @@ export function calculateFundingPercentage(amountRaised: bigint, fundingGoal: bi
   // Use bigint arithmetic: (amountRaised * 100) / fundingGoal
   const percentage = (amountRaised * BigInt(100)) / fundingGoal;
   return Math.min(100, Number(percentage));
-}
-
-/**
- * Format a stroops bigint as a localized XLM string for display.
- */
-export function formatStroopsAsXlm(stroops: bigint, options?: Intl.NumberFormatOptions): string {
-  const xlmStr = stroopsToXlm(stroops);
-  const xlmNum = parseFloat(xlmStr);
-  return xlmNum.toLocaleString(undefined, {
-    maximumFractionDigits: 7,
-    minimumFractionDigits: 0,
-    ...options,
-  });
 }
 
 /**


### PR DESCRIPTION
## Summary
Centralizes Stellar stroops ↔ XLM conversion in `@/lib/stellarAmount` and routes all UI formatting through `formatAmount` in `@/lib/formatters`.

## Purpose / Motivation
Stroop conversion and XLM display logic were duplicated across `types`, components, and `networkFee`. A single tested module reduces drift and precision bugs.

## Changes Made
- Add `src/lib/stellarAmount.ts` with `STROOPS_PER_XLM`, `stroopsToXlm`, `xlmToStroops`, and `stroopsToXlmNumber`
- Add unit tests in `src/__tests__/lib/stellarAmount.test.ts` and `formatAmount` coverage in `formatters.test.ts`
- Remove conversion/format helpers from `src/types/index.ts`
- Migrate all call sites to `@/lib/stellarAmount` and `@/lib/formatters`
- Document usage in `docs/STELLAR_AMOUNT.md`

## How to Test
1. Run `npx jest src/__tests__/lib/stellarAmount.test.ts src/__tests__/lib/formatters.test.ts` — tests pass.
2. Open a cause detail page — raised/goal amounts and progress bar display correctly in en and es.
3. Contribute via donation modal — amount validation and progress labels format with locale.
4. Dashboard contributions and revenue panel — XLM amounts show with expected decimal precision.
5. Withdraw funds (creator, funded campaign) — fee breakdown numbers format correctly.

## Screenshots (if applicable)
N/A — no visual design changes.

## Breaking Changes
- None for users. Internal imports from `@/types` for `stroopsToXlm`, `xlmToStroops`, or `formatStroopsAsXlm` must use `@/lib/stellarAmount` / `@/lib/formatters` instead.

## Related Issues
Closes Iris-IV/ProofOfHeart-frontend#474

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)