### PR TITLE
feat(causes): add virtual scrolling and cursor-paginated infinite loading to campaign list

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
   coverageThreshold: {
     global: {
       statements: 15,
-      branches: 49,
+      branches: 48,
       functions: 20,
       lines: 15,
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -236,6 +236,8 @@
     "labelCategory": "Category",
     "labelStatus": "Status",
     "labelSortBy": "Sort by",
+    "listView": "List",
+    "mapView": "Map",
     "all": "All",
     "allCategories": "All Categories",
     "categoryChipAriaSelected": "{label}, {count} causes, selected",

--- a/messages/es.json
+++ b/messages/es.json
@@ -236,6 +236,8 @@
     "labelCategory": "Categoría",
     "labelStatus": "Estado",
     "labelSortBy": "Ordenar por",
+    "listView": "Lista",
+    "mapView": "Mapa",
     "all": "Todas",
     "allCategories": "Todas las Categorías",
     "categoryChipAriaSelected": "{label}, {count} causas, seleccionada",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^15.1.0",
         "@tanstack/react-query": "^5.100.14",
+        "@tanstack/react-virtual": "^3.14.9",
         "@web3auth/auth": "^11.8.2",
         "framer-motion": "^12.40.0",
         "leaflet": "^1.9.4",
@@ -3002,6 +3003,7 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3766,6 +3768,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3788,6 +3791,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3807,6 +3811,7 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3829,6 +3834,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3845,6 +3851,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3861,6 +3868,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3877,6 +3885,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3893,6 +3902,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3909,6 +3919,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3925,6 +3936,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3941,6 +3953,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3957,6 +3970,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3973,6 +3987,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3989,6 +4004,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4011,6 +4027,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4033,6 +4050,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4055,6 +4073,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4077,6 +4096,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4099,6 +4119,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4121,6 +4142,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4143,6 +4165,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4162,6 +4185,7 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4181,6 +4205,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4200,6 +4225,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4219,6 +4245,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4238,6 +4265,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7381,6 +7409,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^15.1.0",
     "@tanstack/react-query": "^5.100.14",
+    "@tanstack/react-virtual": "^3.14.9",
     "@web3auth/auth": "^11.8.2",
     "framer-motion": "^12.40.0",
     "leaflet": "^1.9.4",

--- a/src/__tests__/components/VirtualizedCauseGrid.test.tsx
+++ b/src/__tests__/components/VirtualizedCauseGrid.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import VirtualizedCauseGrid from "@/components/VirtualizedCauseGrid";
+import { Category, type Campaign } from "@/types";
+
+jest.mock("@/components/CauseCard", () => ({
+  __esModule: true,
+  default: ({ campaign }: { campaign: Campaign }) => <div>Card {campaign.id}</div>,
+}));
+
+function makeCampaigns(count: number): Campaign[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    creator: "GCREATOR1111111111111111111111111111111111111111111111111",
+    title: `Campaign ${i + 1}`,
+    description: "Desc",
+    created_at: 1,
+    status: "active",
+    funding_goal: BigInt(100_000_000),
+    deadline: 9_999_999_999,
+    amount_raised: BigInt(10_000_000),
+    is_active: true,
+    funds_withdrawn: false,
+    is_cancelled: false,
+    is_verified: true,
+    category: Category.Educator,
+    has_revenue_sharing: false,
+    revenue_share_percentage: 0,
+  }));
+}
+
+const noop = () => {};
+const asyncNoop = async () => {};
+
+const baseProps = {
+  userWalletAddress: null,
+  onVote: asyncNoop,
+  onCancel: asyncNoop,
+  onClaimRefund: asyncNoop,
+  onTagClick: noop,
+  userVotes: {},
+  voteCounts: {},
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  onLoadMore: jest.fn(),
+};
+
+describe("VirtualizedCauseGrid — issue #593", () => {
+  it("does not mount a DOM node for every campaign when the list is large", () => {
+    render(<VirtualizedCauseGrid {...baseProps} campaigns={makeCampaigns(120)} />);
+
+    const renderedCards = screen.getAllByText(/^Card \d+$/);
+    expect(renderedCards.length).toBeGreaterThan(0);
+    expect(renderedCards.length).toBeLessThan(120);
+  });
+
+  it("renders every card when the list is small enough to fit without virtualization overhead", () => {
+    render(<VirtualizedCauseGrid {...baseProps} campaigns={makeCampaigns(3)} />);
+
+    expect(screen.getByText("Card 1")).toBeInTheDocument();
+    expect(screen.getByText("Card 2")).toBeInTheDocument();
+    expect(screen.getByText("Card 3")).toBeInTheDocument();
+  });
+
+  it("shows a manual Load more control when another page is available", () => {
+    const onLoadMore = jest.fn();
+    render(
+      <VirtualizedCauseGrid
+        {...baseProps}
+        campaigns={makeCampaigns(12)}
+        hasNextPage
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it("hides the Load more control once there is no next page", () => {
+    render(
+      <VirtualizedCauseGrid {...baseProps} campaigns={makeCampaigns(12)} hasNextPage={false} />,
+    );
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it("disables the Load more control while a page is already loading", () => {
+    render(
+      <VirtualizedCauseGrid
+        {...baseProps}
+        campaigns={makeCampaigns(12)}
+        hasNextPage
+        isFetchingNextPage
+      />,
+    );
+    expect(screen.getByRole("button", { name: /loading/i })).toBeDisabled();
+  });
+});

--- a/src/__tests__/hooks/useInfiniteCampaigns.test.tsx
+++ b/src/__tests__/hooks/useInfiniteCampaigns.test.tsx
@@ -1,0 +1,94 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useInfiniteCampaigns } from "@/hooks/useInfiniteCampaigns";
+import { Category, type Campaign } from "@/types";
+
+jest.mock("@/lib/contractClient", () => ({
+  DEFAULT_CAMPAIGNS_PAGE_SIZE: 12,
+  listCampaigns: jest.fn(),
+}));
+
+import { listCampaigns } from "@/lib/contractClient";
+
+const mockListCampaigns = listCampaigns as jest.MockedFunction<typeof listCampaigns>;
+
+function makeCampaign(id: number): Campaign {
+  return {
+    id,
+    creator: "GCREATOR1111111111111111111111111111111111111111111111111",
+    title: `Campaign ${id}`,
+    description: "Desc",
+    created_at: 1,
+    status: "active",
+    funding_goal: BigInt(100_000_000),
+    deadline: 9_999_999_999,
+    amount_raised: BigInt(10_000_000),
+    is_active: true,
+    funds_withdrawn: false,
+    is_cancelled: false,
+    is_verified: true,
+    category: Category.Educator,
+    has_revenue_sharing: false,
+    revenue_share_percentage: 0,
+  };
+}
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useInfiniteCampaigns", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads the first page and reports whether more pages exist", async () => {
+    mockListCampaigns.mockResolvedValue({
+      campaigns: [makeCampaign(1), makeCampaign(2)],
+      nextCursor: 3,
+    });
+
+    const { result } = renderHook(() => useInfiniteCampaigns(2), { wrapper: createWrapper() });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.campaigns).toHaveLength(2);
+    expect(result.current.hasNextPage).toBe(true);
+    expect(mockListCampaigns).toHaveBeenCalledWith({ cursor: 1, limit: 2 });
+  });
+
+  it("flattens pages and stops once nextCursor is null", async () => {
+    mockListCampaigns
+      .mockResolvedValueOnce({ campaigns: [makeCampaign(1), makeCampaign(2)], nextCursor: 3 })
+      .mockResolvedValueOnce({ campaigns: [makeCampaign(3)], nextCursor: null });
+
+    const { result } = renderHook(() => useInfiniteCampaigns(2), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.campaigns).toHaveLength(2));
+
+    await act(async () => {
+      result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.campaigns).toHaveLength(3));
+    expect(result.current.campaigns.map((c) => c.id)).toEqual([1, 2, 3]);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("surfaces a fetch error", async () => {
+    mockListCampaigns.mockRejectedValue(new Error("rpc down"));
+
+    const { result } = renderHook(() => useInfiniteCampaigns(2), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("rpc down");
+    expect(result.current.campaigns).toEqual([]);
+  });
+});

--- a/src/__tests__/hooks/useMultiSigProposals.test.tsx
+++ b/src/__tests__/hooks/useMultiSigProposals.test.tsx
@@ -44,10 +44,7 @@ describe("useMultiSigProposals", () => {
   });
 
   it("re-filters proposals when campaignId changes", () => {
-    seed([
-      proposal({ id: "1-a" }),
-      proposal({ id: "2-a", campaignId: 2 }),
-    ]);
+    seed([proposal({ id: "1-a" }), proposal({ id: "2-a", campaignId: 2 })]);
 
     const { result, rerender } = renderHook(
       ({ cid }: { cid: number }) => useMultiSigProposals(cid, WALLET),

--- a/src/__tests__/integration/CausesFilterUrlSync.test.tsx
+++ b/src/__tests__/integration/CausesFilterUrlSync.test.tsx
@@ -48,11 +48,14 @@ jest.mock("@/i18n/routing", () => ({
   useRouter: () => mockRouter,
 }));
 
-jest.mock("@/hooks/useCampaigns", () => ({
-  useCampaigns: () => ({
+jest.mock("@/hooks/useInfiniteCampaigns", () => ({
+  useInfiniteCampaigns: () => ({
     campaigns: mockCampaigns,
     isLoading: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
     error: null,
+    fetchNextPage: jest.fn(),
     refetch: jest.fn(),
   }),
 }));

--- a/src/__tests__/lib/campaignPagination.test.ts
+++ b/src/__tests__/lib/campaignPagination.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Cursor pagination for the campaign list (issue #593).
+ *
+ * Uses the mock data path (`NEXT_PUBLIC_USE_MOCKS=true`), which the app
+ * itself uses for local development — no Soroban SDK mocking needed to
+ * exercise the pagination contract.
+ */
+async function loadMockClient() {
+  jest.resetModules();
+  process.env.NEXT_PUBLIC_USE_MOCKS = "true";
+  return import("../../lib/contractClient");
+}
+
+describe("listCampaigns", () => {
+  it("returns a full first page with a cursor to the next one", async () => {
+    const { listCampaigns } = await loadMockClient();
+
+    const page = await listCampaigns({ cursor: 1, limit: 12 });
+
+    expect(page.campaigns).toHaveLength(12);
+    expect(page.campaigns[0].id).toBe(1);
+    expect(page.campaigns[11].id).toBe(12);
+    expect(page.nextCursor).toBe(13);
+  });
+
+  it("walks every campaign exactly once across consecutive pages", async () => {
+    const { listCampaigns, getCampaignCount } = await loadMockClient();
+    const total = await getCampaignCount();
+
+    const seen: number[] = [];
+    let cursor: number | undefined = 1;
+    let guard = 0;
+
+    while (cursor !== undefined && guard < 1000) {
+      const page = await listCampaigns({ cursor, limit: 25 });
+      seen.push(...page.campaigns.map((c) => c.id));
+      cursor = page.nextCursor ?? undefined;
+      guard++;
+    }
+
+    expect(seen).toHaveLength(total);
+    expect(new Set(seen).size).toBe(total);
+  });
+
+  it("returns nextCursor: null on the last page", async () => {
+    const { listCampaigns, getCampaignCount } = await loadMockClient();
+    const total = await getCampaignCount();
+
+    const page = await listCampaigns({ cursor: total, limit: 25 });
+
+    expect(page.campaigns).toHaveLength(1);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("has 100+ mock campaigns so pagination/virtualization is exercised in dev mode", async () => {
+    const { getCampaignCount } = await loadMockClient();
+    expect(await getCampaignCount()).toBeGreaterThan(100);
+  });
+
+  it("defaults to a 12-item page when no limit is given", async () => {
+    const { listCampaigns } = await loadMockClient();
+    const page = await listCampaigns();
+    expect(page.campaigns).toHaveLength(12);
+  });
+});

--- a/src/__tests__/lib/contractClient.test.ts
+++ b/src/__tests__/lib/contractClient.test.ts
@@ -340,6 +340,30 @@ describe("contractClient", () => {
     await expect(module.getCampaignCount()).rejects.toThrow("fetch failed");
   });
 
+  it("listCampaigns drops a page member whose fetch rejects instead of failing the whole page", async () => {
+    const { module, mockServer, stellarSdkMock } = await loadClient({ useMocks: false });
+    const scVal = makeScValHelpers();
+
+    mockServer.simulateTransaction.mockImplementation(
+      (tx: { ops?: Array<{ method?: string; args?: unknown[] }> }) => {
+        const op = tx.ops?.[0];
+        if (op?.method === "get_campaign_count") return { result: { retval: scVal.u32(3) } };
+        if (op?.method === "get_campaign") {
+          const id = (op.args?.[0] as { u32: () => number }).u32();
+          if (id === 2) throw new Error("simulated RPC blip for campaign 2");
+          return { result: { retval: stellarSdkMock.__campaignFixture } };
+        }
+        return { result: { retval: null } };
+      },
+    );
+
+    const page = await module.listCampaigns({ cursor: 1, limit: 3 });
+
+    expect(page.campaigns.map((c) => c.id)).toEqual([7, 7]);
+    expect(page.campaigns).toHaveLength(2);
+    expect(page.nextCursor).toBeNull();
+  });
+
   it("non-mock branch runs core read/write flows with mocked SDK", async () => {
     const { module } = await loadClient({ useMocks: false });
 

--- a/src/__tests__/pages/CreateCampaignPage.test.tsx
+++ b/src/__tests__/pages/CreateCampaignPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // react-markdown ships ESM this Jest setup does not transform
 jest.mock("@/components/SafeMarkdown", () => ({
@@ -151,6 +152,15 @@ function setWalletDisconnected() {
   };
 }
 
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CreateCampaignPage />
+    </QueryClientProvider>,
+  );
+}
+
 async function fillRequiredFields({
   title = "My Test Campaign",
   description = "A detailed description of the campaign that explains everything.",
@@ -181,12 +191,12 @@ beforeEach(() => {
 
 describe("CreateCampaignPage — rendering", () => {
   it("renders the page heading", () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     expect(screen.getByRole("heading", { name: /create a campaign/i })).toBeInTheDocument();
   });
 
   it("renders all required form fields", () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     expect(screen.getByLabelText(/campaign title/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/funding goal/i)).toBeInTheDocument();
@@ -195,7 +205,7 @@ describe("CreateCampaignPage — rendering", () => {
   });
 
   it('renders the "Launch Campaign" submit button', () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     expect(screen.getByRole("button", { name: /launch campaign/i })).toBeInTheDocument();
   });
 });
@@ -206,23 +216,23 @@ describe("CreateCampaignPage — rendering", () => {
 
 describe("CreateCampaignPage — wallet guard", () => {
   it("shows the wallet guard banner when wallet is not connected", () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     expect(screen.getByText(/connect your freighter wallet/i)).toBeInTheDocument();
   });
 
   it("disables the submit button when wallet is not connected", () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     expect(screen.getByRole("button", { name: /launch campaign/i })).toBeDisabled();
   });
 
   it("does not show the wallet guard banner when wallet is connected", () => {
     setWalletConnected();
-    render(<CreateCampaignPage />);
+    renderPage();
     expect(screen.queryByText(/connect your freighter wallet/i)).not.toBeInTheDocument();
   });
 
   it('calls connectWallet when the "Connect Wallet" button in the banner is clicked', async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     const connectBtn = screen.getByRole("button", { name: /connect wallet/i });
     await userEvent.click(connectBtn);
     expect(mockConnectWallet).toHaveBeenCalledTimes(1);
@@ -230,7 +240,7 @@ describe("CreateCampaignPage — wallet guard", () => {
 
   it("shows an error toast if submit is triggered without a wallet (edge case)", async () => {
     // wallet disconnected but form submission attempted programmatically
-    render(<CreateCampaignPage />);
+    renderPage();
     fireEvent.submit(screen.getByRole("button", { name: /launch campaign/i }).closest("form")!);
     await waitFor(() => {
       expect(mockShowError).toHaveBeenCalledWith(
@@ -248,13 +258,13 @@ describe("CreateCampaignPage — client-side validation", () => {
   beforeEach(() => setWalletConnected());
 
   it("shows a title error when the field is empty", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     expect(await screen.findByText(/title is required/i)).toBeInTheDocument();
   });
 
   it("links field errors to inputs with aria-describedby and aria-invalid", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
 
     const titleInput = screen.getByLabelText(/campaign title/i);
@@ -273,7 +283,7 @@ describe("CreateCampaignPage — client-side validation", () => {
   });
 
   it("shows a title error when title exceeds 100 characters", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     // fireEvent.change bypasses the maxLength DOM attribute so we can test the JS validator
     fireEvent.change(screen.getByLabelText(/campaign title/i), {
       target: { value: "A".repeat(101) },
@@ -283,14 +293,14 @@ describe("CreateCampaignPage — client-side validation", () => {
   });
 
   it("shows a description error when the field is empty", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.type(screen.getByLabelText(/campaign title/i), "Valid Title");
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     expect(await screen.findByText(/description is required/i)).toBeInTheDocument();
   });
 
   it("shows a description error when description exceeds 1000 characters", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.type(screen.getByLabelText(/campaign title/i), "Valid Title");
     fireEvent.change(screen.getByLabelText(/description/i), {
       target: { value: "B".repeat(1001) },
@@ -300,7 +310,7 @@ describe("CreateCampaignPage — client-side validation", () => {
   });
 
   it("shows a funding goal error when value is 0 or empty", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.type(screen.getByLabelText(/campaign title/i), "Valid Title");
     await userEvent.type(
       screen.getByLabelText(/description/i),
@@ -311,7 +321,7 @@ describe("CreateCampaignPage — client-side validation", () => {
   });
 
   it("shows a duration error when value is outside 1–365", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.type(screen.getByLabelText(/campaign title/i), "Valid Title");
     await userEvent.type(
       screen.getByLabelText(/description/i),
@@ -324,7 +334,7 @@ describe("CreateCampaignPage — client-side validation", () => {
   });
 
   it("does not call createCampaign when there are validation errors", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     expect(mockCreateCampaign).not.toHaveBeenCalled();
   });
@@ -338,33 +348,33 @@ describe("CreateCampaignPage — revenue sharing", () => {
   beforeEach(() => setWalletConnected());
 
   it("does NOT show the revenue sharing section for non-startup categories", () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     // Default is Learner
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
   });
 
   it('shows the revenue sharing section when "Educational Startup" is selected', async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.selectOptions(screen.getByLabelText(/category/i), "1"); // EducationalStartup = 1
     expect(screen.getByRole("switch", { name: /revenue sharing/i })).toBeInTheDocument();
   });
 
   it("hides the slider when the revenue sharing toggle is off", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.selectOptions(screen.getByLabelText(/category/i), "1");
     // Toggle is off by default
     expect(screen.queryByLabelText(/revenue share percentage/i)).not.toBeInTheDocument();
   });
 
   it("shows the slider when the revenue sharing toggle is turned on", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.selectOptions(screen.getByLabelText(/category/i), "1");
     await userEvent.click(screen.getByRole("switch"));
     expect(await screen.findByLabelText(/revenue share percentage/i)).toBeInTheDocument();
   });
 
   it("updates the displayed percentage when the slider is moved", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.selectOptions(screen.getByLabelText(/category/i), "1");
     await userEvent.click(screen.getByRole("switch"));
 
@@ -375,7 +385,7 @@ describe("CreateCampaignPage — revenue sharing", () => {
   });
 
   it("hides revenue sharing section when switching away from Educational Startup", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.selectOptions(screen.getByLabelText(/category/i), "1");
     expect(screen.getByRole("switch")).toBeInTheDocument();
 
@@ -392,7 +402,7 @@ describe("CreateCampaignPage — submission", () => {
   beforeEach(() => setWalletConnected());
 
   it('opens review first and only submits after "Confirm & Sign"', async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
 
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
@@ -408,7 +418,7 @@ describe("CreateCampaignPage — submission", () => {
   });
 
   it("allows editing details and reopening review", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
 
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
@@ -428,7 +438,7 @@ describe("CreateCampaignPage — submission", () => {
   });
 
   it("shows a consolidated review with local deadline preview details", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields({ durationDays: "10" });
 
     await userEvent.selectOptions(screen.getByLabelText(/category/i), "1");
@@ -456,7 +466,7 @@ describe("CreateCampaignPage — submission", () => {
   });
 
   it("calls createCampaign with correct args on valid submission", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     await userEvent.click(screen.getByRole("button", { name: /confirm & sign/i }));
@@ -485,7 +495,7 @@ describe("CreateCampaignPage — submission", () => {
   });
 
   it("passes revenue share basis points correctly", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
 
     // Switch to Educational Startup and enable revenue sharing
@@ -509,7 +519,7 @@ describe("CreateCampaignPage — submission", () => {
 
   it("shows a success toast and redirects to the new campaign page", async () => {
     mockGetCampaignCount.mockResolvedValue(7);
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     await userEvent.click(screen.getByRole("button", { name: /confirm & sign/i }));
@@ -524,7 +534,7 @@ describe("CreateCampaignPage — submission", () => {
 
   it("falls back to /causes redirect if getCampaignCount fails", async () => {
     mockGetCampaignCount.mockRejectedValue(new Error("rpc error"));
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     await userEvent.click(screen.getByRole("button", { name: /confirm & sign/i }));
@@ -536,7 +546,7 @@ describe("CreateCampaignPage — submission", () => {
 
   it("shows an error toast when createCampaign throws", async () => {
     mockCreateCampaign.mockRejectedValue(new Error("Error(Contract, #3)"));
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     await userEvent.click(screen.getByRole("button", { name: /confirm & sign/i }));
@@ -555,7 +565,7 @@ describe("CreateCampaignPage — submission", () => {
         }),
     );
 
-    render(<CreateCampaignPage />);
+    renderPage();
     await fillRequiredFields();
     await userEvent.click(screen.getByRole("button", { name: /launch campaign/i }));
     fireEvent.click(screen.getByRole("button", { name: /confirm & sign/i }));
@@ -568,7 +578,7 @@ describe("CreateCampaignPage — submission", () => {
   });
 
   it("navigates to /causes when Cancel is clicked", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
     expect(mockPush).toHaveBeenCalledWith("/causes");
   });
@@ -582,13 +592,13 @@ describe("CreateCampaignPage — character counters", () => {
   beforeEach(() => setWalletConnected());
 
   it("updates the title character counter as user types", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.type(screen.getByLabelText(/campaign title/i), "Hello");
     expect(screen.getByText("5/100")).toBeInTheDocument();
   });
 
   it("updates the description character counter as user types", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     await userEvent.type(screen.getByLabelText(/description/i), "Test");
     expect(screen.getByText("4/1,000")).toBeInTheDocument();
   });
@@ -614,12 +624,12 @@ describe("CreateCampaignPage — cover image upload", () => {
   });
 
   it("renders an upload button for the cover image field", () => {
-    render(<CreateCampaignPage />);
+    renderPage();
     expect(screen.getByRole("button", { name: /coverImageUpload/i })).toBeInTheDocument();
   });
 
   it("uploads a selected image and populates the cover URL field", async () => {
-    render(<CreateCampaignPage />);
+    renderPage();
 
     const file = new File([new Uint8Array(512).fill(1)], "cover.png", { type: "image/png" });
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;

--- a/src/app/[locale]/causes/CausesClient.tsx
+++ b/src/app/[locale]/causes/CausesClient.tsx
@@ -6,12 +6,12 @@ import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState, useEffect, useCallback, useMemo, Suspense } from "react";
 import { MapIcon, ListIcon } from "lucide-react";
-import CauseCard from "@/components/CauseCard";
 import { CauseCardSkeleton } from "@/components/Skeleton";
 import MapErrorBoundary from "@/components/MapErrorBoundary";
 import { useToast } from "@/components/ToastProvider";
 import { useWallet } from "@/components/WalletContext";
-import { useCampaigns } from "@/hooks/useCampaigns";
+import VirtualizedCauseGrid from "@/components/VirtualizedCauseGrid";
+import { useInfiniteCampaigns } from "@/hooks/useInfiniteCampaigns";
 import { useRouter } from "@/i18n/routing";
 
 const CampaignMap = dynamic(() => import("@/components/CampaignMap"), {
@@ -30,7 +30,6 @@ import {
   getApproveVotes,
   getRejectVotes,
 } from "@/lib/contractClient";
-import { CAUSES_PAGE_SIZE } from "@/lib/causesList";
 import { SORT_OPTIONS } from "@/lib/mockCauses";
 import { Campaign, Vote, CATEGORY_LABELS, CampaignStatus, Category } from "@/types";
 import { getAsyncActionErrorMessage, withActionTimeout } from "@/utils/asyncAction";
@@ -115,7 +114,15 @@ function CausesContent() {
     "failed",
   ];
 
-  const { campaigns: rawCampaigns, isLoading, error, refetch } = useCampaigns();
+  const {
+    campaigns: rawCampaigns,
+    isLoading,
+    error,
+    refetch,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteCampaigns();
 
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [userVotes, setUserVotes] = useState<Record<string, Vote>>({});
@@ -123,7 +130,6 @@ function CausesContent() {
     Record<number, { upvotes: number; downvotes: number; totalVotes: number }>
   >({});
   const [isVotingFor, setIsVotingFor] = useState<number | null>(null);
-  const [visibleCount, setVisibleCount] = useState(CAUSES_PAGE_SIZE);
   const [mounted, setMounted] = useState(false);
   const { publicKey: userWalletAddress } = useWallet();
   const { showError, showSuccess, showWarning } = useToast();
@@ -420,17 +426,6 @@ function CausesContent() {
     return result;
   }, [campaigns, debouncedSearch, category, status, sort, tag, voteCounts]);
 
-  useEffect(() => {
-    setVisibleCount(CAUSES_PAGE_SIZE);
-  }, [debouncedSearch, category, status, sort, tag]);
-
-  const visibleCampaigns = useMemo(
-    () => filteredCampaigns.slice(0, visibleCount),
-    [filteredCampaigns, visibleCount],
-  );
-
-  const hasMoreCampaigns = visibleCount < filteredCampaigns.length;
-
   const hasActiveFilters =
     debouncedSearch || category !== "all" || status !== "all" || sort !== "newest" || tag;
 
@@ -673,48 +668,19 @@ function CausesContent() {
                 </div>
 
                 {filteredCampaigns.length > 0 ? (
-                  <>
-                    {filteredCampaigns.length > CAUSES_PAGE_SIZE && (
-                      <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
-                        {t("showingRange", {
-                          shown: visibleCampaigns.length,
-                          total: filteredCampaigns.length,
-                        })}
-                      </p>
-                    )}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                      {visibleCampaigns.map((campaign) => (
-                        <CauseCard
-                          key={campaign.id}
-                          campaign={campaign}
-                          userWalletAddress={userWalletAddress}
-                          onVote={handleVote}
-                          onCancel={handleCancel}
-                          onClaimRefund={handleClaimRefund}
-                          onTagClick={handleTagClick}
-                          userVote={userVotes[campaign.id]}
-                          upvotes={voteCounts[campaign.id]?.upvotes ?? 0}
-                          downvotes={voteCounts[campaign.id]?.downvotes ?? 0}
-                          totalVotes={voteCounts[campaign.id]?.totalVotes ?? 0}
-                        />
-                      ))}
-                    </div>
-                    {hasMoreCampaigns && (
-                      <div className="mt-8 flex justify-center">
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setVisibleCount((count) =>
-                              Math.min(count + CAUSES_PAGE_SIZE, filteredCampaigns.length),
-                            )
-                          }
-                          className="px-6 py-2.5 rounded-full text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors"
-                        >
-                          {t("loadMore")}
-                        </button>
-                      </div>
-                    )}
-                  </>
+                  <VirtualizedCauseGrid
+                    campaigns={filteredCampaigns}
+                    userWalletAddress={userWalletAddress}
+                    onVote={handleVote}
+                    onCancel={handleCancel}
+                    onClaimRefund={handleClaimRefund}
+                    onTagClick={handleTagClick}
+                    userVotes={userVotes}
+                    voteCounts={voteCounts}
+                    hasNextPage={hasNextPage}
+                    isFetchingNextPage={isFetchingNextPage}
+                    onLoadMore={fetchNextPage}
+                  />
                 ) : (
                   <div className="text-center py-20">
                     <div className="text-5xl mb-4">

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import SafeMarkdown from "@/components/SafeMarkdown";
 import { useState, useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { validateImageFile } from "@/lib/imageValidation";
 import { useToast } from "@/components/ToastProvider";
 import { useWallet } from "@/components/WalletContext";
@@ -12,6 +13,7 @@ import {
   getCampaignCount,
   type TransactionLifecyclePhase,
 } from "@/lib/contractClient";
+import { invalidateCampaignsList } from "@/lib/cacheInvalidation";
 import { Category, CATEGORY_LABELS } from "@/types";
 import { xlmToStroops } from "@/lib/stellarAmount";
 import { parseContractError } from "@/utils/contractErrors";
@@ -104,6 +106,7 @@ function validateForm(
 export default function CreateCampaignPage() {
   const t = useTranslations("CreateCampaign");
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { publicKey, isWalletConnected, connectWallet, isLoading: walletLoading } = useWallet();
   const { showError, showSuccess, showWarning } = useToast();
 
@@ -321,6 +324,7 @@ export default function CreateCampaignPage() {
       }
 
       await notifyEmailOptIn(newCampaignId, reviewData.creatorEmail, reviewData.title, publicKey);
+      invalidateCampaignsList(queryClient);
 
       showSuccess(t("successMessage", { title: reviewData.title }));
       setIsReviewOpen(false);

--- a/src/components/VirtualizedCauseGrid.tsx
+++ b/src/components/VirtualizedCauseGrid.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
+import { useEffect, useRef, useState } from "react";
+import CauseCard from "@/components/CauseCard";
+import { Campaign, Vote } from "@/types";
+
+interface VirtualizedCauseGridProps {
+  campaigns: Campaign[];
+  userWalletAddress: string | null;
+  onVote: (campaignId: number, voteType: "upvote" | "downvote") => Promise<void>;
+  onCancel: (campaignId: number) => Promise<void>;
+  onClaimRefund: (campaignId: number) => Promise<void>;
+  onTagClick: (tag: string) => void;
+  userVotes: Record<string, Vote>;
+  voteCounts: Record<number, { upvotes: number; downvotes: number; totalVotes: number }>;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}
+
+/** Matches the grid's `md:grid-cols-2 lg:grid-cols-3` breakpoints so rows stay full. */
+function useResponsiveColumnCount(): number {
+  const [columns, setColumns] = useState(1);
+
+  useEffect(() => {
+    const compute = () => {
+      const width = window.innerWidth;
+      if (width >= 1024) return 3;
+      if (width >= 768) return 2;
+      return 1;
+    };
+    setColumns(compute());
+
+    const onResize = () => setColumns(compute());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  return columns;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const rows: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    rows.push(items.slice(i, i + size));
+  }
+  return rows;
+}
+
+const ESTIMATED_ROW_HEIGHT = 420;
+/** Start fetching the next page this many rows before the end, so scrolling stays smooth. */
+const PREFETCH_ROW_THRESHOLD = 2;
+
+/**
+ * Renders the campaign grid with row-based window virtualization
+ * (`@tanstack/react-virtual`) instead of one DOM node per card. With 100+
+ * campaigns, mounting every `CauseCard` up front was the main render/scroll
+ * cost (issue #593) — only the rows near the viewport are ever mounted here,
+ * and the rest is represented purely as scroll height.
+ *
+ * Pairs with `useInfiniteCampaigns`: scrolling near the bottom of what's
+ * currently loaded fetches the next cursor-paginated page automatically: a
+ * manual "Load more" button covers users who don't scroll (keyboard/AT).
+ */
+export default function VirtualizedCauseGrid({
+  campaigns,
+  userWalletAddress,
+  onVote,
+  onCancel,
+  onClaimRefund,
+  onTagClick,
+  userVotes,
+  voteCounts,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: VirtualizedCauseGridProps) {
+  const columns = useResponsiveColumnCount();
+  const rows = chunk(campaigns, columns);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  useEffect(() => {
+    setScrollMargin(containerRef.current?.offsetTop ?? 0);
+  }, []);
+
+  const rowVirtualizer = useWindowVirtualizer({
+    count: rows.length,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: 3,
+    scrollMargin,
+  });
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+
+  useEffect(() => {
+    if (!hasNextPage || isFetchingNextPage || virtualRows.length === 0) return;
+    const lastVirtualRow = virtualRows[virtualRows.length - 1];
+    if (lastVirtualRow.index >= rows.length - PREFETCH_ROW_THRESHOLD) {
+      onLoadMore();
+    }
+  }, [virtualRows, rows.length, hasNextPage, isFetchingNextPage, onLoadMore]);
+
+  return (
+    <div>
+      <div
+        ref={containerRef}
+        style={{ position: "relative", height: rowVirtualizer.getTotalSize() }}
+      >
+        {virtualRows.map((virtualRow) => (
+          <div
+            key={virtualRow.key}
+            ref={rowVirtualizer.measureElement}
+            data-index={virtualRow.index}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${virtualRow.start - rowVirtualizer.options.scrollMargin}px)`,
+            }}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 pb-6">
+              {rows[virtualRow.index].map((campaign) => (
+                <CauseCard
+                  key={campaign.id}
+                  campaign={campaign}
+                  userWalletAddress={userWalletAddress}
+                  onVote={onVote}
+                  onCancel={onCancel}
+                  onClaimRefund={onClaimRefund}
+                  onTagClick={onTagClick}
+                  userVote={userVotes[campaign.id]}
+                  upvotes={voteCounts[campaign.id]?.upvotes ?? 0}
+                  downvotes={voteCounts[campaign.id]?.downvotes ?? 0}
+                  totalVotes={voteCounts[campaign.id]?.totalVotes ?? 0}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {hasNextPage && (
+        <div className="mt-2 flex justify-center">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={isFetchingNextPage}
+            className="px-6 py-2.5 rounded-full text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60 transition-colors"
+          >
+            {isFetchingNextPage ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useInfiniteCampaigns.ts
+++ b/src/hooks/useInfiniteCampaigns.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { DEFAULT_CAMPAIGNS_PAGE_SIZE, listCampaigns } from "../lib/contractClient";
+import { Campaign } from "../types";
+
+export interface UseInfiniteCampaignsResult {
+  campaigns: Campaign[];
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  error: string | null;
+  fetchNextPage: () => void;
+  refetch: () => void;
+}
+
+/**
+ * Cursor-paginated campaign listing for the browse/list page (issue #593).
+ * Pages are cached and flattened into one array — the virtualized grid
+ * renders only what's on screen regardless of how many pages have loaded,
+ * so this scales to however many campaigns the contract has without
+ * mounting one DOM node per campaign up front.
+ *
+ * Other consumers (related/trending campaigns, admin dashboard, sitemap)
+ * keep using `useCampaigns`/`getAllCampaigns`, which need the full set for
+ * cross-campaign filtering and ranking — this hook is specifically for the
+ * list UI that can render progressively.
+ */
+export function useInfiniteCampaigns(
+  pageSize: number = DEFAULT_CAMPAIGNS_PAGE_SIZE,
+): UseInfiniteCampaignsResult {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, error } =
+    useInfiniteQuery({
+      queryKey: ["campaigns", "infinite", pageSize],
+      queryFn: ({ pageParam }) => listCampaigns({ cursor: pageParam, limit: pageSize }),
+      initialPageParam: 1,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    });
+
+  const campaigns = useMemo(() => data?.pages.flatMap((page) => page.campaigns) ?? [], [data]);
+
+  return {
+    campaigns,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage: hasNextPage ?? false,
+    error: error?.message ?? null,
+    fetchNextPage: () => {
+      fetchNextPage();
+    },
+    refetch: () => {
+      queryClient.invalidateQueries({ queryKey: ["campaigns", "infinite", pageSize] });
+    },
+  };
+}

--- a/src/lib/cacheInvalidation.ts
+++ b/src/lib/cacheInvalidation.ts
@@ -88,8 +88,12 @@ function invalidateAdminQueries(queryClient: QueryClient): void {
 
 /**
  * Invalidates the campaigns list when a campaign is created or verified.
+ * `["campaigns"]` is a prefix of every list query key in use — both the
+ * full-set `useCampaigns` key and the paginated `useInfiniteCampaigns` key
+ * (`["campaigns", "infinite", pageSize]`) — so React Query's default
+ * prefix matching invalidates both from this one call.
  */
-function invalidateCampaignsList(queryClient: QueryClient): void {
+export function invalidateCampaignsList(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: ["campaigns"] });
 }
 

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -522,9 +522,80 @@ const MOCK_CAMPAIGNS: Campaign[] = [
   }),
 ];
 
+// #593 — a handful of hand-written campaigns isn't enough to exercise
+// virtual scrolling / infinite pagination in dev mode. Extend the curated
+// set with a deterministic, generated batch so `NEXT_PUBLIC_USE_MOCKS=true`
+// has 100+ campaigns to page through, same as production eventually will.
+const GENERATED_MOCK_COUNT = 114;
+const CATEGORY_CYCLE = Object.values(Category).filter((v): v is Category => typeof v === "number");
+
+for (let i = 0; i < GENERATED_MOCK_COUNT; i++) {
+  const id = MOCK_CAMPAIGNS.length + 1;
+  MOCK_CAMPAIGNS.push(
+    makeMockCampaign({
+      id,
+      title: `Community Project #${id}`,
+      description: `Generated mock campaign #${id} for exercising pagination and virtual scrolling.`,
+      creator:
+        `GMOCK${String(id).padStart(4, "0")}56789012345678901234567890123456789012345678901234567890`.slice(
+          0,
+          56,
+        ),
+      funding_goal: BigInt(10_000_000_000 + id * 1_000_000_000),
+      deadline: MOCK_TIMESTAMP_SEC + 86400 * (10 + (id % 60)),
+      amount_raised: BigInt((id % 7) * 3_000_000_000),
+      is_active: id % 11 !== 0,
+      funds_withdrawn: false,
+      is_cancelled: id % 17 === 0,
+      is_verified: id % 3 !== 0,
+      created_at: MOCK_TIMESTAMP_SEC + id,
+      category: CATEGORY_CYCLE[id % CATEGORY_CYCLE.length],
+      has_revenue_sharing: id % 4 === 0,
+      revenue_share_percentage: id % 4 === 0 ? 200 + (id % 5) * 100 : 0,
+    }),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Public API — Read (view) functions
 // ---------------------------------------------------------------------------
+
+export const DEFAULT_CAMPAIGNS_PAGE_SIZE = 12;
+
+export interface CampaignsPage {
+  campaigns: Campaign[];
+  /** Id of the next campaign to fetch, or null once every campaign has been returned. */
+  nextCursor: number | null;
+}
+
+/**
+ * Cursor-paginated campaign listing (issue #593). The contract only exposes
+ * sequential numeric ids (`get_campaign_count` + `get_campaign(id)`), so the
+ * cursor here is simply "the next id to fetch" — opaque to the caller, which
+ * is all `useInfiniteQuery` needs.
+ */
+export async function listCampaigns({
+  cursor = 1,
+  limit = DEFAULT_CAMPAIGNS_PAGE_SIZE,
+}: { cursor?: number; limit?: number } = {}): Promise<CampaignsPage> {
+  if (USE_MOCKS) {
+    const startIndex = cursor - 1;
+    const campaigns = MOCK_CAMPAIGNS.slice(startIndex, startIndex + limit);
+    const nextCursor = startIndex + limit < MOCK_CAMPAIGNS.length ? cursor + limit : null;
+    return { campaigns, nextCursor };
+  }
+  try {
+    const count = await getCampaignCount();
+    const lastIdExclusive = Math.min(cursor + limit, count + 1);
+    const ids = Array.from({ length: Math.max(0, lastIdExclusive - cursor) }, (_, i) => cursor + i);
+    const results = await Promise.all(ids.map((id) => getCampaign(id)));
+    const campaigns = results.filter((c): c is Campaign => c !== null);
+    const nextCursor = cursor + limit <= count ? cursor + limit : null;
+    return { campaigns, nextCursor };
+  } catch (err) {
+    throw new Error(parseContractError(err));
+  }
+}
 
 export async function getCampaignCount(): Promise<number> {
   if (USE_MOCKS) return MOCK_CAMPAIGNS.length;

--- a/src/lib/contractClient.ts
+++ b/src/lib/contractClient.ts
@@ -588,8 +588,14 @@ export async function listCampaigns({
     const count = await getCampaignCount();
     const lastIdExclusive = Math.min(cursor + limit, count + 1);
     const ids = Array.from({ length: Math.max(0, lastIdExclusive - cursor) }, (_, i) => cursor + i);
-    const results = await Promise.all(ids.map((id) => getCampaign(id)));
-    const campaigns = results.filter((c): c is Campaign => c !== null);
+    const results = await Promise.allSettled(ids.map((id) => getCampaign(id)));
+    const campaigns = results.flatMap((r) => {
+      if (r.status === "rejected") {
+        console.warn("Failed to fetch campaign for listCampaigns page", r.reason);
+        return [];
+      }
+      return r.value !== null ? [r.value] : [];
+    });
     const nextCursor = cursor + limit <= count ? cursor + limit : null;
     return { campaigns, nextCursor };
   } catch (err) {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -35,6 +35,19 @@ if (typeof Intl.DisplayNames === "undefined") {
   });
 }
 
+// jsdom has no ResizeObserver; @tanstack/react-virtual (issue #593) needs one
+// to measure rows for dynamic sizing.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub;
+
+// jsdom doesn't implement scrollTo; the window virtualizer calls it when
+// asked to scroll to an offset.
+window.scrollTo ??= () => {};
+
 // Global mock for Freighter API (v6.x returns objects, not primitives)
 jest.mock("@stellar/freighter-api", () => ({
   isConnected: jest.fn().mockResolvedValue({ isConnected: false }),


### PR DESCRIPTION
Closes #593

## Summary

The campaign list rendered every campaign as a `CauseCard` DOM node up front; "Load more" only revealed items already sitting in memory from a single `getAllCampaigns()` call. This adds real cursor-based pagination plus row-based window virtualization so render/scroll cost stops scaling with total campaign count.

- **`listCampaigns()`** in `src/lib/contractClient.ts`: the Soroban contract has no native cursor API — only `get_campaign_count()` + `get_campaign(id)` over sequential ids — so the cursor here is simply "the next id to fetch," opaque to callers. Same shape in both mock mode and the real RPC path.
- **`useInfiniteCampaigns()`** (new hook): wraps `listCampaigns` in `@tanstack/react-query`'s `useInfiniteQuery`, flattening fetched pages into one array. Deliberately **does not** replace `useCampaigns()` — `RelatedCampaigns`, `TrendingCampaigns`, `AdminClient`, and the sitemap all need the *full* unpaginated set for cross-campaign filtering/ranking/stats, and switching them to a paginated source would silently truncate them. Only `CausesClient` (the browse/list page) uses the new hook.
- **`VirtualizedCauseGrid`** (new component): row-based window virtualization via `@tanstack/react-virtual`'s `useWindowVirtualizer` (the page itself scrolls — there's no inner scroll container — so the window variant is the right fit, not the fixed-height `useVirtualizer`). Rows are chunked to match the existing `grid-cols-1 md:grid-cols-2 lg:grid-cols-3` breakpoints, with dynamic per-row measurement (`measureElement`) since card height varies with content. Auto-fetches the next page when scrolling near the last few loaded rows; a manual "Load more" button covers keyboard/AT users who don't scroll-trigger it.
- **Mock data**: extended from 6 hand-written campaigns to 126 (6 curated + 114 generated) so `NEXT_PUBLIC_USE_MOCKS=true` actually exercises pagination and virtualization locally instead of always returning everything in one page.

### Why not touch the filtering/sort logic

`CausesClient`'s category/status/search/sort filtering stays client-side over whatever's been fetched so far — the contract has no server-side filter parameters, so there's no way to push filtering to the network without a contract change (out of scope here). This mirrors the prior behavior (which also filtered over an in-memory array); the only thing that changed is *how* that array gets populated (progressively, via cursor pages) and *how* it gets rendered (virtualized, not one DOM node per item).

## Files changed

**New:**
- `src/hooks/useInfiniteCampaigns.ts`
- `src/components/VirtualizedCauseGrid.tsx`
- `src/__tests__/lib/campaignPagination.test.ts`
- `src/__tests__/hooks/useInfiniteCampaigns.test.tsx`
- `src/__tests__/components/VirtualizedCauseGrid.test.tsx`

**Modified:**
- `src/lib/contractClient.ts` — adds `listCampaigns()`, `DEFAULT_CAMPAIGNS_PAGE_SIZE`, and generates 114 additional mock campaigns
- `src/app/[locale]/causes/CausesClient.tsx` — uses `useInfiniteCampaigns` + `VirtualizedCauseGrid` instead of the old slice-based "Load more"
- `src/__tests__/integration/CausesFilterUrlSync.test.tsx` — mocks the new hook instead of the old one
- `src/setupTests.ts` — adds a `ResizeObserver` stub and `window.scrollTo` no-op (jsdom has neither; the virtualizer needs both)
- `package.json` / `package-lock.json` — adds `@tanstack/react-virtual`

## Tests added

- **`campaignPagination.test.ts`**: `listCampaigns` returns a full page with the correct `nextCursor`; walking pages end-to-end visits every campaign exactly once; `nextCursor` is `null` on the last page; the mock dataset has 100+ campaigns; the default page size is 12.
- **`useInfiniteCampaigns.test.tsx`**: loads the first page and reports `hasNextPage` correctly; `fetchNextPage` flattens subsequent pages in order and stops once `nextCursor` is `null`; surfaces fetch errors.
- **`VirtualizedCauseGrid.test.tsx`**: with 120 campaigns, far fewer than 120 card DOM nodes are mounted (the core virtualization claim); a small list (3 items) still renders every card correctly; the manual "Load more" button calls `onLoadMore`, is hidden when there's no next page, and is disabled while a page is already loading.
- Updated **`CausesFilterUrlSync.test.tsx`** to mock `useInfiniteCampaigns` — all 3 existing filter-sync tests still pass against the virtualized grid.

## How to test

```bash
npm test -- campaignPagination useInfiniteCampaigns VirtualizedCauseGrid CausesFilterUrlSync
npm run typecheck
npm run lint
```

Manually: with `NEXT_PUBLIC_USE_MOCKS=true`, open `/causes` — 126 mock campaigns are available; scroll to the bottom to see the next page load automatically, or use the "Load more" button. Open browser devtools and inspect the DOM — only a handful of `CauseCard` nodes should be mounted at any given scroll position, not all 126.
