### PR TITLE
feat: add multi-wallet adapter system (Freighter, LOBSTR, xBull)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dmystical-coder/fundstacks-headless-sdk": "^0.2.0",
+        "@lobstrco/signer-extension-api": "2.0.0",
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^15.1.0",
         "@tanstack/react-query": "^5.100.14",
@@ -2885,6 +2886,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lobstrco/signer-extension-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lobstrco/signer-extension-api/-/signer-extension-api-2.0.0.tgz",
+      "integrity": "sha512-jwlVyzMFF296iaNgMWn1lu+EU6BeUD4mgPurEsy8EygYNCrjA8igLpsDlXhfvXhst9tX5w4wRuTDX+FZtpfCug==",
+      "license": "GPL-3.0"
     },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@dmystical-coder/fundstacks-headless-sdk": "^0.2.0",
+    "@lobstrco/signer-extension-api": "2.0.0",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^15.1.0",
     "@tanstack/react-query": "^5.100.14",

--- a/src/components/WalletContext.tsx
+++ b/src/components/WalletContext.tsx
@@ -1,241 +1,296 @@
 "use client";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import {
-  getAddress,
-  getNetwork,
-  isConnected,
-  isAllowed,
-  WatchWalletChanges,
-} from "@stellar/freighter-api";
+import { getNetwork } from "@stellar/freighter-api";
 import React, { createContext, useContext, useEffect, useState, ReactNode, useRef } from "react";
 import { useToast } from "./ToastProvider";
 import { useQueryClient } from "@tanstack/react-query";
 import { IS_MOCK_MODE } from "@/lib/runtimeEnv";
-import InstallFreighterModal from "./InstallFreighterModal";
+import { getAdapter, ALL_ADAPTERS } from "@/lib/walletAdapters";
+import type { WalletId } from "@/lib/walletAdapters";
+import WalletSelectModal from "./WalletSelectModal";
+
+// ---------------------------------------------------------------------------
+// Context type
+// ---------------------------------------------------------------------------
 
 interface WalletContextType {
   publicKey: string | null;
   isWalletConnected: boolean;
   walletNetworkWarning: string | null;
+  /** ID of the currently active wallet adapter, or null if not connected. */
+  activeWalletId: WalletId | null;
   connectWallet: () => Promise<void>;
   disconnectWallet: () => void;
   isLoading: boolean;
+  /**
+   * Signs a Stellar transaction XDR using the active wallet adapter.
+   *
+   * @param xdr               Base64-encoded transaction envelope XDR.
+   * @param networkPassphrase Stellar network passphrase.
+   * @returns Signed XDR string.
+   * @throws if no wallet is connected or the user rejects the signature.
+   */
+  signTransaction: (xdr: string, networkPassphrase: string) => Promise<string>;
 }
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WALLET_ID_STORAGE_KEY = "stellar_wallet_id";
+const PUBLIC_KEY_STORAGE_KEY = "stellar_wallet_public_key";
 
 const MOCK_PUBLIC_KEY = IS_MOCK_MODE ? StellarSdk.Keypair.random().publicKey() : null;
 
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
 
 export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [isWalletConnected, setIsWalletConnected] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
   const [walletNetworkWarning, setWalletNetworkWarning] = useState<string | null>(null);
+  const [activeWalletId, setActiveWalletId] = useState<WalletId | null>(null);
+
+  // Modal state
+  const [showSelectModal, setShowSelectModal] = useState(false);
+  const [connectingId, setConnectingId] = useState<WalletId | null>(null);
+
   const { showError, showWarning, showSuccess } = useToast();
   const queryClient = useQueryClient();
   const previousPublicKeyRef = useRef<string | null>(null);
-  const appNetworkPassphrase = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE || "";
+
+  const appNetworkPassphrase = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "";
   const appNetworkLabel = appNetworkPassphrase.includes("Public Global")
     ? "Mainnet"
     : appNetworkPassphrase.includes("Test SDF")
       ? "Testnet"
       : "the app network";
 
-  useEffect(() => {
-    if (IS_MOCK_MODE) {
-      const storedKey =
-        typeof window !== "undefined" ? localStorage.getItem("stellar_wallet_public_key") : null;
-      if (storedKey) {
-        setPublicKey(storedKey);
-        setIsWalletConnected(true);
-        previousPublicKeyRef.current = storedKey;
-      }
-      setWalletNetworkWarning(null);
-      return;
-    }
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
 
-    // Always re-verify with Freighter rather than blindly trusting localStorage (#97)
-    void checkWalletConnection();
-
-    const watcher = new WatchWalletChanges(1000);
-    watcher.watch(() => {
-      void checkWalletConnection();
-    });
-
-    return () => {
-      watcher.stop();
-    };
-  }, []);
-
-  const checkWalletConnection = async () => {
-    if (IS_MOCK_MODE) {
-      const storedKey =
-        typeof window !== "undefined" ? localStorage.getItem("stellar_wallet_public_key") : null;
-      if (storedKey) {
-        setPublicKey(storedKey);
-        setIsWalletConnected(true);
-        previousPublicKeyRef.current = storedKey;
-      } else {
-        setPublicKey(null);
-        setIsWalletConnected(false);
-      }
-      setWalletNetworkWarning(null);
-      return;
-    }
-
-    try {
-      const connected = await isConnected();
-      const allowed = await isAllowed();
-      if (connected && allowed) {
-        const key = await getAddress();
-        const network = await getNetwork();
-        const walletNetworkPassphrase = network.networkPassphrase || "";
-
-        if (walletNetworkPassphrase !== appNetworkPassphrase) {
-          setPublicKey(null);
-          setIsWalletConnected(false);
-          setWalletNetworkWarning(
-            `Switch Freighter to ${appNetworkLabel} to continue. Current wallet network does not match the app network.`,
-          );
-          localStorage.removeItem("stellar_wallet_public_key");
-          // Invalidate queries on network mismatch
-          invalidateWalletQueries();
-          return;
-        }
-
-        setWalletNetworkWarning(null);
-        const newPublicKey = key.address;
-        setPublicKey(newPublicKey);
-        setIsWalletConnected(true);
-        localStorage.setItem("stellar_wallet_public_key", newPublicKey);
-
-        // Detect account change and invalidate wallet-scoped queries
-        if (
-          previousPublicKeyRef.current !== null &&
-          previousPublicKeyRef.current !== newPublicKey
-        ) {
-          invalidateWalletQueries();
-        }
-        previousPublicKeyRef.current = newPublicKey;
-      } else {
-        setWalletNetworkWarning(null);
-        setPublicKey(null);
-        setIsWalletConnected(false);
-        localStorage.removeItem("stellar_wallet_public_key");
-        // Invalidate queries when disconnected
-        if (previousPublicKeyRef.current !== null) {
-          invalidateWalletQueries();
-          previousPublicKeyRef.current = null;
-        }
-      }
-    } catch {
-      setWalletNetworkWarning(null);
-      setPublicKey(null);
-      setIsWalletConnected(false);
-      localStorage.removeItem("stellar_wallet_public_key");
-      // Invalidate queries on error
-      if (previousPublicKeyRef.current !== null) {
-        invalidateWalletQueries();
-        previousPublicKeyRef.current = null;
-      }
-    }
-  };
-
-  // Invalidate all wallet-scoped queries when account/network changes
   const invalidateWalletQueries = () => {
     queryClient.invalidateQueries({ queryKey: ["admin"] });
     queryClient.invalidateQueries({ queryKey: ["contributions"] });
     queryClient.invalidateQueries({ queryKey: ["revenue"] });
     queryClient.invalidateQueries({ queryKey: ["stellarBalance"] });
-    // Note: campaigns query is not wallet-scoped, so we don't invalidate it
   };
 
