### PR TITLE
[Security] Inject rel='noopener noreferrer' into markdown-rendered links (#627)

### DIFF
--- a/src/components/SafeMarkdown.tsx
+++ b/src/components/SafeMarkdown.tsx
@@ -1,11 +1,20 @@
 "use client";
 
+import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { buildMarkdownSanitizeSchema } from "@/lib/markdownSanitizeSchema";
 
 const markdownSanitizeSchema = buildMarkdownSanitizeSchema(defaultSchema);
+
+const linkComponents: Components = {
+  a: ({ node, children, ...props }) => (
+    <a target="_blank" rel="noopener noreferrer" {...props}>
+      {children}
+    </a>
+  ),
+};
 
 interface SafeMarkdownProps {
   children: string;
@@ -14,6 +23,8 @@ interface SafeMarkdownProps {
 
 /**
  * Renders untrusted markdown with GFM and a hardened rehype-sanitize schema.
+ * All external links automatically get rel="noopener noreferrer" and target="_blank"
+ * to prevent reverse tabnabbing.
  */
 export default function SafeMarkdown({ children, className }: SafeMarkdownProps) {
   return (
@@ -21,6 +32,7 @@ export default function SafeMarkdown({ children, className }: SafeMarkdownProps)
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[[rehypeSanitize, markdownSanitizeSchema]]}
+        components={linkComponents}
       >
         {children}
       </ReactMarkdown>


### PR DESCRIPTION
## Summary

Fixes #627 by configuring the markdown renderer to automatically inject `rel="noopener noreferrer"` and `target="_blank"` into all rendered `<a>` tags.

## Problem

User-supplied markdown descriptions (e.g., campaign descriptions) are rendered using `react-markdown` with `rehype-sanitize`. Previously, links in markdown were rendered without `rel="noopener noreferrer"`, exposing the app to **reverse tabnabbing** attacks where a linked site could control the referring page via `window.opener`.

## Solution

Added a custom `components` override in `SafeMarkdown.tsx` that wraps the default anchor rendering with:

- `target="_blank"` — opens external links in a new tab
- `rel="noopener noreferrer"` — prevents the linked page from accessing `window.opener` and strips referrer info

The sanitizer schema already allows `rel` and `target` attributes on `a` elements by default via `hast-util-sanitize`, so no changes to the sanitizer were needed.

## Changes

| File | Change |
|---|---|
| `src/components/SafeMarkdown.tsx` | Added `components` prop with custom `a` renderer injecting `target="_blank"` and `rel="noopener noreferrer"` |

## Testing

- ✅ All existing SafeMarkdown tests pass
- ✅ TypeScript type-check passes (no errors)
- ✅ ESLint passes (no new warnings)

## Related

Closes #627