### PR TITLE
[Performance] Load Inter via next/font with font-display: swap and preload (#623)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
+import { Inter } from "next/font/google";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
@@ -17,6 +18,12 @@ import { getTextDirection } from "@/lib/direction";
 import { getThemeBlockingScript } from "@/lib/preferences";
 import type { Metadata } from "next";
 import "../globals.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+});
 
 // #138 — Pre-render locale shells at build time so /en and /es appear in the
 // static-pages section of the build output instead of being dynamic routes.
@@ -89,7 +96,7 @@ export default async function RootLayout({
           }}
         />
       </head>
-      <body className="antialiased">
+      <body className={`${inter.variable} antialiased`}>
         <NextIntlClientProvider messages={messages} locale={locale}>
           <a
             href="#main"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,8 +14,8 @@ html.dark {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans:
-    "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+    var(--font-inter), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono:
     ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }


### PR DESCRIPTION
## Summary

Fixes #623 by loading the Inter typeface via `next/font/google` with `display: 'swap'` and a CSS variable. Next.js auto-generates preload `<link>` tags and `@font-face` rules with `font-display: swap`, eliminating the flash of invisible text (FOIT) that previously occurred.

## Problem

The `globals.css` declared `Inter` as the primary font family in the `--font-sans` CSS variable, but **Inter was never actually loaded** — no `@font-face` rules, no Google Fonts import, no `next/font` configuration, and no font files existed in the repository. The browser always fell back to the system font stack.

Even if Inter had been loaded via a traditional `<link>` tag or `@import`, it would have blocked rendering until downloaded, causing a flash of invisible text (FOIT) and negatively impacting Largest Contentful Paint (LCP).

## Solution

Used Next.js's built-in font optimization (`next/font/google`) to load Inter with:

- **`display: 'swap'`** — renders text in a fallback font immediately while Inter loads, eliminating FOIT
- **`variable: '--font-inter'`** — sets a CSS custom property so the font can be referenced in the existing `--font-sans` stack
- **Self-hosted at build time** — Next.js downloads the font file during `next build` and serves it from `/_next/static/media/` with immutable caching, so no CSP changes were needed

The `next/font` integration automatically:
1. Adds `<link rel="preload" as="font" ...>` tags in the `<head>` so the font is discovered early
2. Inlines `@font-face` rules with `font-display: swap`
3. Generates a unique class name for cache-busting

## Changes

| File | Change |
|---|---|
| `src/app/[locale]/layout.tsx` | Added `Inter` import from `next/font/google` with `display: 'swap'` and `variable: '--font-inter'`; applied `inter.variable` class to `<body>` |
| `src/app/globals.css` | Changed `--font-sans` from bare `"Inter"` to `var(--font-inter)` so it resolves to the loaded font |

## Testing

- ✅ TypeScript type-check passes (no errors)
- ✅ ESLint passes (no new warnings)
- ✅ CSP `font-src 'self' data:` is sufficient (Next.js self-hosts font files)
- ✅ Inter will now render as the actual typeface instead of the system fallback

## Related

Closes #623