### PR TITLE
feat: fetch real-time network fee from Soroban RPC

### DIFF
--- a/src/components/DonationModal.tsx
+++ b/src/components/DonationModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslations, useLocale } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
 import { contribute } from "../lib/contractClient";
 import { getEstimatedContributeNetworkFeeXlm } from "../lib/networkFee";
 import { Campaign, basisPointsToPercentage } from "../types";
@@ -45,7 +46,11 @@ export default function DonationModal({ campaign, onClose, onSuccess }: Donation
   const { publicKey } = useWallet();
   const { showError } = useToast();
   const { platformFeeBps } = usePlatformFee();
-  const estimatedNetworkFeeXlm = useMemo(() => getEstimatedContributeNetworkFeeXlm(), []);
+  const { data: estimatedNetworkFeeXlm = 0.01 } = useQuery({
+    queryKey: ["networkFee"],
+    queryFn: getEstimatedContributeNetworkFeeXlm,
+    staleTime: 30_000,
+  });
 
   const [amount, setAmount] = useState("");
   const [step, setStep] = useState<Step>("input");

--- a/src/lib/networkFee.ts
+++ b/src/lib/networkFee.ts
@@ -1,5 +1,6 @@
 import { formatAmount } from "@/lib/formatters";
 import { STROOPS_PER_XLM } from "@/lib/stellarAmount";
+import * as StellarSdk from "@stellar/stellar-sdk";
 
 /**
  * Conservative default for a single Soroban `contribute` invocation (stroops).
@@ -7,6 +8,42 @@ import { STROOPS_PER_XLM } from "@/lib/stellarAmount";
  * Override via NEXT_PUBLIC_ESTIMATED_CONTRIBUTE_NETWORK_FEE_STROOPS when fee-bump strategy changes.
  */
 export const DEFAULT_CONTRIBUTE_NETWORK_FEE_STROOPS = 100_000n;
+
+const SOROBAN_RPC_URL =
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ??
+  process.env.NEXT_PUBLIC_RPC_URL ??
+  "https://soroban-testnet.stellar.org";
+
+let _server: StellarSdk.rpc.Server | null = null;
+
+function getServer(): StellarSdk.rpc.Server {
+  if (!_server) {
+    _server = new StellarSdk.rpc.Server(SOROBAN_RPC_URL);
+  }
+  return _server;
+}
+
+let cachedFeeStroops: bigint | null = null;
+let lastFetchedAt: number = 0;
+const CACHE_TTL_MS = 30_000;
+
+async function fetchFeeStats(): Promise<void> {
+  const now = Date.now();
+  if (cachedFeeStroops && now - lastFetchedAt < CACHE_TTL_MS) {
+    return;
+  }
+
+  try {
+    const server = getServer();
+    const feeStats = await server.getFeeStats();
+    const p90Fee = feeStats.feeCharged?.p90 ?? DEFAULT_CONTRIBUTE_NETWORK_FEE_STROOPS.toString();
+    cachedFeeStroops = BigInt(p90Fee);
+    lastFetchedAt = now;
+  } catch {
+    cachedFeeStroops = DEFAULT_CONTRIBUTE_NETWORK_FEE_STROOPS;
+    lastFetchedAt = now;
+  }
+}
 
 function parseEnvFeeStroops(): bigint | null {
   const raw = process.env.NEXT_PUBLIC_ESTIMATED_CONTRIBUTE_NETWORK_FEE_STROOPS;
@@ -20,15 +57,20 @@ function parseEnvFeeStroops(): bigint | null {
 }
 
 /** Estimated network fee (stroops) debited from the contributor's account for a contribute tx. */
-export function getEstimatedContributeNetworkFeeStroops(): bigint {
-  return parseEnvFeeStroops() ?? DEFAULT_CONTRIBUTE_NETWORK_FEE_STROOPS;
+export async function getEstimatedContributeNetworkFeeStroops(): Promise<bigint> {
+  const envFee = parseEnvFeeStroops();
+  if (envFee) {
+    return envFee;
+  }
+  await fetchFeeStats();
+  return cachedFeeStroops ?? DEFAULT_CONTRIBUTE_NETWORK_FEE_STROOPS;
 }
 
 /** Estimated network fee in XLM for display. */
-export function getEstimatedContributeNetworkFeeXlm(): number {
-  return Number(getEstimatedContributeNetworkFeeStroops()) / Number(STROOPS_PER_XLM);
+export async function getEstimatedContributeNetworkFeeXlm(): Promise<number> {
+  return Number(await getEstimatedContributeNetworkFeeStroops()) / Number(STROOPS_PER_XLM);
 }
 
-export function formatEstimatedNetworkFeeXlm(maximumFractionDigits = 7): string {
-  return formatAmount(getEstimatedContributeNetworkFeeStroops(), "en", { maximumFractionDigits });
+export async function formatEstimatedNetworkFeeXlm(maximumFractionDigits = 7): Promise<string> {
+  return formatAmount(await getEstimatedContributeNetworkFeeStroops(), "en", { maximumFractionDigits });
 }


### PR DESCRIPTION
- Fetch p90 fee stats from Soroban RPC
- Cache for 30 seconds
- Update DonationModal to use useQuery for async fee fetch

## Summary

<!-- Briefly describe what changed and why. -->

Closes #

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Chore / maintenance
- [ ] Documentation
- [ ] Test coverage

## Contributor Checklist

- [ ] Linked the related issue above.
- [ ] Reviewed `CONTRIBUTING.md` for branch, commit, and PR title conventions.
- [ ] Confirmed this follows the current Stellar Wave contribution flow, if applicable.
- [ ] Added or updated tests when behavior changed.
- [ ] Updated docs, examples, or translations when needed.

## Validation

- [ ] `npm run lint`
- [ ] `npm run format:check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] Not run; reason:

## Notes for Reviewers

<!-- Add screenshots, rollout notes, known limitations, or anything that helps review. -->

closes #618