### PR TITLE
feat: design system, map coordinate guard, rich campaign updates, multi-sig withdrawals

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,148 @@
+# ProofOfHeart Design System
+
+The UI was built screen by screen, so the same button existed in a dozen
+near-identical forms — six blues, four radii, three focus treatments, and touch
+targets that shrank whenever a component was written in a hurry. This document
+defines the tokens and primitives that replace those ad-hoc strings.
+
+Two layers, both in this repo — no Figma round-trip is required to use them:
+
+1. **Tokens** — `src/app/globals.css`, in Tailwind v4 `@theme` blocks.
+2. **Primitives** — `src/components/ui`, importable from `@/components/ui`.
+
+## Tokens
+
+Tokens are named for **intent**, never for colour. `bg-brand` survives a
+rebrand; `bg-blue-600` does not.
+
+### Colour
+
+| Token                                      | Intent                                 |
+| ------------------------------------------ | -------------------------------------- |
+| `brand`, `brand-strong`, `brand-subtle`    | Primary action, its hover, its wash    |
+| `accent`, `accent-strong`, `accent-subtle` | Secondary brand (campaign creation)    |
+| `success`, `success-strong`                | Completed, funded, verified            |
+| `warning`, `warning-strong`                | Needs attention, pending, degraded     |
+| `danger`, `danger-strong`                  | Destructive action, validation failure |
+| `info`, `info-strong`                      | Neutral information                    |
+| `muted`, `muted-strong`                    | De-emphasised text (pre-existing)      |
+
+Each maps to a Tailwind palette step, so `bg-brand`, `text-brand`,
+`border-brand` and `ring-brand` all work.
+
+### Radius
+
+| Token             | Value   | Applies to      |
+| ----------------- | ------- | --------------- |
+| `rounded-control` | 0.75rem | Buttons, inputs |
+| `rounded-surface` | 1rem    | Cards, panels   |
+
+### Motion
+
+`--duration-fast` (150ms) for state changes such as hover and focus;
+`--duration-base` (300ms) for entrances and layout shifts. Used as
+`duration-(--duration-fast)`. Anything decorative must respect
+`motion-reduce:`.
+
+### Utilities
+
+- `tap-target` — 44px minimum height (WCAG 2.5.5). Every interactive primitive
+  applies it, so touch targets stop being hand-tuned per screen.
+- `focus-ring` — the single keyboard-focus treatment, visible in both themes.
+  Use it instead of writing `focus:ring-*` by hand; it is `focus-visible`
+  based, so mouse users do not get a ring.
+
+## Primitives
+
+```tsx
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardTitle,
+  Badge,
+  Input,
+  Textarea,
+  Tabs,
+  TabPanel,
+} from "@/components/ui";
+```
+
+### `Button`
+
+Variants are intents: `primary`, `secondary`, `ghost`, `danger`, `success`.
+Sizes: `sm`, `md`, `lg`.
+
+```tsx
+<Button variant="primary" isLoading={isSubmitting} loadingLabel="Posting…">
+  Post Update
+</Button>
+```
+
+`isLoading` disables the button, sets `aria-busy`, and swaps the label in place
+rather than replacing the node — the button keeps its width, so a layout does
+not jump mid-transaction.
+
+### `Card`
+
+The standard surface. Replaces the repeated
+`bg-white dark:bg-zinc-800 rounded-xl shadow-sm border …` string.
+`padding` is `none | sm | md | lg`; `interactive` adds a hover lift and belongs
+only on cards that are themselves a link or button.
+
+### `Badge`
+
+Status pill with a `tone` per intent. A "pending" state should be `warning` on
+every screen so the meaning stays readable.
+
+### `Input` / `Textarea`
+
+Label, hint and error in one component, with `aria-invalid`,
+`aria-describedby` and `role="alert"` wired up. An error is always announced
+instead of being a red string beside an unassociated control.
+
+### `Tabs` / `TabPanel`
+
+Implements the WAI-ARIA tabs pattern: roving `tabindex`, arrow-key navigation
+with wraparound, Home/End, and `aria-controls` / `aria-labelledby` linking each
+tab to its panel.
+
+```tsx
+<Tabs tabs={TABS} activeId={active} onChange={setActive}
+      label="Campaign sections" idPrefix="campaign" />
+<TabPanel tabId="updates" idPrefix="campaign" active={active === "updates"}>
+  <UpdatesSection campaign={campaign} />
+</TabPanel>
+```
+
+`idPrefix` must be unique per tablist on a page — it is how the tab and its
+panel derive matching element ids. An inactive `TabPanel` renders nothing, so
+panels that fetch (comments, updates) stay unmounted until opened.
+
+## Rules
+
+1. **Reach for a primitive first.** A new bespoke button or card needs a reason.
+2. **Use intent tokens, not palette steps,** in anything shared.
+3. **Never hand-roll focus.** `focus-ring` exists so the ring is identical and
+   always visible in dark mode.
+4. **Interactive means `tap-target`.** 44px minimum, no exceptions for "small"
+   controls.
+5. **Extend, don't fork.** A missing variant belongs in the primitive, not in a
+   one-off `className` in a page.
+6. **Every primitive works in both themes.** Dark mode is not a later pass.
+
+## Adoption
+
+The kit ships alongside the existing components rather than replacing them in
+one sweep — a repo-wide restyle would be unreviewable. Migrated so far:
+
+- Dashboard tabs → `Tabs` / `TabPanel`
+- Campaign updates / Q&A tabs → `Tabs` / `TabPanel`
+- Update composer actions → `Button`
+- Dashboard withdrawal cards → `Card`
+
+The remaining screens should migrate opportunistically: when you touch a
+component, swap its bespoke button, card or field for the primitive.
+
+`src/stories/UIKit.stories.tsx` renders every variant side by side — run
+`npm run storybook` to review them together.

--- a/messages/en.json
+++ b/messages/en.json
@@ -40,7 +40,10 @@
     "fundingHistory": "Funding/Donation History",
     "noFundingHistory": "No funding/donation activity yet.",
     "donated": "Donated {amount} XLM on {date}",