-  const isFreighterInstalled = async (): Promise<boolean> => {
+  const clearWalletState = () => {
+    setPublicKey(null);
+    setIsWalletConnected(false);
+    setActiveWalletId(null);
+    setWalletNetworkWarning(null);
+    localStorage.removeItem(PUBLIC_KEY_STORAGE_KEY);
+    localStorage.removeItem(WALLET_ID_STORAGE_KEY);
+  };
+
+  /** Check the Freighter network and warn if mismatched. Returns false on mismatch. */
+  const checkFreighterNetwork = async (): Promise<boolean> => {
     try {
-      const result = await isConnected();
-      return result.isConnected;
+      const network = await getNetwork();
+      const walletPassphrase = network.networkPassphrase ?? "";
+      if (walletPassphrase !== appNetworkPassphrase) {
+        setWalletNetworkWarning(
+          `Switch your wallet to ${appNetworkLabel} to continue. Current wallet network does not match the app network.`,
+        );
+        return false;
+      }
     } catch {
-      return false;
+      // If we can't read the network, don't block — just warn.
+    }
+    setWalletNetworkWarning(null);
+    return true;
+  };
+
+  // -------------------------------------------------------------------------
+  // Silent restore on mount
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (IS_MOCK_MODE) {
+      const storedKey = typeof window !== "undefined"
+        ? localStorage.getItem(PUBLIC_KEY_STORAGE_KEY)
+        : null;
+      if (storedKey) {
+        setPublicKey(storedKey);
+        setIsWalletConnected(true);
+        previousPublicKeyRef.current = storedKey;
+      }
+      return;
+    }
+
+    void silentRestore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /**
+   * On page load, try to silently restore the previously chosen wallet
+   * session without showing any prompts.
+   */
+  const silentRestore = async () => {
+    if (typeof window === "undefined") return;
+
+    const savedWalletId = localStorage.getItem(WALLET_ID_STORAGE_KEY) as WalletId | null;
+    if (!savedWalletId) return;
+
+    // Validate saved ID against known adapters
+    const knownIds = ALL_ADAPTERS.map((a) => a.id);
+    if (!knownIds.includes(savedWalletId)) return;
+
+    try {
+      const adapter = getAdapter(savedWalletId);
+      if (!adapter.isAvailable()) return;
+
+      const connected = await adapter.isConnected();
+      if (!connected) return;
+
+      const key = await adapter.getPublicKey();
+      if (!key) return;
+
+      // Network check for Freighter only (other wallets handle it internally)
+      if (savedWalletId === "freighter") {
+        const ok = await checkFreighterNetwork();
+        if (!ok) {
+          clearWalletState();
+          return;
+        }
+      }
+
+      setActiveWalletId(savedWalletId);
+      setPublicKey(key);
+      setIsWalletConnected(true);
+      localStorage.setItem(PUBLIC_KEY_STORAGE_KEY, key);
+      previousPublicKeyRef.current = key;
+    } catch {
+      // Silent restore failed — start disconnected.
+      clearWalletState();
     }
   };
 
+  // -------------------------------------------------------------------------
+  // connectWallet — opens the wallet selection modal
+  // -------------------------------------------------------------------------
+
   const connectWallet = async () => {
-    setIsLoading(true);
-    try {
-      if (IS_MOCK_MODE) {
+    if (IS_MOCK_MODE) {
+      setIsLoading(true);
+      try {
         const mockAddress = MOCK_PUBLIC_KEY;
-        if (!mockAddress) {
-          throw new Error("Mock wallet initialization failed.");
-        }
+        if (!mockAddress) throw new Error("Mock wallet initialization failed.");
         setPublicKey(mockAddress);
         setIsWalletConnected(true);
+        setActiveWalletId("freighter"); // Mock always uses freighter id
         setWalletNetworkWarning(null);
-        localStorage.setItem("stellar_wallet_public_key", mockAddress);
+        localStorage.setItem(PUBLIC_KEY_STORAGE_KEY, mockAddress);
+        localStorage.setItem(WALLET_ID_STORAGE_KEY, "freighter");
         previousPublicKeyRef.current = mockAddress;
         showSuccess("Mock wallet connected successfully.");
+      } catch {
+        showError("Failed to connect wallet. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    // Show the wallet selection modal
+    setShowSelectModal(true);
+  };
+
+  // -------------------------------------------------------------------------
+  // handleWalletSelected — called when the user picks a wallet in the modal
+  // -------------------------------------------------------------------------
+
+  const handleWalletSelected = async (id: WalletId) => {
+    setConnectingId(id);
+    setIsLoading(true);
+    try {
+      const adapter = getAdapter(id);
+
+      if (!adapter.isAvailable()) {
+        // Not installed; modal shows the install link — shouldn't reach here
+        // for unavailable wallets, but guard anyway.
+        window.open(adapter.installUrl, "_blank");
         return;
       }
 
-      const installed = await isFreighterInstalled();
-      if (!installed) {
-        setShowInstallPrompt(true);
-        setIsLoading(false);
-        return;
+      const key = await adapter.connect();
+
+      // Network check for Freighter
+      if (id === "freighter") {
+        const ok = await checkFreighterNetwork();
+        if (!ok) {
+          showWarning(
+            `Switch your wallet to ${appNetworkLabel} to continue. Current wallet network does not match the app network.`,
+          );
+          return;
+        }
       }
-      const allowed = await isAllowed();
-      if (!allowed) {
-        showWarning("Please allow Freighter to connect to this site.");
-        setIsLoading(false);
-        return;
-      }
-      const key = await getAddress();
-      const network = await getNetwork();
-      if ((network.networkPassphrase || "") !== appNetworkPassphrase) {
-        const warning = `Switch Freighter to ${appNetworkLabel} to continue. Current wallet network does not match the app network.`;
-        setPublicKey(null);
-        setIsWalletConnected(false);
-        setWalletNetworkWarning(warning);
-        showWarning(warning);
-        setIsLoading(false);
-        return;
-      }
-      setWalletNetworkWarning(null);
-      setPublicKey(key.address);
+
+      setActiveWalletId(id);
+      setPublicKey(key);
       setIsWalletConnected(true);
-      localStorage.setItem("stellar_wallet_public_key", key.address);
-      showSuccess("Wallet connected successfully.");
-    } catch {
-      setPublicKey(null);
-      setIsWalletConnected(false);
       setWalletNetworkWarning(null);
-      showError("Failed to connect wallet. Please try again.");
+      localStorage.setItem(PUBLIC_KEY_STORAGE_KEY, key);
+      localStorage.setItem(WALLET_ID_STORAGE_KEY, id);
+
+      if (
+        previousPublicKeyRef.current !== null &&
+        previousPublicKeyRef.current !== key
+      ) {
+        invalidateWalletQueries();
+      }
+      previousPublicKeyRef.current = key;
+
+      setShowSelectModal(false);
+      showSuccess("Wallet connected successfully.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      showError(`Failed to connect wallet: ${message}`);
     } finally {
+      setConnectingId(null);
       setIsLoading(false);
     }
   };
 
-  const handleRetryInstall = async () => {
-    const installed = await isFreighterInstalled();
-    if (installed) {
-      setShowInstallPrompt(false);
-      connectWallet();
+  // -------------------------------------------------------------------------
+  // signTransaction
+  // -------------------------------------------------------------------------
+
+  const signTransaction = async (xdr: string, networkPassphrase: string): Promise<string> => {
+    if (!activeWalletId) {
+      throw new Error("No wallet connected. Please connect a wallet first.");
     }
+    const adapter = getAdapter(activeWalletId);
+    return adapter.signTransaction(xdr, networkPassphrase);
   };
 
+  // -------------------------------------------------------------------------
+  // disconnectWallet
+  // -------------------------------------------------------------------------
+
   const disconnectWallet = () => {
-    setPublicKey(null);
-    setIsWalletConnected(false);
-    setWalletNetworkWarning(null);
-    localStorage.removeItem("stellar_wallet_public_key");
-    // Invalidate wallet-scoped queries on disconnect
+    clearWalletState();
     invalidateWalletQueries();
     previousPublicKeyRef.current = null;
-    // Freighter has no programmatic revoke API. Inform the user how to fully sever access.
     showWarning(
-      "Disconnected. To fully revoke Freighter access, open the extension and remove this site from Connected Sites.",
+      "Disconnected. To fully revoke wallet access, open the extension and remove this site from its connected sites.",
     );
   };
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
 
   return (
     <WalletContext.Provider
@@ -243,20 +298,30 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         publicKey,
         isWalletConnected,
         walletNetworkWarning,
+        activeWalletId,
         connectWallet,
         disconnectWallet,
         isLoading,
+        signTransaction,
       }}
     >
       {children}
-      <InstallFreighterModal
-        isOpen={showInstallPrompt}
-        onClose={() => setShowInstallPrompt(false)}
-        onRetry={handleRetryInstall}
+      <WalletSelectModal
+        isOpen={showSelectModal}
+        isLoading={isLoading}
+        connectingId={connectingId}
+        onSelect={handleWalletSelected}
+        onClose={() => {
+          if (!isLoading) setShowSelectModal(false);
+        }}
       />
     </WalletContext.Provider>
   );
 };
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
 
 export const useWallet = () => {
   const ctx = useContext(WalletContext);

--- a/src/components/WalletSelectModal.tsx
+++ b/src/components/WalletSelectModal.tsx
@@ -1,0 +1,136 @@
+"use client";
+import React from "react";
+import { ALL_ADAPTERS, WALLET_DESCRIPTORS } from "@/lib/walletAdapters";
+import type { WalletId } from "@/lib/walletAdapters";
+
+interface WalletSelectModalProps {
+  isOpen: boolean;
+  isLoading: boolean;
+  /** ID of the wallet currently being connected (shows spinner) */
+  connectingId: WalletId | null;
+  onSelect: (id: WalletId) => void;
+  onClose: () => void;
+}
+
+/**
+ * Modal that lists all registered wallet adapters and lets the user pick one.
+ *
+ * If the chosen wallet is not installed, an install link is shown instead of
+ * triggering a connection attempt.
+ */
+const WalletSelectModal: React.FC<WalletSelectModalProps> = ({
+  isOpen,
+  isLoading,
+  connectingId,
+  onSelect,
+  onClose,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="wallet-select-title"
+      onClick={onClose}
+    >
+      {/* Panel */}
+      <div
+        className="relative w-full max-w-sm rounded-2xl bg-white p-6 shadow-2xl dark:bg-gray-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="mb-5 flex items-center justify-between">
+          <h2 id="wallet-select-title" className="text-lg font-semibold text-gray-900 dark:text-white">
+            Connect Wallet
+          </h2>
+          <button
+            onClick={onClose}
+            disabled={isLoading}
+            aria-label="Close wallet selector"
+            className="rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Wallet options */}
+        <ul className="space-y-3" role="list">
+          {ALL_ADAPTERS.map((adapter) => {
+            const descriptor = WALLET_DESCRIPTORS[adapter.id];
+            const available = adapter.isAvailable();
+            const isConnecting = connectingId === adapter.id;
+
+            return (
+              <li key={adapter.id}>
+                {available ? (
+                  <button
+                    onClick={() => onSelect(adapter.id)}
+                    disabled={isLoading}
+                    aria-busy={isConnecting}
+                    className="flex w-full items-center gap-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-left transition-colors hover:border-blue-400 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-500 dark:hover:bg-gray-700"
+                  >
+                    <span className="text-2xl" aria-hidden="true">
+                      {descriptor.icon}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium text-gray-900 dark:text-white">{descriptor.name}</p>
+                      <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {descriptor.description}
+                      </p>
+                    </div>
+                    {isConnecting && (
+                      <svg
+                        className="h-5 w-5 animate-spin text-blue-500"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                      </svg>
+                    )}
+                  </button>
+                ) : (
+                  /* Extension not detected — show install link */
+                  <a
+                    href={descriptor.installUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex w-full items-center gap-4 rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-left opacity-70 transition-opacity hover:opacity-100 dark:border-gray-600 dark:bg-gray-800"
+                    aria-label={`Install ${descriptor.name} wallet`}
+                  >
+                    <span className="text-2xl" aria-hidden="true">
+                      {descriptor.icon}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium text-gray-900 dark:text-white">{descriptor.name}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        Not installed — click to install
+                      </p>
+                    </div>
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                      <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+                    </svg>
+                  </a>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+
+        <p className="mt-4 text-center text-xs text-gray-400 dark:text-gray-500">
+          By connecting you agree to our terms of service.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default WalletSelectModal;

--- a/src/components/__tests__/WalletContext.test.tsx
+++ b/src/components/__tests__/WalletContext.test.tsx
@@ -1,23 +1,126 @@
 import { render, screen, act, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { WalletProvider, useWallet } from "../WalletContext";
-import { isConnected, isAllowed, getAddress } from "@stellar/freighter-api";
 import { useToast } from "../ToastProvider";
 
-// Mock dependencies
+// Wrap children in a fresh QueryClient to satisfy WalletProvider's useQueryClient call.
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+// ---------------------------------------------------------------------------
+// Mock wallet adapters
+// ---------------------------------------------------------------------------
+
+const mockFreighterConnect = jest.fn();
+const mockFreighterIsConnected = jest.fn();
+const mockFreighterIsAvailable = jest.fn();
+const mockFreighterGetPublicKey = jest.fn();
+
+const mockLobstrIsAvailable = jest.fn().mockReturnValue(false);
+const mockXBullIsAvailable = jest.fn().mockReturnValue(false);
+
+jest.mock("@/lib/walletAdapters", () => ({
+  ALL_ADAPTERS: [
+    {
+      id: "freighter",
+      name: "Freighter",
+      installUrl: "https://www.freighter.app/",
+      isAvailable: () => mockFreighterIsAvailable(),
+      isConnected: () => mockFreighterIsConnected(),
+      connect: () => mockFreighterConnect(),
+      getPublicKey: () => mockFreighterGetPublicKey(),
+      signTransaction: jest.fn(),
+    },
+    {
+      id: "lobstr",
+      name: "LOBSTR",
+      installUrl: "https://lobstr.co/signer-extension/",
+      isAvailable: () => mockLobstrIsAvailable(),
+      isConnected: jest.fn().mockResolvedValue(false),
+      connect: jest.fn(),
+      getPublicKey: jest.fn(),
+      signTransaction: jest.fn(),
+    },
+    {
+      id: "xbull",
+      name: "xBull",
+      installUrl: "https://xbull.app/",
+      isAvailable: () => mockXBullIsAvailable(),
+      isConnected: jest.fn().mockResolvedValue(false),
+      connect: jest.fn(),
+      getPublicKey: jest.fn(),
+      signTransaction: jest.fn(),
+    },
+  ],
+  WALLET_DESCRIPTORS: {
+    freighter: { id: "freighter", name: "Freighter", description: "SDF wallet", installUrl: "https://www.freighter.app/", icon: "🚀" },
+    lobstr: { id: "lobstr", name: "LOBSTR", description: "LOBSTR wallet", installUrl: "https://lobstr.co/signer-extension/", icon: "🦞" },
+    xbull: { id: "xbull", name: "xBull", description: "xBull wallet", installUrl: "https://xbull.app/", icon: "🐂" },
+  },
+  getAdapter: (id: string) => {
+    const adapters: Record<string, object> = {
+      freighter: {
+        id: "freighter",
+        name: "Freighter",
+        installUrl: "https://www.freighter.app/",
+        isAvailable: () => mockFreighterIsAvailable(),
+        isConnected: () => mockFreighterIsConnected(),
+        connect: () => mockFreighterConnect(),
+        getPublicKey: () => mockFreighterGetPublicKey(),
+        signTransaction: jest.fn(),
+      },
+    };
+    return adapters[id];
+  },
+}));
+
+// Mock Freighter getNetwork (used for network passphrase check)
+jest.mock("@stellar/freighter-api", () => ({
+  getNetwork: jest.fn().mockResolvedValue({ networkPassphrase: "" }),
+}));
+
+// ---------------------------------------------------------------------------
+// Other mocks
+// ---------------------------------------------------------------------------
+
 jest.mock("../ToastProvider", () => ({
   useToast: jest.fn(),
 }));
 
-const mockIsConnected = isConnected as jest.Mock;
-const mockIsAllowed = isAllowed as jest.Mock;
-const mockGetAddress = getAddress as jest.Mock;
+jest.mock("../WalletSelectModal", () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    onSelect,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onSelect: (id: string) => void;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="wallet-select-modal">
+        <button onClick={() => onSelect("freighter")}>Select Freighter</button>
+        <button onClick={onClose}>Close Modal</button>
+      </div>
+    ) : null,
+}));
+
 const mockUseToast = useToast as jest.Mock;
 
 const mockShowError = jest.fn();
 const mockShowWarning = jest.fn();
 const mockShowSuccess = jest.fn();
 
-// Dummy component to test the context
+// ---------------------------------------------------------------------------
+// Test component
+// ---------------------------------------------------------------------------
+
 const TestComponent = () => {
   const { publicKey, isWalletConnected, connectWallet, disconnectWallet, isLoading } = useWallet();
   return (
@@ -31,6 +134,19 @@ const TestComponent = () => {
   );
 };
 
+// ---------------------------------------------------------------------------
+// Render helper (wraps WalletProvider in the required QueryClientProvider)
+// ---------------------------------------------------------------------------
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const Wrapper = createWrapper();
+  return render(<Wrapper>{ui}</Wrapper>);
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe("WalletContext", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -40,39 +156,34 @@ describe("WalletContext", () => {
       showWarning: mockShowWarning,
       showSuccess: mockShowSuccess,
     });
-    // Default to not connected
-    mockIsConnected.mockResolvedValue(false);
-    mockIsAllowed.mockResolvedValue(false);
-    mockGetAddress.mockResolvedValue({ address: "GB..." });
-
-    // Mock window.open
-    global.window.open = jest.fn();
+    // Default: Freighter is available but not connected
+    mockFreighterIsAvailable.mockReturnValue(true);
+    mockFreighterIsConnected.mockResolvedValue(false);
+    mockFreighterGetPublicKey.mockResolvedValue("GB...");
+    mockFreighterConnect.mockResolvedValue("GB...");
   });
 
-  it("checks wallet connection on mount - success path", async () => {
-    mockIsConnected.mockResolvedValue(true);
-    mockIsAllowed.mockResolvedValue(true);
-    mockGetAddress.mockResolvedValue({ address: "G-MO-DEV-SUCCESS" });
+  it("silently restores from localStorage on mount when previously connected", async () => {
+    localStorage.setItem("stellar_wallet_id", "freighter");
+    localStorage.setItem("stellar_wallet_public_key", "G-RESTORED");
+    mockFreighterIsConnected.mockResolvedValue(true);
+    mockFreighterGetPublicKey.mockResolvedValue("G-RESTORED");
 
     await act(async () => {
-      render(
+      renderWithProviders(
         <WalletProvider>
           <TestComponent />
         </WalletProvider>,
       );
     });
 
-    expect(screen.getByTestId("publicKey")).toHaveTextContent("G-MO-DEV-SUCCESS");
+    expect(screen.getByTestId("publicKey")).toHaveTextContent("G-RESTORED");
     expect(screen.getByTestId("isConnected")).toHaveTextContent("true");
-    expect(localStorage.getItem("stellar_wallet_public_key")).toBe("G-MO-DEV-SUCCESS");
   });
 
-  it("checks wallet connection on mount - failure path (not allowed)", async () => {
-    mockIsConnected.mockResolvedValue(true);
-    mockIsAllowed.mockResolvedValue(false);
-
+  it("starts disconnected when no localStorage entry exists", async () => {
     await act(async () => {
-      render(
+      renderWithProviders(
         <WalletProvider>
           <TestComponent />
         </WalletProvider>,
@@ -80,37 +191,51 @@ describe("WalletContext", () => {
     });
 
     expect(screen.getByTestId("isConnected")).toHaveTextContent("false");
-    expect(localStorage.getItem("stellar_wallet_public_key")).toBeNull();
+    expect(screen.getByTestId("publicKey")).toHaveTextContent("");
   });
 
-  it("connectWallet - success path", async () => {
-    mockIsConnected.mockResolvedValue(true);
-    mockIsAllowed.mockResolvedValue(true);
-    mockGetAddress.mockResolvedValue({ address: "G-MO-DEV-CONNECT-SUCCESS" });
-
-    render(
+  it("connectWallet opens the wallet selection modal", async () => {
+    renderWithProviders(
       <WalletProvider>
         <TestComponent />
       </WalletProvider>,
     );
 
-    // Initial state check
-    expect(screen.getByTestId("isConnected")).toHaveTextContent("false");
+    await act(async () => {
+      fireEvent.click(screen.getByText("Connect"));
+    });
+
+    expect(screen.getByTestId("wallet-select-modal")).toBeInTheDocument();
+  });
+
+  it("selecting a wallet in the modal connects and persists the key", async () => {
+    mockFreighterConnect.mockResolvedValue("G-MO-DEV-CONNECT-SUCCESS");
+
+    renderWithProviders(
+      <WalletProvider>
+        <TestComponent />
+      </WalletProvider>,
+    );
 
     await act(async () => {
       fireEvent.click(screen.getByText("Connect"));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Select Freighter"));
     });
 
     expect(screen.getByTestId("publicKey")).toHaveTextContent("G-MO-DEV-CONNECT-SUCCESS");
     expect(screen.getByTestId("isConnected")).toHaveTextContent("true");
     expect(mockShowSuccess).toHaveBeenCalledWith("Wallet connected successfully.");
     expect(localStorage.getItem("stellar_wallet_public_key")).toBe("G-MO-DEV-CONNECT-SUCCESS");
+    expect(localStorage.getItem("stellar_wallet_id")).toBe("freighter");
   });
 
-  it("connectWallet - freighter not installed", async () => {
-    mockIsConnected.mockResolvedValue(false);
+  it("shows error toast when wallet connection fails", async () => {
+    mockFreighterConnect.mockRejectedValue(new Error("User rejected"));
 
-    render(
+    renderWithProviders(
       <WalletProvider>
         <TestComponent />
       </WalletProvider>,
@@ -120,18 +245,18 @@ describe("WalletContext", () => {
       fireEvent.click(screen.getByText("Connect"));
     });
 
-    expect(mockShowWarning).toHaveBeenCalledWith(
-      "Freighter wallet not found. Opening install page…",
+    await act(async () => {
+      fireEvent.click(screen.getByText("Select Freighter"));
+    });
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to connect wallet"),
     );
-    expect(global.window.open).toHaveBeenCalledWith("https://www.freighter.app/", "_blank");
     expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
   });
 
-  it("connectWallet - not allowed", async () => {
-    mockIsConnected.mockResolvedValue(true);
-    mockIsAllowed.mockResolvedValue(false);
-
-    render(
+  it("closing the modal without selecting does not connect", async () => {
+    renderWithProviders(
       <WalletProvider>
         <TestComponent />
       </WalletProvider>,
@@ -141,44 +266,27 @@ describe("WalletContext", () => {
       fireEvent.click(screen.getByText("Connect"));
     });
 
-    expect(mockShowWarning).toHaveBeenCalledWith("Please allow Freighter to connect to this site.");
-    expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
-  });
-
-  it("connectWallet - error path", async () => {
-    mockIsConnected.mockResolvedValue(true);
-    mockIsAllowed.mockResolvedValue(true);
-    mockGetAddress.mockRejectedValue(new Error("Failed"));
-
-    render(
-      <WalletProvider>
-        <TestComponent />
-      </WalletProvider>,
-    );
-
     await act(async () => {
-      fireEvent.click(screen.getByText("Connect"));
+      fireEvent.click(screen.getByText("Close Modal"));
     });
 
-    expect(mockShowError).toHaveBeenCalledWith("Failed to connect wallet. Please try again.");
-    expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
+    expect(screen.queryByTestId("wallet-select-modal")).not.toBeInTheDocument();
+    expect(screen.getByTestId("isConnected")).toHaveTextContent("false");
   });
 
-  it("disconnectWallet", async () => {
-    // Start with a connected wallet
-    mockIsConnected.mockResolvedValue(true);
-    mockIsAllowed.mockResolvedValue(true);
-    mockGetAddress.mockResolvedValue({ address: "G-DISCONNECT" });
+  it("disconnectWallet clears state and localStorage", async () => {
+    localStorage.setItem("stellar_wallet_id", "freighter");
+    localStorage.setItem("stellar_wallet_public_key", "G-DISCONNECT");
+    mockFreighterIsConnected.mockResolvedValue(true);
+    mockFreighterGetPublicKey.mockResolvedValue("G-DISCONNECT");
 
-    render(
+    renderWithProviders(
       <WalletProvider>
         <TestComponent />
       </WalletProvider>,
     );
 
-    // Initial connected state
-    await act(async () => {}); // Wait for useEffect
-    expect(screen.getByTestId("isConnected")).toHaveTextContent("true");
+    await act(async () => {}); // Wait for silent restore
 
     await act(async () => {
       fireEvent.click(screen.getByText("Disconnect"));
@@ -187,13 +295,11 @@ describe("WalletContext", () => {
     expect(screen.getByTestId("publicKey")).toHaveTextContent("");
     expect(screen.getByTestId("isConnected")).toHaveTextContent("false");
     expect(localStorage.getItem("stellar_wallet_public_key")).toBeNull();
-    expect(mockShowWarning).toHaveBeenCalledWith(
-      "Disconnected. To fully revoke Freighter access, open the extension and remove this site from Connected Sites.",
-    );
+    expect(localStorage.getItem("stellar_wallet_id")).toBeNull();
+    expect(mockShowWarning).toHaveBeenCalledWith(expect.stringContaining("Disconnected"));
   });
 
   it("throws error when used outside of Provider", () => {
-    // Silence console.error for this test as we expect an error
     const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
     expect(() => {

--- a/src/lib/walletAdapters/FreighterAdapter.ts
+++ b/src/lib/walletAdapters/FreighterAdapter.ts
@@ -1,0 +1,71 @@
+import {
+  isConnected as freighterIsConnected,
+  isAllowed,
+  getAddress,
+  signTransaction as freighterSignTransaction,
+} from "@stellar/freighter-api";
+import { wrapFreighterError } from "@/utils/freighterErrors";
+import type { WalletAdapter, WalletId } from "./types";
+
+/**
+ * Wallet adapter for the Freighter browser extension.
+ *
+ * Freighter API docs: https://docs.freighter.app/docs/guide/usingFreighterWebApp
+ */
+export class FreighterAdapter implements WalletAdapter {
+  readonly id: WalletId = "freighter";
+  readonly name = "Freighter";
+  readonly installUrl = "https://www.freighter.app/";
+
+  isAvailable(): boolean {
+    // Freighter injects itself into window; @stellar/freighter-api guards SSR.
+    if (typeof window === "undefined") return false;
+    // The API module works regardless – if not installed calls resolve to
+    // {isConnected: false}, so we can always call it.  Return true so the
+    // modal always shows Freighter as an option.
+    return true;
+  }
+
+  async isConnected(): Promise<boolean> {
+    try {
+      const connected = await freighterIsConnected();
+      if (!connected.isConnected) return false;
+      const allowed = await isAllowed();
+      return !!allowed.isAllowed;
+    } catch {
+      return false;
+    }
+  }
+
+  async connect(): Promise<string> {
+    const connected = await freighterIsConnected();
+    if (!connected.isConnected) {
+      throw new Error("Freighter extension is not installed.");
+    }
+
+    // Trigger the permission dialog by requesting the address; Freighter will
+    // prompt the user to allow this site if not already allowed.
+    const result = await getAddress();
+    if (!result.address) {
+      throw new Error("Freighter did not return a public key. Please allow access and try again.");
+    }
+    return result.address;
+  }
+
+  async getPublicKey(): Promise<string> {
+    const result = await getAddress();
+    if (!result.address) {
+      throw new Error("Could not retrieve public key from Freighter.");
+    }
+    return result.address;
+  }
+
+  async signTransaction(xdr: string, networkPassphrase: string): Promise<string> {
+    try {
+      const result = await freighterSignTransaction(xdr, { networkPassphrase });
+      return result.signedTxXdr;
+    } catch (error) {
+      wrapFreighterError(error);
+    }
+  }
+}

--- a/src/lib/walletAdapters/LobstrAdapter.ts
+++ b/src/lib/walletAdapters/LobstrAdapter.ts
@@ -1,0 +1,65 @@
+import {
+  getPublicKey as lobstrGetPublicKey,
+  isConnected as lobstrIsConnected,
+  signTransaction as lobstrSignTransaction,
+} from "@lobstrco/signer-extension-api";
+import type { WalletAdapter, WalletId } from "./types";
+
+/**
+ * Wallet adapter for the LOBSTR Signer browser extension.
+ *
+ * LOBSTR Signer docs: https://github.com/lobstrco/lobstr-browser-signer-extension
+ *
+ * Note: The LOBSTR API does not require the network passphrase for signing —
+ * the extension handles network selection internally.
+ */
+export class LobstrAdapter implements WalletAdapter {
+  readonly id: WalletId = "lobstr";
+  readonly name = "LOBSTR";
+  readonly installUrl = "https://lobstr.co/signer-extension/";
+
+  isAvailable(): boolean {
+    if (typeof window === "undefined") return false;
+    // The LOBSTR API is always importable; the extension either responds or
+    // returns false from isConnected(). Show it as an option in all browsers.
+    return true;
+  }
+
+  async isConnected(): Promise<boolean> {
+    try {
+      return await lobstrIsConnected();
+    } catch {
+      return false;
+    }
+  }
+
+  async connect(): Promise<string> {
+    const connected = await lobstrIsConnected();
+    if (!connected) {
+      throw new Error("LOBSTR Signer extension is not installed or not responding.");
+    }
+    const publicKey = await lobstrGetPublicKey();
+    if (!publicKey) {
+      throw new Error("LOBSTR did not return a public key. Please allow access and try again.");
+    }
+    return publicKey;
+  }
+
+  async getPublicKey(): Promise<string> {
+    const publicKey = await lobstrGetPublicKey();
+    if (!publicKey) {
+      throw new Error("Could not retrieve public key from LOBSTR.");
+    }
+    return publicKey;
+  }
+
+  async signTransaction(xdr: string, _networkPassphrase: string): Promise<string> {
+    // The LOBSTR API only accepts the XDR; network passphrase is managed by
+    // the extension itself.
+    const signedXdr = await lobstrSignTransaction(xdr);
+    if (!signedXdr) {
+      throw new Error("LOBSTR did not return a signed transaction.");
+    }
+    return signedXdr;
+  }
+}

--- a/src/lib/walletAdapters/XBullAdapter.ts
+++ b/src/lib/walletAdapters/XBullAdapter.ts
@@ -1,0 +1,96 @@
+import type { WalletAdapter, WalletId } from "./types";
+
+/**
+ * Minimal type declaration for the xBull in-page SDK that the extension
+ * injects at `window.xBullSDK`.
+ *
+ * Full docs: https://github.com/Creit-Tech/xBull-Wallet
+ */
+interface XBullSDK {
+  connect(options?: { canRequestPublicKey?: boolean; canRequestSign?: boolean }): Promise<{
+    canRequestPublicKey: boolean;
+    canRequestSign: boolean;
+  }>;
+  getPublicKey(): Promise<string>;
+  /** Signs a transaction XDR and returns the signed XDR string. */
+  signXDR(
+    xdr: string,
+    options?: { network?: string; publicKey?: string },
+  ): Promise<string>;
+}
+
+declare global {
+  interface Window {
+    xBullSDK?: XBullSDK;
+  }
+}
+
+/**
+ * Wallet adapter for the xBull browser extension.
+ *
+ * xBull injects `window.xBullSDK` when the extension is installed.
+ * We call `connect()` to request permissions and `signXDR()` for signing.
+ */
+export class XBullAdapter implements WalletAdapter {
+  readonly id: WalletId = "xbull";
+  readonly name = "xBull";
+  readonly installUrl = "https://xbull.app/";
+
+  private get sdk(): XBullSDK | undefined {
+    if (typeof window === "undefined") return undefined;
+    return window.xBullSDK;
+  }
+
+  isAvailable(): boolean {
+    return typeof window !== "undefined" && !!window.xBullSDK;
+  }
+
+  async isConnected(): Promise<boolean> {
+    if (!this.sdk) return false;
+    try {
+      // Attempt to retrieve the public key without triggering a permission
+      // prompt.  If the extension is unlocked and already allowed, this
+      // resolves; otherwise it throws.
+      const pk = await this.sdk.getPublicKey();
+      return !!pk;
+    } catch {
+      return false;
+    }
+  }
+
+  async connect(): Promise<string> {
+    if (!this.sdk) {
+      throw new Error("xBull extension is not installed.");
+    }
+    // Request both read and sign permissions.
+    await this.sdk.connect({ canRequestPublicKey: true, canRequestSign: true });
+
+    const publicKey = await this.sdk.getPublicKey();
+    if (!publicKey) {
+      throw new Error("xBull did not return a public key. Please allow access and try again.");
+    }
+    return publicKey;
+  }
+
+  async getPublicKey(): Promise<string> {
+    if (!this.sdk) {
+      throw new Error("xBull extension is not installed.");
+    }
+    const publicKey = await this.sdk.getPublicKey();
+    if (!publicKey) {
+      throw new Error("Could not retrieve public key from xBull.");
+    }
+    return publicKey;
+  }
+
+  async signTransaction(xdr: string, networkPassphrase: string): Promise<string> {
+    if (!this.sdk) {
+      throw new Error("xBull extension is not installed.");
+    }
+    const signedXdr = await this.sdk.signXDR(xdr, { network: networkPassphrase });
+    if (!signedXdr) {
+      throw new Error("xBull did not return a signed transaction.");
+    }
+    return signedXdr;
+  }
+}

--- a/src/lib/walletAdapters/index.ts
+++ b/src/lib/walletAdapters/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Wallet adapter registry.
+ *
+ * Import from this file throughout the app:
+ *
+ *   import { getAdapter, ALL_ADAPTERS } from "@/lib/walletAdapters";
+ */
+
+export type { WalletAdapter, WalletId, WalletDescriptor } from "./types";
+export { WALLET_DESCRIPTORS } from "./types";
+
+export { FreighterAdapter } from "./FreighterAdapter";
+export { LobstrAdapter } from "./LobstrAdapter";
+export { XBullAdapter } from "./XBullAdapter";
+
+import type { WalletAdapter, WalletId } from "./types";
+import { FreighterAdapter } from "./FreighterAdapter";
+import { LobstrAdapter } from "./LobstrAdapter";
+import { XBullAdapter } from "./XBullAdapter";
+
+/**
+ * All supported adapters in display order.
+ * Singletons are fine here because adapters hold no mutable state.
+ */
+export const ALL_ADAPTERS: readonly WalletAdapter[] = [
+  new FreighterAdapter(),
+  new LobstrAdapter(),
+  new XBullAdapter(),
+] as const;
+
+/**
+ * Look up a specific adapter by its stable {@link WalletId}.
+ *
+ * @throws if `id` is not recognised (should never happen in practice).
+ */
+export function getAdapter(id: WalletId): WalletAdapter {
+  const adapter = ALL_ADAPTERS.find((a) => a.id === id);
+  if (!adapter) {
+    throw new Error(`No wallet adapter registered for id "${id}"`);
+  }
+  return adapter;
+}

--- a/src/lib/walletAdapters/types.ts
+++ b/src/lib/walletAdapters/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Common interface that every Stellar wallet adapter must implement.
+ *
+ * Each adapter wraps one concrete wallet (Freighter, LOBSTR, xBull, …) and
+ * exposes a uniform API so the rest of the application never has to care about
+ * which wallet is active.
+ */
+export interface WalletAdapter {
+  /** Stable identifier used for persistence (e.g. localStorage key). */
+  readonly id: WalletId;
+
+  /** Human-readable wallet name shown in the UI. */
+  readonly name: string;
+
+  /**
+   * URL of the wallet's install page.  Shown to users who don't yet have the
+   * extension installed.
+   */
+  readonly installUrl: string;
+
+  /**
+   * Returns `true` when the wallet extension (or injected global) is present
+   * in the current browser environment.
+   */
+  isAvailable(): boolean;
+
+  /**
+   * Returns `true` when the extension is already connected/allowed for this
+   * origin.  Used to silently restore a previous session on page load.
+   */
+  isConnected(): Promise<boolean>;
+
+  /**
+   * Triggers the wallet's authorisation / permission flow and resolves with
+   * the user's Stellar public key on success.
+   *
+   * @throws if the user rejects the permission request or the wallet is
+   * unavailable.
+   */
+  connect(): Promise<string>;
+
+  /**
+   * Signs a Stellar transaction XDR and returns the signed XDR string.
+   *
+   * @param xdr           Base64-encoded transaction envelope XDR.
+   * @param networkPassphrase  Stellar network passphrase.
+   * @returns Signed XDR string (base64-encoded transaction envelope).
+   * @throws {@link UserCancelledError} when the user rejects the signature.
+   */
+  signTransaction(xdr: string, networkPassphrase: string): Promise<string>;
+
+  /**
+   * Returns the public key that is currently active in the wallet.
+   * May be called after `connect()` to refresh the address, e.g. when the
+   * user switches accounts.
+   *
+   * @throws if the wallet is not connected or unavailable.
+   */
+  getPublicKey(): Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Supported wallet IDs
+// ---------------------------------------------------------------------------
+
+export type WalletId = "freighter" | "lobstr" | "xbull";
+
+export interface WalletDescriptor {
+  id: WalletId;
+  name: string;
+  description: string;
+  installUrl: string;
+  /** Emoji or short icon used in the selection modal. */
+  icon: string;
+}
+
+export const WALLET_DESCRIPTORS: Record<WalletId, WalletDescriptor> = {
+  freighter: {
+    id: "freighter",
+    name: "Freighter",
+    description: "Browser extension by Stellar Development Foundation",
+    installUrl: "https://www.freighter.app/",
+    icon: "🚀",
+  },
+  lobstr: {
+    id: "lobstr",
+    name: "LOBSTR",
+    description: "Mobile wallet with browser signer extension",
+    installUrl: "https://lobstr.co/signer-extension/",
+    icon: "🦞",
+  },
+  xbull: {
+    id: "xbull",
+    name: "xBull",
+    description: "Powerful browser extension & PWA wallet",
+    installUrl: "https://xbull.app/",
+    icon: "🐂",
+  },
+};


### PR DESCRIPTION
## Summary

Introduces a uniform wallet adapter layer so the app can support multiple Stellar wallets (Freighter, LOBSTR, xBull) through a single interface, replacing the previous Freighter-only integration.

## Changes

### New: `src/lib/walletAdapters/`
| File | Purpose |
|------|---------|
| `types.ts` | `WalletAdapter` interface, `WalletId` type, `WALLET_DESCRIPTORS` registry |
| `FreighterAdapter.ts` | Wraps `@stellar/freighter-api` |
| `LobstrAdapter.ts` | Wraps `@lobstrco/signer-extension-api` |
| `XBullAdapter.ts` | Uses the `window.xBullSDK` injection pattern |
| `index.ts` | Barrel export, `ALL_ADAPTERS` array, `getAdapter(id)` factory |

### New: `src/components/WalletSelectModal.tsx`
Modal listing all supported wallets. Available wallets show a connect button with a loading spinner; unavailable wallets (extension not installed) show an external install link instead.

### Modified: `src/components/WalletContext.tsx`
- `connectWallet()` now opens the `WalletSelectModal` instead of directly invoking Freighter
- Connection and signing are delegated through the active `WalletAdapter`
- Active wallet id and public key are persisted in `localStorage` (`stellar_wallet_id` / `stellar_wallet_public_key`) and silently restored on page load
- Two new fields added to `WalletContextType` (fully backwards-compatible):
  - `activeWalletId: WalletId | null`
  - `signTransaction(xdr, networkPassphrase): Promise<string>`

### Modified: `src/components/__tests__/WalletContext.test.tsx`
Tests updated to mock the adapter registry instead of `@stellar/freighter-api` directly. All 8 tests pass.

### Dependency
`@lobstrco/signer-extension-api@2.0.0` added (exact pin).

## Testing
- `npm run build` passes cleanly (TypeScript + compilation)
- All 8 `WalletContext` tests pass
- Pre-existing test failures in other suites are unaffected and confirmed present on `main` before these changes

## Notes for reviewer
- `contractClient.ts` and `offchainApiClient.ts` still import `signTransaction` from `@stellar/freighter-api` directly. A follow-up PR should migrate those call-sites to use `WalletContext.signTransaction()` so all wallets can sign contract transactions.