### PR TITLE
fix: markdown sanitization, map coordinate validation, empty description state, and fiat onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,16 @@ NEXT_PUBLIC_WEB3AUTH_CLIENT_ID=
 # Human-readable ETA shown on the maintenance page (optional)
 # NEXT_PUBLIC_MAINTENANCE_ETA=2026-06-02 18:00 UTC
 
+# --- Fiat on-ramp (#637, optional) ---
+# Let non-crypto users buy XLM with a card/bank transfer inside the donation
+# flow. Opt-in: with no provider set, no on-ramp UI or third-party request ships.
+# Provider: "ramp" | "moonpay" | unset to disable
+NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER=
+# Publishable host/API key from your provider dashboard (never a secret key).
+# Ramp: https://dashboard.ramp.network  —  MoonPay: https://dashboard.moonpay.com
+NEXT_PUBLIC_RAMP_API_KEY=
+NEXT_PUBLIC_MOONPAY_API_KEY=
+
 # Alert thresholds (0–1 rates) evaluated over a 5-minute rolling window
 OBSERVABILITY_ALERT_SIMULATION_FAILURE_RATE=0.15
 OBSERVABILITY_ALERT_SUBMISSION_FAILURE_RATE=0.1

--- a/messages/en.json
+++ b/messages/en.json
@@ -556,5 +556,15 @@
     "totalXlm": "{amount} XLM Total",
     "nextXlm": "Next: {amount} XLM",
     "earnedBadges": "Earned Badges"
+  },
+  "CauseDetail": {
+    "noDescription": "No description provided by the creator."
+  },
+  "FiatOnramp": {
+    "buyWithCard": "Buy XLM with card",
+    "buyWithCardDescription": "New to crypto? Purchase XLM with a card or bank transfer, then donate.",
+    "opening": "Opening secure checkout…",
+    "error": "Could not open the payment provider. Please try again.",
+    "poweredBy": "Powered by {provider}"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -556,5 +556,15 @@
     "totalXlm": "{amount} XLM en Total",
     "nextXlm": "Siguiente: {amount} XLM",
     "earnedBadges": "Insignias Ganadas"
+  },
+  "CauseDetail": {
+    "noDescription": "El creador no proporcionó una descripción."
+  },
+  "FiatOnramp": {
+    "buyWithCard": "Compra XLM con tarjeta",
+    "buyWithCardDescription": "¿Nuevo en cripto? Compra XLM con tarjeta o transferencia y luego dona.",
+    "opening": "Abriendo el pago seguro…",
+    "error": "No se pudo abrir el proveedor de pago. Inténtalo de nuevo.",
+    "poweredBy": "Con la tecnología de {provider}"
   }
 }

--- a/src/__tests__/lib/fiatOnramp.test.ts
+++ b/src/__tests__/lib/fiatOnramp.test.ts
@@ -1,0 +1,110 @@
+/**
+ * #637 — Fiat on-ramp URL/config tests.
+ *
+ * Env vars are inlined literally in the browser bundle, so the module reads
+ * `process.env.NEXT_PUBLIC_*` at import time. We reset the module registry
+ * between cases and re-require it after setting env, mirroring build behaviour.
+ */
+
+const ORIGINAL_ENV = process.env;
+
+function loadModule() {
+  let mod!: typeof import("@/lib/fiatOnramp");
+  jest.isolateModules(() => {
+    mod = require("@/lib/fiatOnramp");
+  });
+  return mod;
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER;
+  delete process.env.NEXT_PUBLIC_RAMP_API_KEY;
+  delete process.env.NEXT_PUBLIC_MOONPAY_API_KEY;
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("getFiatOnrampProvider", () => {
+  it("returns null when no provider configured", () => {
+    expect(loadModule().getFiatOnrampProvider()).toBeNull();
+  });
+
+  it("returns null when provider set but API key missing", () => {
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "ramp";
+    expect(loadModule().getFiatOnrampProvider()).toBeNull();
+  });
+
+  it("returns 'ramp' when configured with a key", () => {
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "ramp";
+    process.env.NEXT_PUBLIC_RAMP_API_KEY = "ramp_test_key";
+    expect(loadModule().getFiatOnrampProvider()).toBe("ramp");
+  });
+
+  it("returns 'moonpay' when configured with a key", () => {
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "moonpay";
+    process.env.NEXT_PUBLIC_MOONPAY_API_KEY = "pk_test_key";
+    expect(loadModule().getFiatOnrampProvider()).toBe("moonpay");
+  });
+
+  it("ignores unknown provider values", () => {
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "bogus";
+    process.env.NEXT_PUBLIC_RAMP_API_KEY = "ramp_test_key";
+    expect(loadModule().getFiatOnrampProvider()).toBeNull();
+  });
+});
+
+describe("buildFiatOnrampUrl", () => {
+  it("throws when no provider is configured", () => {
+    expect(() => loadModule().buildFiatOnrampUrl()).toThrow();
+  });
+
+  it("builds a Ramp testnet URL with wallet + amount", () => {
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "ramp";
+    process.env.NEXT_PUBLIC_RAMP_API_KEY = "ramp_test_key";
+    const url = new URL(loadModule().buildFiatOnrampUrl({ walletAddress: "GABC", fiatAmount: 50 }));
+    expect(url.origin).toBe("https://app.demo.ramp.network");
+    expect(url.searchParams.get("hostApiKey")).toBe("ramp_test_key");
+    expect(url.searchParams.get("swapAsset")).toBe("XLM_XLM");
+    expect(url.searchParams.get("userAddress")).toBe("GABC");
+    expect(url.searchParams.get("fiatValue")).toBe("50");
+  });
+
+  it("uses the Ramp mainnet host on mainnet", () => {
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "mainnet";
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "ramp";
+    process.env.NEXT_PUBLIC_RAMP_API_KEY = "ramp_live_key";
+    const url = new URL(loadModule().buildFiatOnrampUrl({ walletAddress: "GABC" }));
+    expect(url.origin).toBe("https://app.ramp.network");
+  });
+
+  it("builds a MoonPay sandbox URL with wallet + amount", () => {
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "moonpay";
+    process.env.NEXT_PUBLIC_MOONPAY_API_KEY = "pk_test_key";
+    const url = new URL(loadModule().buildFiatOnrampUrl({ walletAddress: "GXYZ", fiatAmount: 25 }));
+    expect(url.origin).toBe("https://buy-sandbox.moonpay.com");
+    expect(url.searchParams.get("apiKey")).toBe("pk_test_key");
+    expect(url.searchParams.get("currencyCode")).toBe("xlm");
+    expect(url.searchParams.get("walletAddress")).toBe("GXYZ");
+    expect(url.searchParams.get("baseCurrencyAmount")).toBe("25");
+  });
+
+  it("does not leak an API key when the address is absent", () => {
+    process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER = "moonpay";
+    process.env.NEXT_PUBLIC_MOONPAY_API_KEY = "pk_test_key";
+    const url = new URL(loadModule().buildFiatOnrampUrl());
+    expect(url.searchParams.has("walletAddress")).toBe(false);
+  });
+});
+
+describe("getFiatOnrampProviderLabel", () => {
+  it("maps provider ids to display labels", () => {
+    const mod = loadModule();
+    expect(mod.getFiatOnrampProviderLabel("ramp")).toBe("Ramp");
+    expect(mod.getFiatOnrampProviderLabel("moonpay")).toBe("MoonPay");
+  });
+});

--- a/src/__tests__/lib/rehypeNoPrototypePollution.test.ts
+++ b/src/__tests__/lib/rehypeNoPrototypePollution.test.ts
@@ -1,0 +1,113 @@
+import {
+  PROTOTYPE_POLLUTION_KEYS,
+  stripPrototypePollutionKeys,
+  scrubHastTree,
+  rehypeNoPrototypePollution,
+} from "@/lib/rehypeNoPrototypePollution";
+
+/**
+ * #634 regression tests — prove the markdown pipeline cannot be used to smuggle
+ * prototype-polluting keys onto rendered nodes or onto Object.prototype.
+ */
+describe("prototype pollution defense", () => {
+  afterEach(() => {
+    // Ensure no test leaked a polluted prototype.
+    delete (Object.prototype as Record<string, unknown>).polluted;
+  });
+
+  it("exposes the dangerous key list", () => {
+    expect(PROTOTYPE_POLLUTION_KEYS).toEqual(["__proto__", "constructor", "prototype"]);
+  });
+
+  describe("stripPrototypePollutionKeys", () => {
+    it("removes __proto__/constructor/prototype own keys", () => {
+      const payload = JSON.parse('{"safe":1,"__proto__":{"polluted":true},"constructor":2}');
+      const cleaned = stripPrototypePollutionKeys(payload);
+
+      expect(cleaned).toEqual({ safe: 1 });
+      expect(Object.prototype.hasOwnProperty.call(cleaned, "__proto__")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(cleaned, "constructor")).toBe(false);
+    });
+
+    it("cleans nested objects and arrays", () => {
+      const payload = JSON.parse(
+        '{"a":{"__proto__":{"x":1},"keep":"y"},"list":[{"prototype":9,"ok":true}]}',
+      );
+      const cleaned = stripPrototypePollutionKeys(payload) as {
+        a: Record<string, unknown>;
+        list: Record<string, unknown>[];
+      };
+
+      expect(cleaned.a).toEqual({ keep: "y" });
+      expect(cleaned.list[0]).toEqual({ ok: true });
+    });
+
+    it("does not mutate Object.prototype while cleaning a malicious payload", () => {
+      const payload = JSON.parse('{"__proto__":{"polluted":true}}');
+      stripPrototypePollutionKeys(payload);
+
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+
+  describe("scrubHastTree", () => {
+    it("deletes dangerous keys from element properties", () => {
+      const properties: Record<string, unknown> = {};
+      Object.defineProperty(properties, "__proto__", {
+        value: { polluted: true },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(properties, "constructor", {
+        value: "evil",
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      properties.className = "safe";
+      const tree = {
+        type: "root",
+        children: [
+          {
+            type: "element",
+            tagName: "a",
+            properties,
+            children: [],
+          },
+        ],
+      };
+
+      scrubHastTree(tree);
+
+      const node = tree.children[0] as { properties: Record<string, unknown> };
+      expect(Object.prototype.hasOwnProperty.call(node.properties, "__proto__")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(node.properties, "constructor")).toBe(false);
+      expect(node.properties.className).toBe("safe");
+    });
+  });
+
+  describe("rehypeNoPrototypePollution plugin", () => {
+    it("returns a transformer that scrubs the tree in place", () => {
+      const properties: Record<string, unknown> = { id: "x" };
+      Object.defineProperty(properties, "__proto__", {
+        value: { polluted: true },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+
+      const tree = {
+        type: "root",
+        children: [{ type: "element", tagName: "span", properties, children: [] }],
+      };
+
+      const transform = rehypeNoPrototypePollution();
+      const result = transform(tree) as typeof tree;
+
+      const node = result.children[0] as { properties: Record<string, unknown> };
+      expect(Object.prototype.hasOwnProperty.call(node.properties, "__proto__")).toBe(false);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+});

--- a/src/__tests__/utils/markdownContent.test.ts
+++ b/src/__tests__/utils/markdownContent.test.ts
@@ -1,0 +1,27 @@
+import { isBlankMarkdown } from "@/utils/markdownContent";
+
+/** #655 — empty campaign descriptions must be detected so a fallback can show. */
+describe("isBlankMarkdown", () => {
+  it("treats null and undefined as blank", () => {
+    expect(isBlankMarkdown(null)).toBe(true);
+    expect(isBlankMarkdown(undefined)).toBe(true);
+  });
+
+  it("treats an empty or whitespace-only string as blank", () => {
+    expect(isBlankMarkdown("")).toBe(true);
+    expect(isBlankMarkdown("   \n\t  ")).toBe(true);
+  });
+
+  it("treats markdown with only syntax characters as blank", () => {
+    expect(isBlankMarkdown("###")).toBe(true);
+    expect(isBlankMarkdown("**  **")).toBe(true);
+    expect(isBlankMarkdown("- \n- \n")).toBe(true);
+    expect(isBlankMarkdown("<!-- hidden note -->")).toBe(true);
+  });
+
+  it("treats real content as non-blank", () => {
+    expect(isBlankMarkdown("Hello world")).toBe(false);
+    expect(isBlankMarkdown("# Heading\n\nSome text.")).toBe(false);
+    expect(isBlankMarkdown("A")).toBe(false);
+  });
+});

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -21,7 +21,7 @@ import { usePlatformFee } from '@/hooks/usePlatformFee';
 "use client";
 
 import Link from "next/link";
-import { Bookmark } from "lucide-react";
+import { Bookmark, FileText } from "lucide-react";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import { useState, useEffect } from "react";
@@ -86,6 +86,7 @@ import { getAsyncActionErrorMessage, withActionTimeout } from "@/utils/asyncActi
 import { trackViewCampaign } from "@/lib/analytics";
 import { formatXlm, formatDate } from "@/lib/formatters";
 import { getLocalizedDescription } from "@/utils/localizedDescription";
+import { isBlankMarkdown } from "@/utils/markdownContent";
 import { isSameAddress } from "@/lib/stellar";
 const EditCampaignMetadata = dynamic(() => import("@/components/EditCampaignMetadata"), {
   ssr: false,
@@ -94,6 +95,7 @@ const EditCampaignMetadata = dynamic(() => import("@/components/EditCampaignMeta
 export default function CauseDetailClient({ id }: { id: string }) {
   const { publicKey: userWalletAddress } = useWallet();
   const tContractErrors = useTranslations("ContractErrors");
+  const tCauseDetail = useTranslations("CauseDetail");
   const locale = useLocale();
   const {
     campaign: fetchedCampaign,
@@ -313,6 +315,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
 
   const isCreator = userWalletAddress ? isSameAddress(campaign.creator, userWalletAddress) : false;
   const canEdit = isCreator && !campaign.is_verified && !campaign.is_cancelled;
+  const localizedDescription = getLocalizedDescription(campaign.description, locale);
 
   const raised = stroopsToXlmNumber(campaign.amount_raised);
   const goal = stroopsToXlmNumber(campaign.funding_goal);
@@ -382,30 +385,43 @@ export default function CauseDetailClient({ id }: { id: string }) {
                 {campaign.title}
               </h1>
               <div className="relative">
-                <div
-                  className={`overflow-hidden transition-all duration-300 ${!isDescriptionExpanded ? "max-h-[250px] relative" : ""}`}
-                >
-                  <SafeMarkdown className="prose prose-zinc dark:prose-invert max-w-none break-words">
-                    {getLocalizedDescription(campaign.description, locale)}
-                  </SafeMarkdown>
-                  {!isDescriptionExpanded && (
-                    <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-zinc-800 to-transparent pointer-events-none" />
-                  )}
-                </div>
-                {campaign.description &&
-                  getLocalizedDescription(campaign.description, locale).length > 500 && (
-                    <div className="mt-2 text-center">
-                      <button
-                        type="button"
-                        onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
-                        className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded px-3 py-1 transition-colors"
-                        aria-expanded={isDescriptionExpanded}
-                        aria-controls="campaign-description"
-                      >
-                        {isDescriptionExpanded ? "Show less" : "Read more"}
-                      </button>
+                {isBlankMarkdown(localizedDescription) ? (
+                  <div
+                    id="campaign-description"
+                    className="flex items-center gap-3 rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/40 px-4 py-6 text-sm text-zinc-500 dark:text-zinc-400"
+                    role="status"
+                  >
+                    <FileText size={18} className="shrink-0 opacity-70" aria-hidden="true" />
+                    <span>{tCauseDetail("noDescription")}</span>
+                  </div>
+                ) : (
+                  <>
+                    <div
+                      id="campaign-description"
+                      className={`overflow-hidden transition-all duration-300 ${!isDescriptionExpanded ? "max-h-[250px] relative" : ""}`}
+                    >
+                      <SafeMarkdown className="prose prose-zinc dark:prose-invert max-w-none break-words">
+                        {localizedDescription}
+                      </SafeMarkdown>
+                      {!isDescriptionExpanded && (
+                        <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-zinc-800 to-transparent pointer-events-none" />
+                      )}
                     </div>
-                  )}
+                    {localizedDescription.length > 500 && (
+                      <div className="mt-2 text-center">
+                        <button
+                          type="button"
+                          onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
+                          className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded px-3 py-1 transition-colors"
+                          aria-expanded={isDescriptionExpanded}
+                          aria-controls="campaign-description"
+                        >
+                          {isDescriptionExpanded ? "Show less" : "Read more"}
+                        </button>
+                      </div>
+                    )}
+                  </>
+                )}
               </div>
 
               {canEdit && (

--- a/src/components/CampaignMap.tsx
+++ b/src/components/CampaignMap.tsx
@@ -67,7 +67,10 @@ interface CampaignMapProps {
 
 export default function CampaignMap({ campaigns }: CampaignMapProps) {
   const t = useTranslations("CampaignMap");
-  const validCampaigns = useMemo(() => filterByValidCoordinates(campaigns), [campaigns]);
+  const validCampaigns = useMemo(
+    () => filterByValidCoordinates(Array.isArray(campaigns) ? campaigns : []),
+    [campaigns],
+  );
 
   const center = useMemo<[number, number]>(() => {
     if (validCampaigns.length === 0) return [20, 0];

--- a/src/components/DonationModal.tsx
+++ b/src/components/DonationModal.tsx
@@ -22,6 +22,7 @@ const EXPLORER_BASE =
 import { type TransactionLifecyclePhase } from "../lib/contractClient";
 import { validateContributorNotCreator } from "../utils/validators";
 import { explorerTxUrl } from "../utils/explorer";
+import FiatOnrampButton from "./FiatOnrampButton";
 import {
   trackClickContribute,
   trackEnterAmount,
@@ -494,6 +495,13 @@ export default function DonationModal({
               >
                 {amountNum > 0 ? t("donateAmount", { amount: amountNum }) : t("donate")}
               </button>
+
+              {/* #637 — fiat on-ramp so non-crypto users can buy XLM to donate.
+                  Renders nothing unless a provider is configured via env vars. */}
+              <FiatOnrampButton
+                walletAddress={publicKey}
+                fiatAmount={amountNum > 0 ? amountNum : null}
+              />
             </>
           )}
 

--- a/src/components/FiatOnrampButton.tsx
+++ b/src/components/FiatOnrampButton.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { CreditCard, ExternalLink, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  buildFiatOnrampUrl,
+  getFiatOnrampProvider,
+  getFiatOnrampProviderLabel,
+} from "@/lib/fiatOnramp";
+
+interface FiatOnrampButtonProps {
+  /** Wallet address the purchased XLM is deposited into. */
+  walletAddress?: string | null;
+  /** Optional fiat amount hint passed to the provider. */
+  fiatAmount?: number | null;
+  className?: string;
+}
+
+/**
+ * #637 — Entry point into a fiat-to-crypto on-ramp.
+ *
+ * Renders nothing unless a provider (Ramp/MoonPay) is configured via env vars.
+ * Opens the provider's hosted checkout in a new tab, showing loading state
+ * while it opens and an inline error if the popup is blocked or the URL cannot
+ * be built.
+ */
+export default function FiatOnrampButton({
+  walletAddress,
+  fiatAmount,
+  className,
+}: FiatOnrampButtonProps) {
+  const t = useTranslations("FiatOnramp");
+  const [isOpening, setIsOpening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const provider = getFiatOnrampProvider();
+  if (!provider) return null;
+
+  const handleClick = () => {
+    setError(null);
+    setIsOpening(true);
+    try {
+      const url = buildFiatOnrampUrl({ walletAddress, fiatAmount });
+      const opened = window.open(url, "_blank", "noopener,noreferrer");
+      if (!opened) {
+        setError(t("error"));
+      }
+    } catch {
+      setError(t("error"));
+    } finally {
+      setIsOpening(false);
+    }
+  };
+
+  return (
+    <div className={className}>
+      <div className="rounded-xl border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 p-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
+            <CreditCard size={18} aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+              {t("buyWithCard")}
+            </p>
+            <p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+              {t("buyWithCardDescription")}
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={isOpening}
+          className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 px-4 py-2.5 text-sm font-medium text-zinc-800 dark:text-zinc-100 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isOpening ? (
+            <>
+              <Loader2 size={16} className="animate-spin" aria-hidden="true" />
+              {t("opening")}
+            </>
+          ) : (
+            <>
+              <ExternalLink size={16} aria-hidden="true" />
+              {t("buyWithCard")}
+            </>
+          )}
+        </button>
+
+        {error ? (
+          <p role="alert" className="mt-2 text-xs text-red-500">
+            {error}
+          </p>
+        ) : (
+          <p className="mt-2 text-center text-[11px] text-zinc-400 dark:text-zinc-500">
+            {t("poweredBy", { provider: getFiatOnrampProviderLabel(provider) })}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SafeMarkdown.tsx
+++ b/src/components/SafeMarkdown.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { buildMarkdownSanitizeSchema } from "@/lib/markdownSanitizeSchema";
+import { rehypeNoPrototypePollution } from "@/lib/rehypeNoPrototypePollution";
 
 const markdownSanitizeSchema = buildMarkdownSanitizeSchema(defaultSchema);
 
@@ -20,7 +21,7 @@ export default function SafeMarkdown({ children, className }: SafeMarkdownProps)
     <div className={className}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[[rehypeSanitize, markdownSanitizeSchema]]}
+        rehypePlugins={[[rehypeSanitize, markdownSanitizeSchema], rehypeNoPrototypePollution]}
       >
         {children}
       </ReactMarkdown>

--- a/src/lib/fiatOnramp.ts
+++ b/src/lib/fiatOnramp.ts
@@ -1,0 +1,112 @@
+/**
+ * #637 — Fiat-to-crypto on-ramp configuration.
+ *
+ * Non-crypto-native supporters can't donate without first acquiring XLM. This
+ * module builds a hosted-widget checkout URL for a fiat on-ramp provider (Ramp
+ * or MoonPay) so the donation flow can hand off to a card/bank purchase that
+ * deposits XLM straight into the supporter's wallet.
+ *
+ * Everything is driven by public environment variables and is entirely opt-in:
+ * with no provider key configured, no on-ramp UI is shown and no third-party
+ * request is made. No secrets live here — only the publishable client key each
+ * provider issues for hosted-widget URLs.
+ *
+ * `process.env.NEXT_PUBLIC_*` is inlined at build time by literal-text
+ * substitution, so these must stay literal property reads.
+ */
+
+export type FiatOnrampProvider = "ramp" | "moonpay";
+
+const RAMP_HOSTS = {
+  testnet: "https://app.demo.ramp.network",
+  mainnet: "https://app.ramp.network",
+} as const;
+
+const MOONPAY_HOSTS = {
+  testnet: "https://buy-sandbox.moonpay.com",
+  mainnet: "https://buy.moonpay.com",
+} as const;
+
+const ENV = {
+  provider: process.env.NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER,
+  rampApiKey: process.env.NEXT_PUBLIC_RAMP_API_KEY,
+  moonpayApiKey: process.env.NEXT_PUBLIC_MOONPAY_API_KEY,
+  network: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
+};
+
+function normalizeProvider(value: string | undefined): FiatOnrampProvider | null {
+  if (value === "ramp" || value === "moonpay") return value;
+  return null;
+}
+
+function isMainnet(): boolean {
+  return ENV.network === "mainnet";
+}
+
+/**
+ * The configured on-ramp provider, or `null` when the feature is disabled or
+ * missing its API key. UI should hide the on-ramp entry point when this is null.
+ */
+export function getFiatOnrampProvider(): FiatOnrampProvider | null {
+  const provider = normalizeProvider(ENV.provider);
+  if (!provider) return null;
+  if (provider === "ramp" && !ENV.rampApiKey) return null;
+  if (provider === "moonpay" && !ENV.moonpayApiKey) return null;
+  return provider;
+}
+
+/** Human-readable provider label for UI ("Ramp", "MoonPay"). */
+export function getFiatOnrampProviderLabel(provider: FiatOnrampProvider): string {
+  return provider === "ramp" ? "Ramp" : "MoonPay";
+}
+
+export interface FiatOnrampParams {
+  /** Destination Stellar wallet address the purchased XLM should be sent to. */
+  walletAddress?: string | null;
+  /** Optional pre-filled fiat amount hint (provider dependent). */
+  fiatAmount?: number | null;
+}
+
+function buildRampUrl(apiKey: string, params: FiatOnrampParams): string {
+  const host = isMainnet() ? RAMP_HOSTS.mainnet : RAMP_HOSTS.testnet;
+  const url = new URL(host);
+  url.searchParams.set("hostApiKey", apiKey);
+  url.searchParams.set("swapAsset", "XLM_XLM");
+  url.searchParams.set("defaultAsset", "XLM_XLM");
+  if (params.walletAddress) url.searchParams.set("userAddress", params.walletAddress);
+  if (params.fiatAmount && params.fiatAmount > 0) {
+    url.searchParams.set("fiatValue", String(params.fiatAmount));
+    url.searchParams.set("fiatCurrency", "USD");
+  }
+  return url.toString();
+}
+
+function buildMoonpayUrl(apiKey: string, params: FiatOnrampParams): string {
+  const host = isMainnet() ? MOONPAY_HOSTS.mainnet : MOONPAY_HOSTS.testnet;
+  const url = new URL(host);
+  url.searchParams.set("apiKey", apiKey);
+  url.searchParams.set("currencyCode", "xlm");
+  if (params.walletAddress) url.searchParams.set("walletAddress", params.walletAddress);
+  if (params.fiatAmount && params.fiatAmount > 0) {
+    url.searchParams.set("baseCurrencyAmount", String(params.fiatAmount));
+    url.searchParams.set("baseCurrencyCode", "usd");
+  }
+  return url.toString();
+}
+
+/**
+ * Build the hosted-widget checkout URL for the active provider.
+ *
+ * @throws if no provider is configured — callers should gate on
+ * `getFiatOnrampProvider()` first.
+ */
+export function buildFiatOnrampUrl(params: FiatOnrampParams = {}): string {
+  const provider = getFiatOnrampProvider();
+  if (provider === "ramp" && ENV.rampApiKey) {
+    return buildRampUrl(ENV.rampApiKey, params);
+  }
+  if (provider === "moonpay" && ENV.moonpayApiKey) {
+    return buildMoonpayUrl(ENV.moonpayApiKey, params);
+  }
+  throw new Error("Fiat on-ramp is not configured");
+}

--- a/src/lib/markdownSanitizeSchema.ts
+++ b/src/lib/markdownSanitizeSchema.ts
@@ -1,4 +1,5 @@
 import type { Schema } from "hast-util-sanitize";
+import { stripPrototypePollutionKeys } from "./rehypeNoPrototypePollution";
 
 /** Protocol and tag restrictions applied on top of rehype-sanitize defaults. */
 export const MARKDOWN_SANITIZE_OVERRIDES: Partial<Schema> = {
@@ -16,7 +17,7 @@ export const MARKDOWN_SANITIZE_OVERRIDES: Partial<Schema> = {
  * Called from SafeMarkdown at runtime so Jest can mock rehype-sanitize in integration tests.
  */
 export function buildMarkdownSanitizeSchema(defaultSchema: Schema): Schema {
-  return {
+  const schema: Schema = {
     ...defaultSchema,
     ...MARKDOWN_SANITIZE_OVERRIDES,
     protocols: {
@@ -33,4 +34,8 @@ export function buildMarkdownSanitizeSchema(defaultSchema: Schema): Schema {
       ),
     },
   };
+
+  // #634 — never let a prototype-polluting key survive in the schema that is
+  // spread onto rendered nodes.
+  return stripPrototypePollutionKeys(schema);
 }

--- a/src/lib/rehypeNoPrototypePollution.ts
+++ b/src/lib/rehypeNoPrototypePollution.ts
@@ -1,0 +1,98 @@
+/**
+ * #634 — Defense against prototype pollution in the markdown rendering path.
+ *
+ * `react-markdown` turns untrusted markdown into a hast tree and then spreads
+ * each node's `properties` onto React elements. A crafted payload can smuggle
+ * `__proto__`, `constructor`, or `prototype` keys into that property bag (for
+ * example through a raw attribute name), and older parsers have historically
+ * copied such keys onto plain objects, mutating `Object.prototype` for the
+ * whole runtime.
+ *
+ * This module strips those keys defensively — both when merging the sanitize
+ * schema and, at render time, from every hast node — so no attacker-controlled
+ * markdown can reach a prototype-polluting assignment regardless of parser
+ * version.
+ */
+
+/** Keys that can walk up an object's prototype chain and pollute it. */
+export const PROTOTYPE_POLLUTION_KEYS = ["__proto__", "constructor", "prototype"] as const;
+
+const DANGEROUS_KEY_SET = new Set<string>(PROTOTYPE_POLLUTION_KEYS);
+
+/** True for a value we should recurse into (plain object or array). */
+function isTraversable(value: unknown): value is Record<string, unknown> | unknown[] {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Recursively remove prototype-polluting own keys from a value.
+ *
+ * Returns a structurally cleaned copy: objects are rebuilt so that a key such
+ * as `__proto__` can never survive as a real, enumerable own property. Arrays
+ * are cleaned element-by-element. Non-objects are returned untouched.
+ */
+export function stripPrototypePollutionKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripPrototypePollutionKeys(item)) as unknown as T;
+  }
+
+  if (isTraversable(value)) {
+    const cleaned: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      if (DANGEROUS_KEY_SET.has(key)) continue;
+      cleaned[key] = stripPrototypePollutionKeys((value as Record<string, unknown>)[key]);
+    }
+    return cleaned as unknown as T;
+  }
+
+  return value;
+}
+
+interface HastNodeLike {
+  type?: string;
+  properties?: Record<string, unknown> | null;
+  children?: unknown;
+  [key: string]: unknown;
+}
+
+/** Delete dangerous own keys from a single object in place. */
+function deleteDangerousKeys(obj: Record<string, unknown>): void {
+  for (const key of PROTOTYPE_POLLUTION_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      delete obj[key];
+    }
+  }
+}
+
+/** Walk a hast node tree, scrubbing `properties` on every element. */
+export function scrubHastTree(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const child of node) scrubHastTree(child);
+    return;
+  }
+
+  if (!isTraversable(node)) return;
+
+  const hastNode = node as HastNodeLike;
+
+  if (hastNode.properties && typeof hastNode.properties === "object") {
+    deleteDangerousKeys(hastNode.properties as Record<string, unknown>);
+  }
+
+  if (Array.isArray(hastNode.children)) {
+    for (const child of hastNode.children) scrubHastTree(child);
+  }
+}
+
+/**
+ * rehype plugin: scrubs prototype-polluting keys from the hast tree after
+ * sanitization, right before `react-markdown` maps properties onto elements.
+ */
+export function rehypeNoPrototypePollution() {
+  return (tree: unknown) => {
+    scrubHastTree(tree);
+    return tree;
+  };
+}
+
+export default rehypeNoPrototypePollution;

--- a/src/utils/markdownContent.ts
+++ b/src/utils/markdownContent.ts
@@ -1,0 +1,25 @@
+/**
+ * #655 — Helpers for detecting markdown content that renders to nothing.
+ *
+ * A campaign description can be an empty string, whitespace, or markdown that
+ * produces no visible output (for example a lone comment or stray formatting
+ * characters). In every one of those cases the detail page would otherwise show
+ * a large blank gap, so callers use this to decide when to render a fallback.
+ */
+
+/**
+ * True when the given markdown string has no meaningful, visible content.
+ *
+ * Strips markdown comments and formatting-only characters before checking for
+ * any remaining non-whitespace text.
+ */
+export function isBlankMarkdown(content: string | null | undefined): boolean {
+  if (content == null) return true;
+
+  const withoutComments = content.replace(/<!--[\s\S]*?-->/g, "");
+
+  // Remove characters that are purely markdown syntax and carry no text.
+  const withoutSyntax = withoutComments.replace(/[#>*_~`\-+.\s[\]()!|\\]/g, "");
+
+  return withoutSyntax.length === 0;
+}


### PR DESCRIPTION
## Summary

Implements four issues on a single branch.

### #634 — Markdown renderer vulnerable to prototype pollution
- Added `rehypeNoPrototypePollution`, a rehype plugin that scrubs `__proto__`, `constructor`, and `prototype` keys from every hast node's `properties` after sanitization, right before `react-markdown` spreads them onto elements.
- Hardened `buildMarkdownSanitizeSchema` to deep-strip the same dangerous keys from the merged sanitize schema.
- Wired both into `SafeMarkdown` (the single markdown rendering path used by campaign descriptions, updates, and previews).
- Added regression tests proving `Object.prototype` cannot be polluted and dangerous keys are removed from node properties.

### #637 — Support fiat onboarding via Ramp/MoonPay
- Added `FiatOnrampButton`, surfaced inside the donation flow (`DonationModal`), so non-crypto users can buy XLM with a card/bank transfer that deposits straight into their wallet.
- Provider + keys are entirely behind `NEXT_PUBLIC_*` env vars (`NEXT_PUBLIC_FIAT_ONRAMP_PROVIDER`, `NEXT_PUBLIC_RAMP_API_KEY`, `NEXT_PUBLIC_MOONPAY_API_KEY`), documented in `.env.example`. No secrets hardcoded; feature is opt-in (no config → no UI, no third-party request).
- Handles loading ("opening checkout") and error (popup blocked / unconfigured) states. Uses each provider's testnet/sandbox host on testnet and production host on mainnet.

### #654 — Explore map view crashes on invalid coordinates
- Coordinate validation (`hasValidCoordinates` / `filterByValidCoordinates`) and a dedicated `MapErrorBoundary` around `CampaignMap` are already present upstream; added a guard so a non-array `campaigns` prop can't throw.

### #655 — Missing error state for empty campaign description
- Added `isBlankMarkdown` util that detects empty/whitespace/comment/syntax-only descriptions.
- `CauseDetailClient` now renders a "No description provided by the creator" fallback instead of an awkward blank space.

### i18n & tests
- Added `CauseDetail` and `FiatOnramp` message keys to `en` and `es`.
- New unit tests for the prototype-pollution defense, fiat on-ramp URL building, and blank-markdown detection. No new runtime dependencies.

Closes #634
Closes #637
Closes #654
Closes #655


---

## Rebased onto latest `main` — conflicts resolved

This branch was rebased onto `main` (`b44f0aa`) to clear the merge conflict. **3 files conflicted; all resolved by keeping both sides:**

| File | Conflict | Resolution |
|---|---|---|
| `src/components/CampaignMap.tsx` | `main` added `useTranslations("CampaignMap")` for the empty state; this branch added an `Array.isArray` guard | **Both kept** — translations hook retained *and* the defensive guard applied |
| `messages/en.json` | `main` appended `Onboarding`, `CampaignMap`, `Gamification`, `ContributorLeaderboard`, `DonatorBadges`; this branch appended `CauseDetail`, `FiatOnramp` | **All 7 namespaces kept** |
| `messages/es.json` | same as above | **All 7 namespaces kept** |

`CauseDetailClient.tsx` and `DonationModal.tsx` auto-merged; both sides verified present (`SafeMarkdown` / `noDescription` / `FiatOnrampButton` alongside `ContributorLeaderboard` / `useTranslations`).

Locale integrity re-checked after resolution: **27 namespaces in `en`, 27 in `es`, keys at full parity.**

### No regressions from the rebase

Measured against a clean `upstream/main` worktree at the same commit:

| Check | `main` (`b44f0aa`) | This branch | Delta |
|---|---|---|---|
| `tsc --noEmit` | 7 errors | 7 errors | **0 new** |
| Unit tests | 34 failed / 361 passed (395) | 34 failed / 382 passed (416) | **0 new failures, +21 passing** |
| Failing suite set | 30 suites | 30 suites | **byte-identical** |

The set of failing suites is identical on both — no suite fails on this branch that does not already fail on `main`.

### Note for maintainers: `main` is currently broken (pre-existing, not from this PR)

CI is red on this PR because **it is red on `main` itself** — the latest `main` run (`b44f0aa`) fails `CI`, `Bundle Size`, and `Verification (E2E)`, and other open PRs show the same failures.

Root cause is merge commit `9ceebfd` ("Merge branch 'main' into feat/donor-engagement-and-campaign-ux", merged via #771). That merge committed **both sides of an unresolved conflict** rather than resolving it:

- `src/app/[locale]/causes/[id]/CauseDetailClient.tsx` — parent `b46b840` had 443 lines, parent `4ee7380` had 702; the merge result is **743 lines** containing two interleaved copies of the import block (two `use client` directives, a duplicated `@/lib/contractClient` import whose opening brace was lost, and a local `formatDate` that collides with the imported one).
- `src/components/WalletContext.tsx` — same pattern.

This is what produces all 7 `tsc` syntax errors and cascades into the build, lint, and test jobs.

I have deliberately **not** repaired it in this PR: doing so correctly means re-performing someone else's feature merge (donor badges, recurring donations, description fallback) and risks silently dropping their work. It needs a separate fix from that PR's author or a maintainer. Happy to take it on if you'd like — just say the word.

Once `main` is green, this branch should go green with it; it is `MERGEABLE` and conflict-free as of now.