-    "campaignFallback": "Campaign #{id}"
+    "campaignFallback": "Campaign #{id}",
+    "withdrawalsTab": "Withdrawals",
+    "withdrawalsHeading": "Multi-Signature Withdrawals",
+    "withdrawalsDescription": "Campaigns you run. Once a campaign reaches its goal you can propose a withdrawal and collect approvals from your organization's signers before the funds move."
   },
   "MyContributions": {
     "title": "My Contributions",

--- a/messages/es.json
+++ b/messages/es.json
@@ -40,7 +40,10 @@
     "fundingHistory": "Historial de Financiación/Donaciones",
     "noFundingHistory": "Aún no hay actividad de financiación/donación.",
     "donated": "Donó {amount} XLM el {date}",
-    "campaignFallback": "Campaña #{id}"
+    "campaignFallback": "Campaña #{id}",
+    "withdrawalsTab": "Retiros",
+    "withdrawalsHeading": "Retiros con firma múltiple",
+    "withdrawalsDescription": "Campañas que administras. Cuando una campaña alcanza su meta, puedes proponer un retiro y reunir las aprobaciones de los firmantes de tu organización antes de mover los fondos."
   },
   "MyContributions": {
     "title": "Mis Contribuciones",

--- a/src/__tests__/components/UpdateComposer.test.tsx
+++ b/src/__tests__/components/UpdateComposer.test.tsx
@@ -2,6 +2,17 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UpdateComposer from "@/components/UpdateComposer";
 import { ToastProvider } from "@/components/ToastProvider";
 
+// react-markdown ships ESM this Jest setup does not transform, so the markdown
+// renderer is stubbed the same way AppPageComponents.test.tsx does.
+jest.mock("@/components/SafeMarkdown", () => ({
+  __esModule: true,
+  default: ({ children, className }: { children: string; className?: string }) => (
+    <div data-testid="safe-markdown" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
 const mockOnSubmit = jest.fn();
 
 const renderWithToastProvider = (ui: React.ReactElement) => {

--- a/src/__tests__/components/UpdateItem.test.tsx
+++ b/src/__tests__/components/UpdateItem.test.tsx
@@ -6,6 +6,19 @@ jest.mock("@/lib/campaignUpdates", () => ({
   verifyUpdateSignature: jest.fn().mockResolvedValue(true),
 }));
 
+// react-markdown ships ESM that this Jest setup does not transform, so the
+// renderer is stubbed the same way AppPageComponents.test.tsx does. Like
+// react-markdown, the stub renders its input as text and never as HTML — the
+// sanitize schema itself is covered by SafeMarkdown.test.tsx.
+jest.mock("@/components/SafeMarkdown", () => ({
+  __esModule: true,
+  default: ({ children, className }: { children: string; className?: string }) => (
+    <div data-testid="safe-markdown" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
 const mockUpdate: CampaignUpdate = {
   id: "test-update-1",
   campaignId: 1,
@@ -19,6 +32,18 @@ describe("UpdateItem", () => {
   it("renders update content correctly", () => {
     render(<UpdateItem update={mockUpdate} />);
     expect(screen.getByText(mockUpdate.content)).toBeInTheDocument();
+  });
+
+  it("renders content through the sanitized markdown renderer", () => {
+    const markdownUpdate: CampaignUpdate = {
+      ...mockUpdate,
+      content:
+        "## Milestone reached\n\nWe hit **80%** of our goal — [details](https://example.org).",
+    };
+
+    render(<UpdateItem update={markdownUpdate} />);
+
+    expect(screen.getByTestId("safe-markdown")).toHaveTextContent("Milestone reached");
   });
 
   it("displays shortened author address", () => {

--- a/src/__tests__/components/UpdatesList.test.tsx
+++ b/src/__tests__/components/UpdatesList.test.tsx
@@ -2,6 +2,17 @@ import { render, screen } from "@testing-library/react";
 import UpdatesList from "@/components/UpdatesList";
 import { CampaignUpdate } from "@/types";
 
+// react-markdown ships ESM this Jest setup does not transform, so the markdown
+// renderer is stubbed the same way AppPageComponents.test.tsx does.
+jest.mock("@/components/SafeMarkdown", () => ({
+  __esModule: true,
+  default: ({ children, className }: { children: string; className?: string }) => (
+    <div data-testid="safe-markdown" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
 const mockUpdates: CampaignUpdate[] = [
   {
     id: "update-1",

--- a/src/__tests__/integration/CampaignUpdates.test.tsx
+++ b/src/__tests__/integration/CampaignUpdates.test.tsx
@@ -6,6 +6,17 @@ import UpdatesSection from "@/components/UpdatesSection";
 import { Campaign, Category } from "@/types";
 import * as campaignUpdatesModule from "@/lib/campaignUpdates";
 
+// react-markdown ships ESM this Jest setup does not transform, so the markdown
+// renderer is stubbed the same way AppPageComponents.test.tsx does.
+jest.mock("@/components/SafeMarkdown", () => ({
+  __esModule: true,
+  default: ({ children, className }: { children: string; className?: string }) => (
+    <div data-testid="safe-markdown" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
 // Mock the campaign updates module
 jest.mock("@/lib/campaignUpdates", () => ({
   getCampaignUpdates: jest.fn(),

--- a/src/app/[locale]/admin/AdminClient.tsx
+++ b/src/app/[locale]/admin/AdminClient.tsx
@@ -28,6 +28,7 @@ const AdminTwoFactorSetup = dynamic(() => import("@/components/admin/AdminTwoFac
 const CampaignMap = dynamic(() => import("@/components/CampaignMap"), {
   ssr: false,
 });
+import MapErrorBoundary from "@/components/MapErrorBoundary";
 
 const TransferAdminModal = dynamic(() => import("@/components/TransferAdminModal"), {
   ssr: false,
@@ -752,7 +753,10 @@ export default function AdminDashboard() {
 
       {/* ── Campaign Map ── */}
       <section className="mt-12">
-        <CampaignMap campaigns={campaigns} />
+        {/* A Leaflet failure here must not take the whole admin console down. */}
+        <MapErrorBoundary>
+          <CampaignMap campaigns={campaigns} />
+        </MapErrorBoundary>
       </section>
 
       {/* ── Two-Factor Authentication ── */}

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -6,7 +6,7 @@ import { notFound } from "next/navigation";
 import Image from "next/image";
 import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
-import UpdatesSection from "@/components/UpdatesSection";
+import CampaignTabs from "@/components/CampaignTabs";
 const RevenueSharingPanel = dynamic(() => import("@/components/RevenueSharingPanel"), {
   ssr: false,
 });
@@ -551,8 +551,8 @@ export default function CauseDetailClient({ id }: { id: string }) {
               </div>
             )}
 
-            {/* Updates Section */}
-            <UpdatesSection campaign={campaign} />
+            {/* Updates / Q&A tabs */}
+            <CampaignTabs campaign={campaign} />
           </div>
 
           <div className="space-y-6">

--- a/src/app/[locale]/dashboard/DashboardClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardClient.tsx
@@ -1,16 +1,24 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import React, { useMemo, useState } from "react";
 import MyContributionsSection from "@/components/MyContributionsSection";
 import TransactionHistorySection from "@/components/TransactionHistorySection";
 import { Spinner, DashboardSkeleton } from "@/components/Skeleton";
 import { useWallet } from "@/components/WalletContext";
+import { Tabs, TabPanel, Card } from "@/components/ui";
 import { useCampaigns } from "@/hooks/useCampaigns";
 import { useStellarBalance } from "@/hooks/useStellarBalance";
 import { useSavedCampaigns } from "@/hooks/useSavedCampaigns";
 import { isSameAddress } from "@/lib/stellar";
+
+// Pulls in the contract client and the proposal store; only creators with a
+// funded campaign ever open this tab, so keep it out of the dashboard bundle.
+const MultiSigWithdrawalPanel = dynamic(() => import("@/components/MultiSigWithdrawalPanel"), {
+  ssr: false,
+});
 
 export default function DashboardPage() {
   const t = useTranslations("Dashboard");
@@ -24,7 +32,9 @@ export default function DashboardPage() {
   const balanceError = balanceQueryError ? t("balanceFetchError") : null;
   const { savedIds } = useSavedCampaigns();
 
-  const [activeTab, setActiveTab] = useState<"overview" | "contributions" | "history">("overview");
+  const [activeTab, setActiveTab] = useState<
+    "overview" | "contributions" | "history" | "withdrawals"
+  >("overview");
 
   const savedCampaigns = useMemo(
     () => campaigns.filter((c) => savedIds.includes(c.id)),
@@ -61,10 +71,11 @@ export default function DashboardPage() {
     return <DashboardSkeleton />;
   }
 
-  const tabs: Array<{ id: typeof activeTab; label: string }> = [
+  const tabs: Array<{ id: typeof activeTab; label: string; count?: number }> = [
     { id: "overview", label: "Overview" },
     { id: "contributions", label: "My Contributions" },
     { id: "history", label: "Transaction History" },
+    { id: "withdrawals", label: t("withdrawalsTab"), count: submittedCampaigns.length },
   ];
 
   return (
@@ -72,115 +83,126 @@ export default function DashboardPage() {
       <h1 className="text-3xl font-bold mb-6">{t("title")}</h1>
 
       {/* Tab navigation */}
-      <div
-        className="flex gap-1 mb-8 border-b border-zinc-200 dark:border-zinc-700"
-        role="tablist"
-        aria-label="Dashboard sections"
-      >
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            role="tab"
-            aria-selected={activeTab === tab.id}
-            aria-controls={`tabpanel-${tab.id}`}
-            onClick={() => setActiveTab(tab.id)}
-            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              activeTab === tab.id
-                ? "border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400"
-                : "border-transparent text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      <Tabs
+        tabs={tabs}
+        activeId={activeTab}
+        onChange={setActiveTab}
+        label="Dashboard sections"
+        idPrefix="dashboard"
+        className="mb-8"
+      />
 
       {/* Overview tab */}
-      {activeTab === "overview" && (
-        <div role="tabpanel" id="tabpanel-overview" aria-label="Overview">
-          <section className="mb-8">
-            <h2 className="text-xl font-semibold mb-2">{t("walletBalance")}</h2>
-            {balanceLoading ? (
-              <span className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
-                <Spinner className="h-4 w-4 text-blue-500" /> {t("loadingBalance")}
-              </span>
-            ) : balanceError ? (
-              <span className="text-red-500">{balanceError}</span>
-            ) : (
-              <span className="text-zinc-900 dark:text-zinc-50 font-mono">{balance} XLM</span>
-            )}
-          </section>
+      <TabPanel tabId="overview" idPrefix="dashboard" active={activeTab === "overview"}>
+        <section className="mb-8">
+          <h2 className="text-xl font-semibold mb-2">{t("walletBalance")}</h2>
+          {balanceLoading ? (
+            <span className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
+              <Spinner className="h-4 w-4 text-blue-500" /> {t("loadingBalance")}
+            </span>
+          ) : balanceError ? (
+            <span className="text-red-500">{balanceError}</span>
+          ) : (
+            <span className="text-zinc-900 dark:text-zinc-50 font-mono">{balance} XLM</span>
+          )}
+        </section>
 
-          <section className="mb-8">
-            <h2 className="text-xl font-semibold mb-2">Saved Campaigns</h2>
-            {savedCampaigns.length === 0 ? (
-              <span className="text-zinc-500 dark:text-zinc-400">
-                You haven&apos;t saved any campaigns yet.
-              </span>
-            ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {savedCampaigns.map((campaign) => (
+        <section className="mb-8">
+          <h2 className="text-xl font-semibold mb-2">Saved Campaigns</h2>
+          {savedCampaigns.length === 0 ? (
+            <span className="text-zinc-500 dark:text-zinc-400">
+              You haven&apos;t saved any campaigns yet.
+            </span>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {savedCampaigns.map((campaign) => (
+                <Link
+                  key={campaign.id}
+                  href={`/causes/${campaign.id}`}
+                  className="border rounded-xl p-4 bg-zinc-50 dark:bg-zinc-900 hover:border-blue-300 dark:hover:border-blue-700 transition-colors"
+                >
+                  <div className="font-medium text-zinc-900 dark:text-zinc-50">
+                    {campaign.title}
+                  </div>
+                  <div className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 line-clamp-2 break-words">
+                    {campaign.description}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-xl font-semibold mb-2">{t("submittedCampaigns")}</h2>
+          {submittedCampaigns.length === 0 ? (
+            <span className="text-zinc-500 dark:text-zinc-400">{t("noSubmittedCampaigns")}</span>
+          ) : (
+            <ul className="space-y-2">
+              {submittedCampaigns.map((campaign) => (
+                <li
+                  key={campaign.id}
+                  className="border rounded-xl p-4 bg-zinc-50 dark:bg-zinc-900 min-h-[60px]"
+                >
                   <Link
-                    key={campaign.id}
                     href={`/causes/${campaign.id}`}
-                    className="border rounded-xl p-4 bg-zinc-50 dark:bg-zinc-900 hover:border-blue-300 dark:hover:border-blue-700 transition-colors"
+                    className="font-medium text-zinc-900 dark:text-zinc-50 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
                   >
-                    <div className="font-medium text-zinc-900 dark:text-zinc-50">
-                      {campaign.title}
-                    </div>
-                    <div className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 line-clamp-2 break-words">
-                      {campaign.description}
-                    </div>
+                    {campaign.title}
                   </Link>
-                ))}
-              </div>
-            )}
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-xl font-semibold mb-2">{t("submittedCampaigns")}</h2>
-            {submittedCampaigns.length === 0 ? (
-              <span className="text-zinc-500 dark:text-zinc-400">{t("noSubmittedCampaigns")}</span>
-            ) : (
-              <ul className="space-y-2">
-                {submittedCampaigns.map((campaign) => (
-                  <li
-                    key={campaign.id}
-                    className="border rounded-xl p-4 bg-zinc-50 dark:bg-zinc-900 min-h-[60px]"
-                  >
-                    <Link
-                      href={`/causes/${campaign.id}`}
-                      className="font-medium text-zinc-900 dark:text-zinc-50 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                    >
-                      {campaign.title}
-                    </Link>
-                    <div className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 line-clamp-2">
-                      {campaign.description}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-        </div>
-      )}
+                  <div className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 line-clamp-2">
+                    {campaign.description}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </TabPanel>
 
       {/* Contributions tab */}
-      {activeTab === "contributions" && (
-        <div role="tabpanel" id="tabpanel-contributions" aria-label="My Contributions">
-          <MyContributionsSection walletAddress={publicKey} />
-        </div>
-      )}
+      <TabPanel tabId="contributions" idPrefix="dashboard" active={activeTab === "contributions"}>
+        <MyContributionsSection walletAddress={publicKey} />
+      </TabPanel>
 
       {/* Transaction History tab */}
-      {activeTab === "history" && (
-        <div role="tabpanel" id="tabpanel-history" aria-label="Transaction History">
-          <TransactionHistorySection
-            walletAddress={publicKey}
-            campaignTitleMap={campaignTitleMap}
-          />
-        </div>
-      )}
+      <TabPanel tabId="history" idPrefix="dashboard" active={activeTab === "history"}>
+        <TransactionHistorySection walletAddress={publicKey} campaignTitleMap={campaignTitleMap} />
+      </TabPanel>
+
+      {/* Withdrawals tab — multi-signature approvals for campaigns you run */}
+      <TabPanel tabId="withdrawals" idPrefix="dashboard" active={activeTab === "withdrawals"}>
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold mb-1">{t("withdrawalsHeading")}</h2>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              {t("withdrawalsDescription")}
+            </p>
+          </div>
+
+          {submittedCampaigns.length === 0 ? (
+            <span className="text-zinc-500 dark:text-zinc-400">{t("noSubmittedCampaigns")}</span>
+          ) : (
+            submittedCampaigns.map((campaign) => (
+              <Card key={campaign.id} padding="sm" className="bg-zinc-50 dark:bg-zinc-900">
+                <div className="flex items-start justify-between gap-3">
+                  <Link
+                    href={`/causes/${campaign.id}`}
+                    className="font-medium text-zinc-900 dark:text-zinc-50 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                  >
+                    {campaign.title}
+                  </Link>
+                </div>
+
+                {/* The panel renders nothing unless the campaign is funded and
+                    not yet withdrawn, so campaigns that cannot pay out stay
+                    listed but quiet. */}
+                <MultiSigWithdrawalPanel campaign={campaign} walletAddress={publicKey} />
+              </Card>
+            ))
+          )}
+        </section>
+      </TabPanel>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,6 +68,57 @@ body {
   --color-muted-strong: var(--color-zinc-700);
 }
 
+/* =========================================================================
+   Design system tokens
+   -------------------------------------------------------------------------
+   The single source of truth for brand colour, radius, elevation and motion.
+   UI primitives in `src/components/ui` consume these, so a token change here
+   propagates through every surface instead of being re-typed per component.
+   See docs/DESIGN_SYSTEM.md.
+
+   Semantic intents: brand (primary action), accent (secondary brand),
+   success, warning, danger, info. Each has a base and a `-strong` hover step.
+   ========================================================================= */
+@theme {
+  /* ── Brand ─────────────────────────────────────────────────────────── */
+  --color-brand: var(--color-blue-600);
+  --color-brand-strong: var(--color-blue-700);
+  --color-brand-subtle: var(--color-blue-50);
+  --color-accent: var(--color-purple-600);
+  --color-accent-strong: var(--color-purple-700);
+  --color-accent-subtle: var(--color-purple-50);
+
+  /* ── Status ────────────────────────────────────────────────────────── */
+  --color-success: var(--color-green-600);
+  --color-success-strong: var(--color-green-700);
+  --color-warning: var(--color-amber-500);
+  --color-warning-strong: var(--color-amber-600);
+  --color-danger: var(--color-red-600);
+  --color-danger-strong: var(--color-red-700);
+  --color-info: var(--color-sky-600);
+  --color-info-strong: var(--color-sky-700);
+
+  /* ── Radius scale ──────────────────────────────────────────────────── */
+  --radius-control: 0.75rem; /* buttons, inputs */
+  --radius-surface: 1rem; /* cards, panels */
+
+  /* ── Motion ────────────────────────────────────────────────────────── */
+  --duration-fast: 150ms;
+  --duration-base: 300ms;
+}
+
+/* Minimum interactive target (WCAG 2.5.5). Applied by every UI primitive
+   so touch targets stay consistent instead of being hand-tuned per button. */
+@utility tap-target {
+  min-height: 44px;
+}
+
+/* The one focus ring for the whole app: consistent, visible in both themes,
+   and only shown for keyboard focus. */
+@utility focus-ring {
+  @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900;
+}
+
 /* Custom utility utilities for responsive accessibility */
 @utility text-muted {
   @apply text-zinc-500 dark:text-zinc-300;

--- a/src/components/CampaignMap.tsx
+++ b/src/components/CampaignMap.tsx
@@ -21,14 +21,34 @@ const defaultIcon = L.icon({
 
 L.Marker.prototype.options.icon = defaultIcon;
 
+/** Geographic bounds of a WGS-84 coordinate. */
+export const LATITUDE_BOUNDS = { min: -90, max: 90 } as const;
+export const LONGITUDE_BOUNDS = { min: -180, max: 180 } as const;
+
+/**
+ * True when a campaign carries coordinates Leaflet can actually project.
+ *
+ * Presence and finiteness are not enough: Leaflet's Mercator projection blows
+ * up on out-of-range latitudes (|lat| >= 90 projects to ±Infinity, which
+ * throws inside `MapContainer` and takes the whole page down), and a longitude
+ * outside ±180 places a marker off the world. Bad data from the contract or a
+ * mistyped form entry therefore has to be rejected here, before it reaches
+ * the map.
+ */
 export function hasValidCoordinates(
   campaign: Campaign,
 ): campaign is Campaign & { latitude: number; longitude: number } {
+  const { latitude, longitude } = campaign;
+
   return (
-    campaign.latitude != null &&
-    campaign.longitude != null &&
-    Number.isFinite(campaign.latitude) &&
-    Number.isFinite(campaign.longitude)
+    latitude != null &&
+    longitude != null &&
+    Number.isFinite(latitude) &&
+    Number.isFinite(longitude) &&
+    latitude >= LATITUDE_BOUNDS.min &&
+    latitude <= LATITUDE_BOUNDS.max &&
+    longitude >= LONGITUDE_BOUNDS.min &&
+    longitude <= LONGITUDE_BOUNDS.max
   );
 }
 

--- a/src/components/CampaignTabs.tsx
+++ b/src/components/CampaignTabs.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Campaign } from "@/types";
+import CommentsSection from "@/components/CommentsSection";
+import UpdatesSection from "@/components/UpdatesSection";
+import { Tabs, TabPanel } from "@/components/ui";
+
+type CampaignTabId = "updates" | "comments";
+
+const TABS = [
+  { id: "updates" as const, label: "Updates" },
+  { id: "comments" as const, label: "Comments / Q&A" },
+];
+
+interface CampaignTabsProps {
+  campaign: Campaign;
+}
+
+/**
+ * Tabbed footer of the campaign detail page.
+ *
+ * Updates and the Q&A thread each pull their own list, so stacking both meant
+ * every visitor paid for both queries and had to scroll past one to reach the
+ * other. `TabPanel` unmounts the inactive panel, so only the open tab fetches.
+ */
+export default function CampaignTabs({ campaign }: CampaignTabsProps) {
+  const [activeTab, setActiveTab] = useState<CampaignTabId>("updates");
+
+  return (
+    <div className="space-y-6">
+      <Tabs
+        tabs={TABS}
+        activeId={activeTab}
+        onChange={setActiveTab}
+        label="Campaign updates and discussion"
+        idPrefix="campaign"
+      />
+
+      <TabPanel tabId="updates" idPrefix="campaign" active={activeTab === "updates"}>
+        <UpdatesSection campaign={campaign} />
+      </TabPanel>
+
+      <TabPanel tabId="comments" idPrefix="campaign" active={activeTab === "comments"}>
+        <CommentsSection campaign={campaign} />
+      </TabPanel>
+    </div>
+  );
+}

--- a/src/components/UpdateComposer.tsx
+++ b/src/components/UpdateComposer.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
-import { Loader2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { Bold, Italic, Link2, List, Heading2 } from "lucide-react";
+import SafeMarkdown from "@/components/SafeMarkdown";
 import { useToast } from "@/components/ToastProvider";
+import { Button } from "@/components/ui";
 
 interface UpdateComposerProps {
   campaignId: number;
@@ -14,9 +16,27 @@ interface UpdateComposerProps {
 const MIN_CONTENT_LENGTH = 10;
 const MAX_CONTENT_LENGTH = 2000;
 
+type ComposerMode = "write" | "preview";
+
 /**
- * Composer component for campaign creators to post updates.
- * Only visible/enabled for the campaign creator.
+ * Markdown snippets the toolbar inserts. `wrap` surrounds the selection,
+ * `prefix` starts the line — enough to cover the formatting creators reach for
+ * without pulling in a WYSIWYG editor and its sanitisation surface.
+ */
+const TOOLBAR = [
+  { id: "bold", label: "Bold", icon: Bold, wrap: "**", placeholder: "bold text" },
+  { id: "italic", label: "Italic", icon: Italic, wrap: "_", placeholder: "italic text" },
+  { id: "heading", label: "Heading", icon: Heading2, prefix: "## ", placeholder: "Heading" },
+  { id: "list", label: "Bullet list", icon: List, prefix: "- ", placeholder: "List item" },
+  { id: "link", label: "Link", icon: Link2, link: true, placeholder: "link text" },
+] as const;
+
+/**
+ * Composer for campaign creators to post rich updates.
+ *
+ * Content is markdown: it is stored as written and rendered through
+ * `SafeMarkdown`, so the preview here is the same renderer contributors see.
+ * Only visible to the campaign creator.
  */
 export default function UpdateComposer({
   campaignId,
@@ -27,7 +47,39 @@ export default function UpdateComposer({
   const [content, setContent] = useState("");
   const [isExpanded, setIsExpanded] = useState(false);
   const [notify, setNotify] = useState(true);
+  const [mode, setMode] = useState<ComposerMode>("write");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { showError, showSuccess } = useToast();
+
+  const applyFormat = (item: (typeof TOOLBAR)[number]) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selected = content.slice(start, end) || item.placeholder;
+
+    let inserted: string;
+    if ("link" in item) {
+      inserted = `[${selected}](https://)`;
+    } else if ("wrap" in item) {
+      inserted = `${item.wrap}${selected}${item.wrap}`;
+    } else {
+      // Line prefix: start on a fresh line unless we already are on one.
+      const needsNewline = start > 0 && content[start - 1] !== "\n";
+      inserted = `${needsNewline ? "\n" : ""}${item.prefix}${selected}`;
+    }
+
+    const next = content.slice(0, start) + inserted + content.slice(end);
+    setContent(next);
+
+    // Restore focus and put the caret after the inserted snippet.
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const caret = start + inserted.length;
+      textarea.setSelectionRange(caret, caret);
+    });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,6 +94,7 @@ export default function UpdateComposer({
       await onSubmit(trimmedContent, notify);
       setContent("");
       setIsExpanded(false);
+      setMode("write");
       showSuccess("Update posted successfully!");
     } catch (error) {
       showError(
@@ -53,6 +106,7 @@ export default function UpdateComposer({
   const handleCancel = () => {
     setContent("");
     setIsExpanded(false);
+    setMode("write");
   };
 
   const characterCount = content.length;
@@ -92,21 +146,82 @@ export default function UpdateComposer({
         </button>
       ) : (
         <div className="space-y-5">
-          {/* Textarea */}
-          <div className="relative">
-            <label htmlFor={`update-content-${campaignId}`} className="sr-only">
-              Update content
-            </label>
-            <textarea
-              id={`update-content-${campaignId}`}
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="Share progress, milestones, or news..."
-              rows={5}
-              className="w-full px-5 py-4 bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-700 rounded-2xl text-zinc-900 dark:text-zinc-50 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 dark:focus:ring-purple-400/50 focus:border-purple-500/50 transition-all text-sm leading-relaxed"
-              autoFocus
-            />
+          {/* Write / Preview switch */}
+          <div className="flex items-center justify-between gap-3 border-b border-zinc-200 dark:border-zinc-700 pb-2">
+            <div className="flex gap-1">
+              {(["write", "preview"] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setMode(m)}
+                  aria-pressed={mode === m}
+                  className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors ${
+                    mode === m
+                      ? "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300"
+                      : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-200"
+                  }`}
+                >
+                  {m === "write" ? "Write" : "Preview"}
+                </button>
+              ))}
+            </div>
+
+            {mode === "write" && (
+              <div className="flex items-center gap-0.5">
+                {TOOLBAR.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => applyFormat(item)}
+                      title={item.label}
+                      aria-label={item.label}
+                      className="p-1.5 rounded-md text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+                    >
+                      <Icon className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
+
+          {mode === "write" ? (
+            <div className="relative">
+              <label htmlFor={`update-content-${campaignId}`} className="sr-only">
+                Update content
+              </label>
+              <textarea
+                ref={textareaRef}
+                id={`update-content-${campaignId}`}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="Share progress, milestones, or news… Markdown is supported."
+                rows={5}
+                className="w-full px-5 py-4 bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-700 rounded-2xl text-zinc-900 dark:text-zinc-50 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 dark:focus:ring-purple-400/50 focus:border-purple-500/50 transition-all text-sm leading-relaxed"
+                autoFocus
+              />
+              <p className="mt-2 text-[11px] text-zinc-500 dark:text-zinc-400">
+                Supports markdown: **bold**, _italic_, ## headings, - lists and [links](url).
+              </p>
+            </div>
+          ) : (
+            <div
+              className="min-h-[140px] px-5 py-4 bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-700 rounded-2xl"
+              data-testid="update-preview"
+            >
+              {content.trim() ? (
+                <SafeMarkdown className="prose prose-sm prose-zinc dark:prose-invert max-w-none break-words">
+                  {content}
+                </SafeMarkdown>
+              ) : (
+                <p className="text-sm text-zinc-400 dark:text-zinc-500">
+                  Nothing to preview yet — switch to Write and start typing.
+                </p>
+              )}
+            </div>
+          )}
 
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             {/* Notify toggle */}
@@ -143,28 +258,24 @@ export default function UpdateComposer({
 
           {/* Action buttons */}
           <div className="flex items-center gap-3 pt-2">
-            <button
+            <Button
               type="submit"
               disabled={!canSubmit}
-              className="flex-1 py-3 px-6 bg-linear-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 disabled:from-zinc-200 disabled:to-zinc-300 dark:disabled:from-zinc-800 dark:disabled:to-zinc-900 disabled:text-zinc-500 dark:disabled:text-zinc-600 text-white font-bold rounded-xl transition-all duration-300 shadow-md hover:shadow-lg disabled:shadow-none text-sm active:scale-[0.98]"
+              isLoading={isSubmitting}
+              loadingLabel="Posting..."
+              fullWidth
+              className="flex-1 bg-linear-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white"
             >
-              {isSubmitting ? (
-                <span className="flex items-center justify-center gap-2">
-                  <Loader2 className="animate-spin h-4 w-4" aria-hidden="true" />
-                  Posting...
-                </span>
-              ) : (
-                "Post Update"
-              )}
-            </button>
-            <button
+              Post Update
+            </Button>
+            <Button
               type="button"
+              variant="secondary"
               onClick={handleCancel}
               disabled={isSubmitting}
-              className="py-3 px-6 border-2 border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 disabled:opacity-50 font-bold rounded-xl transition-all duration-300 text-sm"
             >
               Cancel
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/src/components/UpdateItem.tsx
+++ b/src/components/UpdateItem.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { ShieldCheck } from "lucide-react";
 import { CampaignUpdate } from "@/types";
+import SafeMarkdown from "./SafeMarkdown";
 import VerifiedIcon from "./icons/VerifiedIcon";
 import { verifyUpdateSignature } from "@/lib/campaignUpdates";
 
@@ -125,10 +126,11 @@ export default function UpdateItem({ update }: UpdateItemProps) {
         </div>
       </div>
 
-      {/* Update content */}
-      <div className="text-zinc-700 dark:text-zinc-300 leading-relaxed whitespace-pre-wrap break-words text-sm ml-0 sm:ml-16">
+      {/* Update content — markdown, sanitized with the same hardened schema
+          used for campaign descriptions. Author input is never trusted HTML. */}
+      <SafeMarkdown className="prose prose-sm prose-zinc dark:prose-invert max-w-none break-words text-zinc-700 dark:text-zinc-300 ml-0 sm:ml-16">
         {update.content}
-      </div>
+      </SafeMarkdown>
     </article>
   );
 }

--- a/src/components/__tests__/CampaignMap.test.tsx
+++ b/src/components/__tests__/CampaignMap.test.tsx
@@ -115,6 +115,33 @@ describe("hasValidCoordinates", () => {
     const campaign = makeCampaign({ latitude: -Infinity, longitude: -74.006 });
     expect(hasValidCoordinates(campaign)).toBe(false);
   });
+
+  // Out-of-range values are finite numbers, so a finiteness check alone lets
+  // them through — and Leaflet's Mercator projection throws on |lat| >= 90.
+  it("returns false when latitude is above 90", () => {
+    expect(hasValidCoordinates(makeCampaign({ latitude: 91, longitude: 0 }))).toBe(false);
+  });
+
+  it("returns false when latitude is below -90", () => {
+    expect(hasValidCoordinates(makeCampaign({ latitude: -90.5, longitude: 0 }))).toBe(false);
+  });
+
+  it("returns false when longitude is above 180", () => {
+    expect(hasValidCoordinates(makeCampaign({ latitude: 0, longitude: 180.1 }))).toBe(false);
+  });
+
+  it("returns false when longitude is below -180", () => {
+    expect(hasValidCoordinates(makeCampaign({ latitude: 0, longitude: -181 }))).toBe(false);
+  });
+
+  it("accepts the exact bounds of the coordinate system", () => {
+    expect(hasValidCoordinates(makeCampaign({ latitude: 90, longitude: 180 }))).toBe(true);
+    expect(hasValidCoordinates(makeCampaign({ latitude: -90, longitude: -180 }))).toBe(true);
+  });
+
+  it("accepts null island (0, 0) — a valid coordinate, not a missing one", () => {
+    expect(hasValidCoordinates(makeCampaign({ latitude: 0, longitude: 0 }))).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -145,6 +172,16 @@ describe("filterByValidCoordinates", () => {
   it("handles empty array", () => {
     const result = filterByValidCoordinates([]);
     expect(result).toHaveLength(0);
+  });
+
+  it("drops out-of-range coordinates before they reach the map", () => {
+    const good = makeCampaign({ id: 1, latitude: 40.7128, longitude: -74.006 });
+    const badLat = makeCampaign({ id: 2, latitude: 1000, longitude: 10 });
+    const badLng = makeCampaign({ id: 3, latitude: 10, longitude: -900 });
+
+    const result = filterByValidCoordinates([good, badLat, badLng]);
+
+    expect(result.map((c) => c.id)).toEqual([1]);
   });
 });
 

--- a/src/components/__tests__/ui.test.tsx
+++ b/src/components/__tests__/ui.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { Badge, Button, Card, CardTitle, Input, TabPanel, Tabs, Textarea } from "@/components/ui";
+
+// ---------------------------------------------------------------------------
+// Button
+// ---------------------------------------------------------------------------
+
+describe("Button", () => {
+  it("renders its label and fires onClick", async () => {
+    const onClick = jest.fn();
+    render(<Button onClick={onClick}>Donate</Button>);
+
+    await userEvent.click(screen.getByRole("button", { name: "Donate" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to type=button so it cannot submit a form by accident", () => {
+    render(<Button>Cancel</Button>);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+  });
+
+  it("is disabled and marked busy while loading", () => {
+    render(
+      <Button isLoading loadingLabel="Posting…">
+        Post Update
+      </Button>,
+    );
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).toHaveTextContent("Posting…");
+  });
+
+  it("swallows clicks while loading", async () => {
+    const onClick = jest.fn();
+    render(
+      <Button isLoading onClick={onClick}>
+        Post
+      </Button>,
+    );
+
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("keeps the caller's className last so it can override", () => {
+    render(<Button className="custom-class">Go</Button>);
+    expect(screen.getByRole("button").className).toMatch(/custom-class$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Card + Badge
+// ---------------------------------------------------------------------------
+
+describe("Card", () => {
+  it("renders as the requested element", () => {
+    render(
+      <Card as="section" aria-label="Panel">
+        <CardTitle>Heading</CardTitle>
+      </Card>,
+    );
+
+    expect(screen.getByRole("region", { name: "Panel" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Heading" })).toBeInTheDocument();
+  });
+});
+
+describe("Badge", () => {
+  it("renders its content", () => {
+    render(<Badge tone="warning">Pending</Badge>);
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fields
+// ---------------------------------------------------------------------------
+
+describe("Input / Textarea", () => {
+  it("associates the label with the control", () => {
+    render(<Input label="Signer address" />);
+    expect(screen.getByLabelText("Signer address")).toBeInTheDocument();
+  });
+
+  it("exposes the error to assistive tech", () => {
+    render(<Input label="Goal" error="Must be greater than zero." />);
+
+    const input = screen.getByLabelText("Goal");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("alert")).toHaveTextContent("Must be greater than zero.");
+    expect(input.getAttribute("aria-describedby")).toBe(screen.getByRole("alert").id);
+  });
+
+  it("describes the control with its hint when there is no error", () => {
+    render(<Textarea label="Update" hint="Markdown supported." />);
+
+    const textarea = screen.getByLabelText("Update");
+    expect(textarea).not.toHaveAttribute("aria-invalid");
+    expect(textarea.getAttribute("aria-describedby")).toBe(
+      screen.getByText("Markdown supported.").id,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+
+const TABS = [
+  { id: "updates" as const, label: "Updates" },
+  { id: "comments" as const, label: "Comments" },
+];
+
+function TabsHarness() {
+  const [active, setActive] = useState<"updates" | "comments">("updates");
+
+  return (
+    <>
+      <Tabs
+        tabs={TABS}
+        activeId={active}
+        onChange={setActive}
+        label="Campaign sections"
+        idPrefix="test"
+      />
+      <TabPanel tabId="updates" idPrefix="test" active={active === "updates"}>
+        Updates panel
+      </TabPanel>
+      <TabPanel tabId="comments" idPrefix="test" active={active === "comments"}>
+        Comments panel
+      </TabPanel>
+    </>
+  );
+}
+
+describe("Tabs", () => {
+  it("shows only the active panel", () => {
+    render(<TabsHarness />);
+
+    expect(screen.getByText("Updates panel")).toBeInTheDocument();
+    expect(screen.queryByText("Comments panel")).not.toBeInTheDocument();
+  });
+
+  it("switches panels on click", async () => {
+    render(<TabsHarness />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Comments" }));
+
+    expect(screen.getByText("Comments panel")).toBeInTheDocument();
+    expect(screen.queryByText("Updates panel")).not.toBeInTheDocument();
+  });
+
+  it("wires aria-controls to the panel it opens", async () => {
+    render(<TabsHarness />);
+
+    const tab = screen.getByRole("tab", { name: "Updates" });
+    expect(tab).toHaveAttribute("aria-selected", "true");
+    expect(tab.getAttribute("aria-controls")).toBe(screen.getByRole("tabpanel").id);
+    expect(screen.getByRole("tabpanel").getAttribute("aria-labelledby")).toBe(tab.id);
+  });
+
+  it("uses a roving tabindex so the tablist is one tab stop", () => {
+    render(<TabsHarness />);
+
+    expect(screen.getByRole("tab", { name: "Updates" })).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("tab", { name: "Comments" })).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("moves between tabs with arrow keys and wraps around", async () => {
+    render(<TabsHarness />);
+
+    screen.getByRole("tab", { name: "Updates" }).focus();
+
+    await userEvent.keyboard("{ArrowRight}");
+    expect(screen.getByRole("tab", { name: "Comments" })).toHaveAttribute("aria-selected", "true");
+
+    await userEvent.keyboard("{ArrowRight}");
+    expect(screen.getByRole("tab", { name: "Updates" })).toHaveAttribute("aria-selected", "true");
+
+    await userEvent.keyboard("{End}");
+    expect(screen.getByRole("tab", { name: "Comments" })).toHaveAttribute("aria-selected", "true");
+
+    await userEvent.keyboard("{Home}");
+    expect(screen.getByRole("tab", { name: "Updates" })).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { cn } from "./cn";
+
+export type BadgeTone = "neutral" | "brand" | "accent" | "success" | "warning" | "danger" | "info";
+
+const TONES: Record<BadgeTone, string> = {
+  neutral:
+    "bg-zinc-100 text-zinc-700 border-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700",
+  brand:
+    "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800",
+  accent:
+    "bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:border-purple-800",
+  success:
+    "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
+  warning:
+    "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800",
+  danger:
+    "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800",
+  info: "bg-sky-100 text-sky-700 border-sky-200 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-800",
+};
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone;
+  size?: "sm" | "md";
+}
+
+/**
+ * Small status pill. Tones are intents, not colours — a "pending" badge should
+ * be `warning` everywhere so the meaning stays readable across screens.
+ */
+export default function Badge({
+  tone = "neutral",
+  size = "md",
+  className,
+  children,
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border font-semibold whitespace-nowrap",
+        size === "sm" ? "px-2 py-0.5 text-[10px]" : "px-2.5 py-0.5 text-xs",
+        TONES[tone],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { forwardRef } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "./cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "success";
+export type ButtonSize = "sm" | "md" | "lg";
+
+const VARIANTS: Record<ButtonVariant, string> = {
+  primary: "bg-brand text-white hover:bg-brand-strong shadow-sm",
+  secondary:
+    "border border-zinc-300 dark:border-zinc-600 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800",
+  ghost: "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800",
+  danger: "bg-danger text-white hover:bg-danger-strong shadow-sm",
+  success: "bg-success text-white hover:bg-success-strong shadow-sm",
+};
+
+const SIZES: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs gap-1.5",
+  md: "px-4 py-2.5 text-sm gap-2",
+  lg: "px-6 py-3 text-base gap-2",
+};
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  /** Renders a spinner, disables the button, and marks it `aria-busy`. */
+  isLoading?: boolean;
+  /** Replaces the label while loading. Falls back to the normal children. */
+  loadingLabel?: string;
+  fullWidth?: boolean;
+}
+
+/**
+ * The one button. Every variant is a semantic intent, not a colour, so a token
+ * change in `globals.css` restyles the whole app.
+ *
+ * A loading button stays mounted and keeps its width — the label swaps rather
+ * than the node being replaced, so layout does not jump mid-transaction.
+ */
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = "primary",
+    size = "md",
+    isLoading = false,
+    loadingLabel,
+    fullWidth = false,
+    disabled,
+    className,
+    children,
+    type = "button",
+    ...props
+  },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      disabled={disabled || isLoading}
+      aria-busy={isLoading || undefined}
+      className={cn(
+        "inline-flex items-center justify-center rounded-control font-semibold tap-target focus-ring",
+        "transition-colors duration-(--duration-fast)",
+        "disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none",
+        "active:scale-[0.98] motion-reduce:active:scale-100",
+        VARIANTS[variant],
+        SIZES[size],
+        fullWidth && "w-full",
+        className,
+      )}
+      {...props}
+    >
+      {isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+      {isLoading ? (loadingLabel ?? children) : children}
+    </button>
+  );
+});
+
+export default Button;

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { cn } from "./cn";
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** `md` is the standard panel padding; `none` lets the caller own it. */
+  padding?: "none" | "sm" | "md" | "lg";
+  /** Adds a hover lift. Use only when the whole card is a link or button. */
+  interactive?: boolean;
+  as?: "div" | "section" | "article" | "aside";
+}
+
+const PADDING = {
+  none: "",
+  sm: "p-4",
+  md: "p-6",
+  lg: "p-8",
+} as const;
+
+/**
+ * The standard surface: white on light, zinc-800 on dark, one border, one
+ * radius. Replaces the hand-repeated
+ * `bg-white dark:bg-zinc-800 rounded-xl shadow-sm border …` string that had
+ * drifted across the campaign, dashboard and admin screens.
+ */
+export default function Card({
+  padding = "md",
+  interactive = false,
+  as: Tag = "div",
+  className,
+  children,
+  ...props
+}: CardProps) {
+  return (
+    <Tag
+      className={cn(
+        "bg-white dark:bg-zinc-800 rounded-surface border border-zinc-200 dark:border-zinc-700 shadow-sm",
+        interactive &&
+          "transition-shadow duration-(--duration-base) hover:shadow-md hover:border-zinc-300 dark:hover:border-zinc-600",
+        PADDING[padding],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+export function CardHeader({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn("flex items-center justify-between gap-3 mb-4", className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function CardTitle({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h2
+      className={cn("text-lg font-semibold text-zinc-900 dark:text-zinc-50", className)}
+      {...props}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { forwardRef, useId } from "react";
+import { cn } from "./cn";
+
+const CONTROL_BASE =
+  "w-full px-3 py-2.5 text-sm rounded-control bg-white dark:bg-zinc-900 " +
+  "text-zinc-900 dark:text-zinc-50 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 " +
+  "border border-zinc-300 dark:border-zinc-600 focus-ring " +
+  "transition-colors duration-(--duration-fast) disabled:opacity-60 disabled:cursor-not-allowed";
+
+const INVALID = "border-danger dark:border-danger focus-visible:ring-danger";
+
+interface FieldShellProps {
+  label?: string;
+  hint?: string;
+  error?: string;
+  controlId: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Wraps a control with its label, hint and error, and wires the `aria-*`
+ * relationships. Every form control in the kit renders through this, so an
+ * error message is always announced instead of being a red string next to an
+ * unassociated input.
+ */
+function FieldShell({ label, hint, error, controlId, children, className }: FieldShellProps) {
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      {label && (
+        <label
+          htmlFor={controlId}
+          className="block text-xs font-medium text-zinc-700 dark:text-zinc-300"
+        >
+          {label}
+        </label>
+      )}
+      {children}
+      {hint && !error && (
+        <p id={`${controlId}-hint`} className="text-xs text-zinc-500 dark:text-zinc-400">
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p id={`${controlId}-error`} role="alert" className="text-xs font-medium text-danger">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
+  label?: string;
+  hint?: string;
+  error?: string;
+  wrapperClassName?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { label, hint, error, wrapperClassName, className, id, ...props },
+  ref,
+) {
+  const generatedId = useId();
+  const controlId = id ?? generatedId;
+
+  return (
+    <FieldShell
+      label={label}
+      hint={hint}
+      error={error}
+      controlId={controlId}
+      className={wrapperClassName}
+    >
+      <input
+        ref={ref}
+        id={controlId}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${controlId}-error` : hint ? `${controlId}-hint` : undefined}
+        className={cn(CONTROL_BASE, error && INVALID, className)}
+        {...props}
+      />
+    </FieldShell>
+  );
+});
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  hint?: string;
+  error?: string;
+  wrapperClassName?: string;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { label, hint, error, wrapperClassName, className, id, ...props },
+  ref,
+) {
+  const generatedId = useId();
+  const controlId = id ?? generatedId;
+
+  return (
+    <FieldShell
+      label={label}
+      hint={hint}
+      error={error}
+      controlId={controlId}
+      className={wrapperClassName}
+    >
+      <textarea
+        ref={ref}
+        id={controlId}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${controlId}-error` : hint ? `${controlId}-hint` : undefined}
+        className={cn(CONTROL_BASE, "leading-relaxed resize-y", error && INVALID, className)}
+        {...props}
+      />
+    </FieldShell>
+  );
+});

--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { cn } from "./cn";
+
+export interface TabItem<T extends string = string> {
+  id: T;
+  label: React.ReactNode;
+  /** Optional count rendered after the label (e.g. number of updates). */
+  count?: number;
+}
+
+/** Element ids are derived, not generated, so `Tabs` and `TabPanel` agree. */
+export const tabButtonId = (idPrefix: string, tabId: string) => `${idPrefix}-tab-${tabId}`;
+export const tabPanelId = (idPrefix: string, tabId: string) => `${idPrefix}-panel-${tabId}`;
+
+export interface TabsProps<T extends string = string> {
+  tabs: ReadonlyArray<TabItem<T>>;
+  activeId: T;
+  onChange: (id: T) => void;
+  /** Accessible name for the tablist, e.g. "Campaign sections". */
+  label: string;
+  /** Unique per tablist on the page — keeps element ids from colliding. */
+  idPrefix: string;
+  className?: string;
+}
+
+/**
+ * Accessible tab bar following the WAI-ARIA tabs pattern: roving tabindex,
+ * arrow-key navigation with wraparound, Home/End, and `aria-controls` pointing
+ * at the panel.
+ *
+ * Panels are rendered by the caller with {@link TabPanel} so each screen keeps
+ * control over mounting — the campaign page, for instance, must not mount the
+ * comments query until its tab is opened.
+ */
+export default function Tabs<T extends string = string>({
+  tabs,
+  activeId,
+  onChange,
+  label,
+  idPrefix,
+  className,
+}: TabsProps<T>) {
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  const selectAndFocus = useCallback(
+    (id: T) => {
+      onChange(id);
+      // Focus follows selection in an automatic-activation tablist.
+      requestAnimationFrame(() => tabRefs.current[id]?.focus());
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const index = tabs.findIndex((tab) => tab.id === activeId);
+    if (index === -1) return;
+
+    switch (event.key) {
+      case "ArrowRight":
+        event.preventDefault();
+        selectAndFocus(tabs[(index + 1) % tabs.length].id);
+        break;
+      case "ArrowLeft":
+        event.preventDefault();
+        selectAndFocus(tabs[(index - 1 + tabs.length) % tabs.length].id);
+        break;
+      case "Home":
+        event.preventDefault();
+        selectAndFocus(tabs[0].id);
+        break;
+      case "End":
+        event.preventDefault();
+        selectAndFocus(tabs[tabs.length - 1].id);
+        break;
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label={label}
+      className={cn("flex gap-1 border-b border-zinc-200 dark:border-zinc-700", className)}
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeId;
+        return (
+          <button
+            key={tab.id}
+            ref={(node) => {
+              tabRefs.current[tab.id] = node;
+            }}
+            role="tab"
+            type="button"
+            id={tabButtonId(idPrefix, tab.id)}
+            aria-selected={isActive}
+            aria-controls={tabPanelId(idPrefix, tab.id)}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onChange(tab.id)}
+            onKeyDown={handleKeyDown}
+            className={cn(
+              "px-4 py-2.5 text-sm font-medium border-b-2 -mb-px tap-target focus-ring rounded-t-md",
+              "transition-colors duration-(--duration-fast) inline-flex items-center gap-2",
+              isActive
+                ? "border-brand text-brand dark:text-blue-400 dark:border-blue-400"
+                : "border-transparent text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200",
+            )}
+          >
+            {tab.label}
+            {typeof tab.count === "number" && tab.count > 0 && (
+              <span
+                className={cn(
+                  "rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
+                  isActive
+                    ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                    : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+                )}
+              >
+                {tab.count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export interface TabPanelProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Must match the `id` of the tab that controls this panel. */
+  tabId: string;
+  /** Must match the `idPrefix` given to the matching {@link Tabs}. */
+  idPrefix: string;
+  active: boolean;
+}
+
+/**
+ * Panel for a {@link Tabs} tab. Renders nothing when inactive so heavy panels
+ * (queries, maps, editors) stay unmounted until opened.
+ */
+export function TabPanel({
+  tabId,
+  idPrefix,
+  active,
+  className,
+  children,
+  ...props
+}: TabPanelProps) {
+  if (!active) return null;
+
+  return (
+    <div
+      role="tabpanel"
+      id={tabPanelId(idPrefix, tabId)}
+      aria-labelledby={tabButtonId(idPrefix, tabId)}
+      // The WAI-ARIA tabs pattern requires a focusable panel: after activating
+      // a tab, Tab must move into the panel even when its first child is not
+      // itself focusable. The lint rule does not model that exception.
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={0}
+      className={cn("focus-ring rounded-md", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/cn.ts
+++ b/src/components/ui/cn.ts
@@ -1,0 +1,13 @@
+/**
+ * Joins class names, dropping falsy values.
+ *
+ * Deliberately dependency-free — the project has no `clsx`/`classnames`, and a
+ * three-line helper is not worth a new dependency. It does NOT de-duplicate
+ * conflicting Tailwind utilities: primitives put their own classes first and
+ * append the caller's `className` last, so the caller wins by source order.
+ */
+export type ClassValue = string | false | null | undefined;
+
+export function cn(...classes: ClassValue[]): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,21 @@
+/**
+ * ProofOfHeart UI kit — the shared primitives every screen should build from.
+ * See docs/DESIGN_SYSTEM.md for tokens, usage rules and the adoption plan.
+ */
+export { default as Button } from "./Button";
+export type { ButtonProps, ButtonSize, ButtonVariant } from "./Button";
+
+export { default as Card, CardHeader, CardTitle } from "./Card";
+export type { CardProps } from "./Card";
+
+export { default as Badge } from "./Badge";
+export type { BadgeProps, BadgeTone } from "./Badge";
+
+export { Input, Textarea } from "./Field";
+export type { InputProps, TextareaProps } from "./Field";
+
+export { default as Tabs, TabPanel, tabButtonId, tabPanelId } from "./Tabs";
+export type { TabItem, TabPanelProps, TabsProps } from "./Tabs";
+
+export { cn } from "./cn";
+export type { ClassValue } from "./cn";

--- a/src/stories/UIKit.stories.tsx
+++ b/src/stories/UIKit.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardHeader,
+  CardTitle,
+  Input,
+  TabPanel,
+  Tabs,
+  Textarea,
+  type BadgeTone,
+  type ButtonVariant,
+} from "../components/ui";
+
+const meta: Meta = {
+  title: "UI/Design System",
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "The shared primitives every screen builds from. Tokens live in `src/app/globals.css`; see `docs/DESIGN_SYSTEM.md`.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+const VARIANTS: ButtonVariant[] = ["primary", "secondary", "ghost", "danger", "success"];
+const TONES: BadgeTone[] = ["neutral", "brand", "accent", "success", "warning", "danger", "info"];
+
+export const Buttons: StoryObj = {
+  render: () => (
+    <div className="space-y-6">
+      <div className="flex flex-wrap gap-3 items-center">
+        {VARIANTS.map((variant) => (
+          <Button key={variant} variant={variant}>
+            {variant}
+          </Button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-3 items-center">
+        <Button size="sm">Small</Button>
+        <Button size="md">Medium</Button>
+        <Button size="lg">Large</Button>
+      </div>
+      <div className="flex flex-wrap gap-3 items-center">
+        <Button isLoading loadingLabel="Posting…">
+          Post Update
+        </Button>
+        <Button disabled>Disabled</Button>
+      </div>
+    </div>
+  ),
+};
+
+export const Badges: StoryObj = {
+  render: () => (
+    <div className="flex flex-wrap gap-2 items-center">
+      {TONES.map((tone) => (
+        <Badge key={tone} tone={tone}>
+          {tone}
+        </Badge>
+      ))}
+    </div>
+  ),
+};
+
+export const Cards: StoryObj = {
+  render: () => (
+    <div className="grid gap-4 sm:grid-cols-2 max-w-3xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Standard surface</CardTitle>
+          <Badge tone="success">Funded</Badge>
+        </CardHeader>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          One border, one radius, one shadow — in both themes.
+        </p>
+      </Card>
+      <Card interactive>
+        <CardHeader>
+          <CardTitle>Interactive</CardTitle>
+        </CardHeader>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          Hover lift — only for cards that are themselves a link or button.
+        </p>
+      </Card>
+    </div>
+  ),
+};
+
+export const Fields: StoryObj = {
+  render: () => (
+    <div className="space-y-4 max-w-md">
+      <Input label="Signer address" placeholder="G…" hint="Stellar public key of a co-signer." />
+      <Input label="Funding goal" defaultValue="-5" error="Goal must be greater than zero." />
+      <Textarea label="Update" rows={4} placeholder="Share progress…" hint="Markdown supported." />
+    </div>
+  ),
+};
+
+const DEMO_TABS = [
+  { id: "updates" as const, label: "Updates", count: 3 },
+  { id: "comments" as const, label: "Comments / Q&A" },
+];
+
+function TabsDemo() {
+  const [active, setActive] = useState<"updates" | "comments">("updates");
+
+  return (
+    <div className="max-w-xl space-y-4">
+      <Tabs
+        tabs={DEMO_TABS}
+        activeId={active}
+        onChange={setActive}
+        label="Campaign sections"
+        idPrefix="story"
+      />
+      <TabPanel tabId="updates" idPrefix="story" active={active === "updates"}>
+        <Card>Updates panel — arrow keys move between tabs.</Card>
+      </TabPanel>
+      <TabPanel tabId="comments" idPrefix="story" active={active === "comments"}>
+        <Card>Comments panel — the inactive panel is unmounted, not hidden.</Card>
+      </TabPanel>
+    </div>
+  );
+}
+
+export const TabsStory: StoryObj = {
+  name: "Tabs",
+  render: () => <TabsDemo />,
+};


### PR DESCRIPTION
## Summary


Closes #643
Closes #639
Closes #661
Closes #641

Worth knowing up front: parts of three of these issues already exist on `main`
— `CampaignMap`, `MapErrorBoundary`, `MultiSigWithdrawalPanel` and the
`Updates*` components are all there. I checked each issue against what is
actually wired up and built the gap rather than rewriting working code.

### #643 — Map crashes on invalid coordinates

`hasValidCoordinates` rejected `null`, `undefined`, `NaN` and `Infinity` — but
an out-of-range coordinate is a perfectly finite number, so `latitude: 1000`
sailed through. Leaflet's Mercator projection produces ±Infinity for
`|lat| >= 90`, which throws inside `MapContainer` and takes the page with it.
Coordinates are now range-checked against WGS-84 bounds (±90 / ±180), with the
exact bounds and `(0, 0)` treated as valid.

The error boundary was also only half applied: `CausesClient` wrapped the map,
but `AdminClient` rendered it bare, so a Leaflet failure took down the whole
admin console. Wrapped.

### #639 — Rich campaign updates

Updates existed but `UpdateItem` rendered `{update.content}` as plain text, so
nothing about them was rich. Bodies now render through `SafeMarkdown` — the
same hardened `rehype-sanitize` schema used for campaign descriptions, so
author input is never trusted HTML.

`UpdateComposer` gains a formatting toolbar (bold, italic, heading, list, link)
that inserts markdown around the current selection, and a **Write / Preview**
switch that previews through that same renderer, so creators see exactly what
contributors will.

The issue asks for a tab, and updates were a stacked section. New
`CampaignTabs` puts **Updates** and **Comments / Q&A** behind a tablist. That
also surfaces `CommentsSection`, which was built but rendered nowhere. Because
`TabPanel` unmounts the inactive panel, a visitor now pays for one list query
instead of both.

### #661 — Multi-signature withdrawals in the creator dashboard

`MultiSigWithdrawalPanel` was fully implemented — proposal creation, signer
collection, threshold, progress, execution, `useMultiSigProposals`, and a
complete `MultiSigPanel` message namespace in both locales — and referenced
from no page at all. The feature existed and was unreachable.

Added a **Withdrawals** tab to the dashboard listing the campaigns you created,
each with the panel attached. It is dynamically imported (it pulls in the
contract client) and the panel self-hides unless the campaign is funded and not
yet withdrawn, so campaigns that cannot pay out stay listed but quiet. New
`Dashboard` strings added to `en` and `es`.

### #641 — Design system / UI kit

Tokens in `globals.css`, primitives in `src/components/ui`, both documented in
`docs/DESIGN_SYSTEM.md`.

Tokens are named for **intent**, not colour — `bg-brand` survives a rebrand,
`bg-blue-600` does not: `brand`/`accent`, `success`/`warning`/`danger`/`info`,
each with a `-strong` hover step, plus `rounded-control` / `rounded-surface`
and two motion durations. Two utilities matter most: `tap-target` (44px, WCAG
2.5.5) and `focus-ring`, so touch targets and the keyboard focus ring stop
being retyped — and quietly dropped — per component.

Primitives: `Button` (5 intents, 3 sizes, in-place loading state that keeps its
width so nothing jumps mid-transaction), `Card` + `CardHeader`/`CardTitle`,
`Badge`, `Input`/`Textarea` (label, hint and error with `aria-invalid`,
`aria-describedby` and `role="alert"` wired up), and `Tabs`/`TabPanel`
implementing the WAI-ARIA pattern — roving tabindex, arrow keys with
wraparound, Home/End, linked `aria-controls`/`aria-labelledby`.

The kit ships **alongside** existing components rather than replacing them in
one sweep — a repo-wide restyle would be unreviewable. Migrated here as proof:
dashboard tabs, campaign tabs, composer actions, withdrawal cards. `docs/`
records the adoption rule for everything else.

**Not done:** the Figma half of the issue. That is design work I can't produce
from the codebase; this PR covers the "implement a matching React UI library"
half and documents the system so a Figma file can be built to match it.

### Verification

- `npx tsc --noEmit` — clean
- `npx eslint src` — 0 errors
- `npx prettier --check` — clean
- `npx jest` — **349 passing, up from 326**