### PR TITLE
fix(seo): include dynamic cause-detail URLs in sitemap

### DIFF
--- a/src/__tests__/app/sitemap.test.ts
+++ b/src/__tests__/app/sitemap.test.ts
@@ -1,0 +1,58 @@
+jest.mock("@/lib/contractClient", () => ({
+  getAllCampaigns: jest.fn(),
+}));
+
+jest.mock("@/i18n/routing", () => ({
+  routing: { locales: ["en", "es"], defaultLocale: "en" },
+}));
+
+jest.mock("@/lib/seo", () => ({
+  absoluteUrl: (path: string) =>
+    `https://example.test${path.startsWith("/") ? path : `/${path}`}`,
+}));
+
+import sitemap from "@/app/sitemap";
+import { getAllCampaigns } from "@/lib/contractClient";
+
+const mockedGetAllCampaigns = getAllCampaigns as jest.MockedFunction<typeof getAllCampaigns>;
+
+describe("sitemap", () => {
+  beforeEach(() => {
+    mockedGetAllCampaigns.mockReset();
+  });
+
+  it("includes cause detail URLs for each locale", async () => {
+    mockedGetAllCampaigns.mockResolvedValue([
+      {
+        id: 42,
+        created_at: 1_700_000_000,
+      } as Awaited<ReturnType<typeof getAllCampaigns>>[number],
+    ]);
+
+    const entries = await sitemap();
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        url: "https://example.test/en/causes/42",
+        changeFrequency: "hourly",
+        priority: 0.9,
+      }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        url: "https://example.test/es/causes/42",
+        changeFrequency: "hourly",
+        priority: 0.9,
+      }),
+    );
+  });
+
+  it("returns static routes when campaign fetch fails", async () => {
+    mockedGetAllCampaigns.mockRejectedValue(new Error("rpc down"));
+
+    const entries = await sitemap();
+
+    expect(entries.some((e) => e.url === "https://example.test/en/causes")).toBe(true);
+    expect(entries.filter((e) => /\/causes\/\d+$/.test(e.url))).toHaveLength(0);
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,23 +1,32 @@
 import { MetadataRoute } from "next";
-
-const BASE_URL = "https://proofofheart.org";
-const LOCALES = ["en", "es"];
+import { getAllCampaigns } from "@/lib/contractClient";
+import { absoluteUrl } from "@/lib/seo";
+import { routing } from "@/i18n/routing";
 
 // Static routes to include in the sitemap.
 // All paths are relative — the sitemap builder prepends /${locale} for each locale.
 // Do NOT include non-localized bare paths here; canonical URLs are locale-prefixed.
 const STATIC_ROUTES = ["", "/causes", "/causes/new", "/about", "/dashboard"];
 
-async function getCampaignIds(): Promise<number[]> {
+/** Caps dynamic URLs so sitemap generation stays bounded as campaign count grows. */
+const MAX_CAMPAIGN_SITEMAP_URLS = 10_000;
+
+async function getCampaignSitemapEntries(): Promise<
+  Pick<MetadataRoute.Sitemap[number], "url" | "lastModified" | "changeFrequency" | "priority">[]
+> {
   try {
-    const res = await fetch(`${BASE_URL}/api/campaigns`, {
-      next: { revalidate: 3600 },
-    });
-    if (!res.ok) return [];
-    const data = await res.json();
-    return data.map((c: { id: number }) => c.id);
+    const campaigns = await getAllCampaigns();
+    const capped = campaigns.slice(0, MAX_CAMPAIGN_SITEMAP_URLS);
+
+    return capped.flatMap((campaign) =>
+      routing.locales.map((locale) => ({
+        url: absoluteUrl(`/${locale}/causes/${campaign.id}`),
+        lastModified: new Date(campaign.created_at * 1000),
+        changeFrequency: "hourly" as const,
+        priority: 0.9,
+      })),
+    );
   } catch {
-    // If the API is unreachable during build, return empty array
     return [];
   }
 }
@@ -25,25 +34,14 @@ async function getCampaignIds(): Promise<number[]> {
 export const revalidate = 3600;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const campaignIds = await getCampaignIds();
+  const campaignEntries = await getCampaignSitemapEntries();
 
-  // Build static routes for all locales
   const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.flatMap((route) =>
-    LOCALES.map((locale) => ({
-      url: `${BASE_URL}/${locale}${route}`,
+    routing.locales.map((locale) => ({
+      url: absoluteUrl(`/${locale}${route}`),
       lastModified: new Date(),
       changeFrequency: "daily" as const,
       priority: route === "" ? 1 : 0.8,
-    })),
-  );
-
-  // Build dynamic campaign routes for all locales
-  const campaignEntries: MetadataRoute.Sitemap = campaignIds.flatMap((id) =>
-    LOCALES.map((locale) => ({
-      url: `${BASE_URL}/${locale}/causes/${id}`,
-      lastModified: new Date(),
-      changeFrequency: "hourly" as const,
-      priority: 0.9,
     })),
   );
 


### PR DESCRIPTION
## Summary
Adds dynamic cause-detail URLs to the sitemap by loading campaigns through the existing contract client (live Soroban or mock data), with a bounded cap for large lists.

## Purpose / Motivation
Search engines only discovered static routes; `/causes/[id]` pages were missing from `sitemap.xml`. The previous implementation fetched a non-existent `/api/campaigns` endpoint on production, so dynamic URLs were never emitted and mock/local builds could not populate the sitemap.

## Changes Made
- Resolve campaign IDs via `getAllCampaigns()` so mock and live modes share the same code path as the rest of the app.
- Emit per-locale URLs using `routing.locales` and `absoluteUrl()` for consistent site base URL handling.
- Cap dynamic entries at 10,000 campaigns to keep sitemap generation predictable as the on-chain list grows.
- Use each campaign's `created_at` for `lastModified` on detail URLs.
- Add unit tests for locale expansion and graceful degradation when campaign loading fails.

## How to Test
1. Set `NEXT_PUBLIC_USE_MOCKS=true` and `NEXT_PUBLIC_SITE_URL=http://localhost:3000`, then run `npm run dev`.
2. Open `http://localhost:3000/sitemap.xml` and confirm entries such as `/en/causes/1` and `/es/causes/1` for mock campaign IDs.
3. Set `NEXT_PUBLIC_USE_MOCKS=false` with a valid `NEXT_PUBLIC_CONTRACT_ADDRESS` and RPC URL; reload `sitemap.xml` and confirm live campaign IDs appear.
4. Run `npx jest src/__tests__/app/sitemap.test.ts`.

## Breaking Changes
None.

## Related Issues
Closes Iris-IV/ProofOfHeart-frontend#470

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors