### PR TITLE
chore: Setup code coverage reporting with Codecov (#665)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,18 @@ jobs:
           src/__tests__/integration/CausesFilterUrlSync.test.tsx
           src/__tests__/components/CauseCard.test.tsx
 
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-proofofheart
+          fail_ci_if_error: false
+
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
Closes #665

## Overview
Resolves #665 by configuring automated Jest/Vitest code coverage reporting upload to Codecov via GitHub Actions CI workflow.

## Key Changes
- **`.github/workflows/ci.yml`**: Added `codecov/codecov-action@v4` step targeting `./coverage/lcov.info` generated during the Jest test execution run.
- **`codecov.yml`**: Added repository configuration defining target coverage precision, 1% patch threshold checks, and pull request comment formatting layout.

## Verification
- Verified workflow YAML syntax and artifact upload paths.
