### PR TITLE
docs: Add Terms of Service and Privacy Policy pages

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,43 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | Proof of Heart',
+  description: 'Privacy Policy covering wallet addresses and analytics for Proof of Heart.',
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-4xl">
+      <h1 className="text-4xl font-bold mb-6">Privacy Policy</h1>
+      <p className="text-gray-500 mb-8">Last updated: {new Date().toLocaleDateString()}</p>
+
+      <div className="prose prose-slate max-w-none">
+        <h2>1. Overview</h2>
+        <p>
+          At Proof of Heart, we prioritize your privacy. As an on-chain, non-custodial platform, we minimize the data we collect. This Privacy Policy outlines how we handle data related to wallet addresses, analytics, and off-chain stores.
+        </p>
+
+        <h2>2. Data We Collect</h2>
+        <h3>a. Public Blockchain Data</h3>
+        <p>
+          We interact with the Stellar blockchain. Your public wallet address, transaction history, and interactions with our smart contracts are public by nature and not controlled by us. We use this public data to render the user interface and track campaign progress.
+        </p>
+
+        <h3>b. Analytics and Off-Chain Data</h3>
+        <p>
+          We may collect anonymous usage data to improve our platform (e.g., page views, button clicks). This data does not personally identify you. Any off-chain data (such as campaign descriptions stored in IPFS or centralized databases) is retained as long as the campaign is active.
+        </p>
+
+        <h2>3. Data Retention</h2>
+        <p>
+          Public blockchain data is permanent. Off-chain analytics data is retained for up to 12 months for product improvement purposes. Campaign metadata is retained indefinitely to maintain historical records of fundraising.
+        </p>
+
+        <h2>4. Third-Party Services</h2>
+        <p>
+          We use external RPC providers and analytics tools. These third parties have their own privacy policies. We do not share personally identifiable information with them.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service | Proof of Heart',
+  description: 'Terms of Service for the Proof of Heart fundraising platform.',
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-4xl">
+      <h1 className="text-4xl font-bold mb-6">Terms of Service</h1>
+      <p className="text-gray-500 mb-8">Last updated: {new Date().toLocaleDateString()}</p>
+
+      <div className="prose prose-slate max-w-none">
+        <h2>1. Introduction</h2>
+        <p>
+          Welcome to Proof of Heart. By accessing or using our non-custodial, on-chain fundraising platform, you agree to comply with and be bound by these Terms of Service.
+        </p>
+
+        <h2>2. Non-Custodial Nature</h2>
+        <p>
+          Proof of Heart is a non-custodial platform. We do not hold, manage, or have access to your private keys or the funds transacted on the platform. All transactions occur directly on the Stellar blockchain via smart contracts. You are solely responsible for the security of your wallet and funds.
+        </p>
+
+        <h2>3. Smart Contracts</h2>
+        <p>
+          Interactions with the platform involve executing smart contracts on the blockchain. While we strive to ensure the security and reliability of our contracts, blockchain technology involves inherent risks. We are not liable for any losses resulting from contract vulnerabilities or network failures.
+        </p>
+
+        <h2>4. User Responsibilities</h2>
+        <p>
+          You agree to use the platform in compliance with all applicable laws and regulations. You must not use the platform for any illegal activities, including but not limited to money laundering, fraud, or financing illicit acts.
+        </p>
+
+        <h2>5. Limitation of Liability</h2>
+        <p>
+          To the maximum extent permitted by law, Proof of Heart and its contributors shall not be liable for any direct, indirect, incidental, or consequential damages arising out of your use of or inability to use the platform.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -82,6 +82,30 @@ export default function Footer() {
                 </li>
               </ul>
             </div>
+
+            <div>
+              <h2 className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">
+                Legal
+              </h2>
+              <ul className="mt-3 space-y-2 text-sm">
+                <li>
+                  <Link
+                    href="/terms"
+                    className="text-zinc-600 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-50"
+                  >
+                    Terms of Service
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/privacy"
+                    className="text-zinc-600 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-50"
+                  >
+                    Privacy Policy
+                  </Link>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Overview
This PR adds the necessary legal documentation for the Proof of Heart platform, emphasizing our non-custodial and on-chain nature.

## Changes Included
- **Terms of Service (#501):** Added a new `/terms` route containing the Terms of Service tailored for an on-chain, non-custodial fundraising platform.
- **Privacy Policy (#502):** Added a new `/privacy` route explaining data collection practices, retention policies, and public blockchain visibility.
- **Footer Links:** Updated the application footer to include a new "Legal" section with links to both documents.

Fixes #501
Fixes #502
Fixes #503 