### PR TITLE
feat(causes): category filter chips with live counts

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -223,6 +223,8 @@
     "labelSortBy": "Sort by",
     "all": "All",
     "allCategories": "All Categories",
+    "categoryChipAriaSelected": "{label}, {count} causes, selected",
+    "categoryChipAriaUnselected": "{label}, {count} causes",
     "allStatuses": "All Statuses",
     "clearFilters": "Clear filters",
     "clearAllFilters": "Clear all filters",

--- a/messages/es.json
+++ b/messages/es.json
@@ -223,6 +223,8 @@
     "labelSortBy": "Ordenar por",
     "all": "Todas",
     "allCategories": "Todas las Categorías",
+    "categoryChipAriaSelected": "{label}, {count} causas, seleccionada",
+    "categoryChipAriaUnselected": "{label}, {count} causas",
     "allStatuses": "Todos los Estados",
     "clearFilters": "Borrar filtros",
     "clearAllFilters": "Borrar todos los filtros",

--- a/src/__tests__/integration/CausesFilterUrlSync.test.tsx
+++ b/src/__tests__/integration/CausesFilterUrlSync.test.tsx
@@ -28,7 +28,17 @@ const mockCampaigns = [
 ];
 
 jest.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
+  useTranslations:
+    () => (key: string, values?: { label?: string; count?: number }) => {
+      if (key === "allCategories") return "All Categories";
+      if (key === "categoryChipAriaSelected") {
+        return `${values?.label}, ${values?.count} causes, selected`;
+      }
+      if (key === "categoryChipAriaUnselected") {
+        return `${values?.label}, ${values?.count} causes`;
+      }
+      return key;
+    },
 }));
 
 jest.mock("next/navigation", () => ({
@@ -87,8 +97,8 @@ describe("Causes filters URL sync", () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(<CausesClient />);
 
-    const [categorySelect, statusSelect, sortSelect] = screen.getAllByRole("combobox");
-    await user.selectOptions(categorySelect, "0");
+    const [statusSelect, sortSelect] = screen.getAllByRole("combobox");
+    await user.click(screen.getByRole("button", { name: "Learner, 1 causes" }));
     await user.selectOptions(statusSelect, "active");
     await user.selectOptions(sortSelect, "oldest");
     await user.type(screen.getByPlaceholderText("searchPlaceholder"), "science");
@@ -111,11 +121,26 @@ describe("Causes filters URL sync", () => {
     );
 
     render(<CausesClient />);
-    const [categorySelect, statusSelect, sortSelect] = screen.getAllByRole("combobox");
+    const [statusSelect, sortSelect] = screen.getAllByRole("combobox");
 
     expect(await screen.findByDisplayValue("astro")).toBeInTheDocument();
-    expect(categorySelect).toHaveValue("2");
+    expect(screen.getByRole("button", { name: "Educator, 0 causes, selected" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(statusSelect).toHaveValue("funded");
     expect(sortSelect).toHaveValue("most_funded");
+  });
+
+  it("shows live category counts on filter chips", () => {
+    render(<CausesClient />);
+
+    expect(screen.getByRole("button", { name: "All Categories, 1 causes, selected" })).toHaveTextContent(
+      "1",
+    );
+    expect(screen.getByRole("button", { name: "Learner, 1 causes" })).toHaveTextContent("1");
+    expect(screen.getByRole("button", { name: "Educational Startup, 0 causes" })).toHaveTextContent(
+      "0",
+    );
   });
 });

--- a/src/app/[locale]/causes/CausesClient.tsx
+++ b/src/app/[locale]/causes/CausesClient.tsx
@@ -31,6 +31,12 @@ const CATEGORY_ICONS: Record<Category, string> = {
   [Category.Publisher]: "📚",
 };
 
+const CATEGORY_VALUES = Object.values(Category).filter(
+  (value): value is Category => typeof value === "number",
+);
+
+type CategoryFilter = "all" | Category;
+
 function useDebounce<T>(value: T, delay: number): T {
   const [debounced, setDebounced] = useState(value);
   useEffect(() => {
@@ -248,6 +254,47 @@ function CausesContent() {
     setTag(nextTag);
   }, []);
 
+  const campaignsMatchingNonCategoryFilters = useMemo(() => {
+    let result = [...campaigns];
+
+    if (debouncedSearch.trim()) {
+      const q = debouncedSearch.toLowerCase();
+      result = result.filter(
+        (c) =>
+          c.title.toLowerCase().includes(q) ||
+          c.description.toLowerCase().includes(q) ||
+          (CATEGORY_LABELS[c.category] ?? "").toLowerCase().includes(q) ||
+          c.tags?.some((t) => t.toLowerCase().includes(q)),
+      );
+    }
+
+    if (status !== "all") result = result.filter((c) => c.status === status);
+    if (tag) result = result.filter((c) => c.tags?.includes(tag));
+
+    return result;
+  }, [campaigns, debouncedSearch, status, tag]);
+
+  const categoryCounts = useMemo(() => {
+    const perCategory = Object.fromEntries(
+      CATEGORY_VALUES.map((cat) => [cat, 0]),
+    ) as Record<Category, number>;
+
+    for (const campaign of campaignsMatchingNonCategoryFilters) {
+      perCategory[campaign.category] += 1;
+    }
+
+    return {
+      all: campaignsMatchingNonCategoryFilters.length,
+      ...perCategory,
+    };
+  }, [campaignsMatchingNonCategoryFilters]);
+
+  const isCategorySelected = useCallback(
+    (cat: CategoryFilter) =>
+      cat === "all" ? category === "all" : category === String(cat),
+    [category],
+  );
+
   // -------------------------------------------------------------------------
   // Filtering + sorting
   // -------------------------------------------------------------------------
@@ -392,26 +439,59 @@ function CausesContent() {
             )}
           </div>
 
+          {/* Category filter chips */}
+          {!isLoading && !error && (
+            <div
+              role="group"
+              aria-label={t("labelCategory")}
+              className="flex flex-wrap gap-2"
+            >
+              {(["all", ...CATEGORY_VALUES] as CategoryFilter[]).map((cat) => {
+                const selected = isCategorySelected(cat);
+                const count =
+                  cat === "all" ? categoryCounts.all : categoryCounts[cat as Category];
+                const label =
+                  cat === "all"
+                    ? t("allCategories")
+                    : `${CATEGORY_ICONS[cat]} ${CATEGORY_LABELS[cat]}`;
+                const accessibleName =
+                  cat === "all" ? t("allCategories") : CATEGORY_LABELS[cat as Category];
+
+                return (
+                  <button
+                    key={String(cat)}
+                    type="button"
+                    aria-pressed={selected}
+                    aria-label={t(
+                      selected ? "categoryChipAriaSelected" : "categoryChipAriaUnselected",
+                      { label: accessibleName, count },
+                    )}
+                    onClick={() => setCategory(cat === "all" ? "all" : String(cat))}
+                    className={`inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-800 ${
+                      selected
+                        ? "bg-blue-600 text-white"
+                        : "bg-zinc-100 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-600"
+                    }`}
+                  >
+                    <span aria-hidden="true">{label}</span>
+                    <span
+                      className={`tabular-nums text-xs font-semibold px-1.5 py-0.5 rounded-full ${
+                        selected
+                          ? "bg-blue-500 text-white"
+                          : "bg-zinc-200 dark:bg-zinc-600 text-zinc-600 dark:text-zinc-300"
+                      }`}
+                      aria-hidden="true"
+                    >
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
           {/* Filter row */}
           <div className="flex flex-wrap gap-3 items-center">
-            <div className="flex items-center gap-2">
-              <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
-                {t("labelCategory")}
-              </label>
-              <select
-                value={category}
-                onChange={(e) => setCategory(e.target.value)}
-                className="text-sm rounded-lg border border-zinc-200 dark:border-zinc-600 bg-zinc-50 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="all">{t("allCategories")}</option>
-                {Object.entries(CATEGORY_LABELS).map(([val, label]) => (
-                  <option key={val} value={val}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
             <div className="flex items-center gap-2">
               <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
                 {t("labelStatus")}
@@ -456,32 +536,6 @@ function CausesContent() {
             )}
           </div>
         </div>
-
-        {/* Category pills */}
-        {!isLoading && !error && (
-          <div className="flex flex-wrap gap-2 mb-6">
-            {(
-              ["all", ...Object.values(Category).filter((v) => typeof v === "number")] as (
-                | "all"
-                | Category
-              )[]
-            ).map((cat) => (
-              <button
-                key={String(cat)}
-                onClick={() => setCategory(cat === "all" ? "all" : String(cat))}
-                className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
-                  (cat === "all" ? category === "all" : category === String(cat))
-                    ? "bg-blue-600 text-white"
-                    : "bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700"
-                }`}
-              >
-                {cat === "all"
-                  ? t("all")
-                  : `${CATEGORY_ICONS[cat as Category]} ${CATEGORY_LABELS[cat as Category]}`}
-              </button>
-            ))}
-          </div>
-        )}
 
         {/* Error state */}
         {error && (

--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -4,26 +4,26 @@ import { useLocale } from "next-intl";
 import { formatAmount, type FormatAmountOptions } from "@/lib/formatters";
 
 interface AmountProps extends FormatAmountOptions {
-    value: bigint;
-    locale?: string;
-    className?: string;
+  value: bigint;
+  locale?: string;
+  className?: string;
 }
 
 export default function Amount({
-    value,
-    locale,
-    maximumFractionDigits,
-    minimumFractionDigits,
-    className,
+  value,
+  locale,
+  maximumFractionDigits,
+  minimumFractionDigits,
+  className,
 }: AmountProps) {
-    const resolvedLocale = locale ?? useLocale();
+  const resolvedLocale = locale ?? useLocale();
 
-    return (
-        <span className={className}>
-            {formatAmount(value, resolvedLocale, {
-                maximumFractionDigits,
-                minimumFractionDigits,
-            })}
-        </span>
-    );
+  return (
+    <span className={className}>
+      {formatAmount(value, resolvedLocale, {
+        maximumFractionDigits,
+        minimumFractionDigits,
+      })}
+    </span>
+  );
 }

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -14,6 +14,7 @@ import {
   calculateFundingPercentage,
   formatStroopsAsXlm,
 } from '../types';
+import Amount from './Amount';
 import AsyncButtonContent from './AsyncButtonContent';
 import CampaignStatusBadge from './CampaignStatusBadge';
 import CancelCampaignModal from './cancelCampaignModal';

--- a/src/components/FundingProgressBar.tsx
+++ b/src/components/FundingProgressBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useEffect, useRef, useState, useId } from "react";
 import { useLocale } from "next-intl";
 import { motion, useSpring, useTransform } from "framer-motion";


### PR DESCRIPTION
## Summary
Adds category filter chips with live counts on `/causes`, replacing the category dropdown. Chips reflect the on-chain `Category` enum, update counts as search/status/tag filters change, sync selection to the URL, and use toggle button semantics for accessibility.

## Purpose / Motivation
Issue #478 — help users discover causes by category with visible counts instead of a plain select control.

## Changes Made
- Compute per-category counts from campaigns matching non-category filters (search, status, tag).
- Render filter chips for All + Learner, Educational Startup, Educator, Publisher with count badges.
- Remove redundant category `<select>`; status and sort dropdowns unchanged.
- Chips use `role="group"`, `aria-pressed`, and descriptive `aria-label` strings (i18n en/es).
- Update `CausesFilterUrlSync` tests for chip interaction and live counts.

## How to Test
1. Open `/causes` with mock or live campaigns loaded.
2. Confirm five chips appear (All Categories + four enum values) each showing a count.
3. Click a category chip — list filters to that category and URL gains `?category=<n>`.
4. Click All Categories — filter clears and `category` param is removed from URL.
5. Apply search/status filters — chip counts update without changing the selected chip.
6. Reload with `?category=1` — Educational Startup chip is pressed/selected.
7. Tab to chips and activate with keyboard; verify focus ring and screen reader labels.

## Breaking Changes
- None.

## Related Issues
Closes Iris-IV/ProofOfHeart-frontend#478

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated