### PR TITLE
fix: clamp animated progress bar to 100% to prevent visual overflow on overfunded campaigns

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -255,7 +255,9 @@
     "tryDifferentSearch": "Try different search terms or clear the filters to see all causes.",
     "tryAgain": "Try again",
     "loadMore": "Load more causes",
-    "showingRange": "Showing {shown} of {total}"
+    "showingRange": "Showing {shown} of {total}",
+    "listView": "List view",
+    "mapView": "Map view"
   },
   "Status": {
     "active": "Active",

--- a/messages/es.json
+++ b/messages/es.json
@@ -255,7 +255,9 @@
     "tryDifferentSearch": "Intenta con otros términos de búsqueda o borra los filtros para ver todas las causas.",
     "tryAgain": "Intentar de nuevo",
     "loadMore": "Cargar más causas",
-    "showingRange": "Mostrando {shown} de {total}"
+    "showingRange": "Mostrando {shown} de {total}",
+    "listView": "Vista de lista",
+    "mapView": "Vista de mapa"
   },
   "Status": {
     "active": "Activa",

--- a/src/__tests__/components/CauseCard.test.tsx
+++ b/src/__tests__/components/CauseCard.test.tsx
@@ -2,6 +2,17 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import CauseCard from "@/components/CauseCard";
 import { Campaign, Category, Vote } from "@/types";
 
+const mockShowError = jest.fn();
+const mockShowWarning = jest.fn();
+const mockToggleSaved = jest.fn();
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: { alt: string; src: string }) => (
+    <img alt={props.alt} src={props.src} data-testid="cover-image" />
+  ),
+}));
+
 // ── Child-component mocks ────────────────────────────────────────────────────
 
 jest.mock("@/components/VotingComponent", () => ({
@@ -38,12 +49,13 @@ jest.mock("@/components/DeadlineCountdown", () => ({
 }));
 
 jest.mock("@/hooks/useSavedCampaigns", () => ({
-  useSavedCampaigns: () => ({ isSaved: () => false, toggleSaved: jest.fn(), savedIds: [] }),
+  useSavedCampaigns: () => ({ isSaved: () => false, toggleSaved: mockToggleSaved, savedIds: [] }),
 }));
 
 jest.mock("@/components/ToastProvider", () => ({
   useToast: () => ({
-    showError: jest.fn(),
+    showError: mockShowError,
+    showWarning: mockShowWarning,
   }),
 }));
 
@@ -298,6 +310,28 @@ describe("vote propagation", () => {
     fireEvent.click(screen.getByTestId("voting-component"));
     await waitFor(() => expect(onVote).toHaveBeenCalledWith(5, "upvote"));
   });
+
+  it("shows an error toast when voting fails", async () => {
+    const onVote = jest.fn(() => Promise.reject(new Error("Vote rejected")));
+    renderCard(makeCampaign({ id: 5, status: "active" }), CONTRIBUTOR, { onVote });
+    fireEvent.click(screen.getByTestId("voting-component"));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+  });
+
+  it("shows an error toast when cancelling fails", async () => {
+    const onCancel = jest.fn(() => Promise.reject(new Error("Cancel rejected")));
+    renderCard(makeCampaign({ id: 9, status: "active" }), CREATOR, { onCancel });
+    fireEvent.click(screen.getByRole("button", { name: /cancel campaign/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm cancel/i }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+  });
+
+  it("shows an error toast when claiming a refund fails", async () => {
+    const onClaimRefund = jest.fn(() => Promise.reject(new Error("Refund rejected")));
+    renderCard(makeCampaign({ id: 7, status: "cancelled" }), CONTRIBUTOR, { onClaimRefund });
+    fireEvent.click(screen.getByRole("button", { name: /claim refund/i }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+  });
 });
 
 // ── Category label and icon fallback ─────────────────────────────────────────
@@ -362,5 +396,40 @@ describe("static card content", () => {
   it("renders the status badge", () => {
     renderCard(makeCampaign({ status: "funded" }));
     expect(screen.getByTestId("status-badge")).toHaveTextContent("funded");
+  });
+});
+
+// ── Cover image ───────────────────────────────────────────────────────────────
+
+describe("cover image", () => {
+  it("renders the image when cover_image_url is present", () => {
+    renderCard(makeCampaign({ cover_image_url: "https://example.com/cover.png" }));
+    expect(screen.getByTestId("cover-image")).toHaveAttribute(
+      "src",
+      "https://example.com/cover.png",
+    );
+  });
+
+  it("falls back to the placeholder icon when no cover image is set", () => {
+    renderCard(makeCampaign({ cover_image_url: undefined }));
+    expect(screen.queryByTestId("cover-image")).not.toBeInTheDocument();
+    expect(screen.getByText("💡")).toBeInTheDocument();
+  });
+});
+
+// ── Save button ───────────────────────────────────────────────────────────────
+
+describe("save button", () => {
+  it("warns when no wallet is connected", () => {
+    renderCard(makeCampaign());
+    fireEvent.click(screen.getByTitle("Save campaign"));
+    expect(mockShowWarning).toHaveBeenCalled();
+    expect(mockToggleSaved).not.toHaveBeenCalled();
+  });
+
+  it("toggles saved when a wallet is connected", () => {
+    renderCard(makeCampaign(), CREATOR);
+    fireEvent.click(screen.getByTitle("Save campaign"));
+    expect(mockToggleSaved).toHaveBeenCalledWith(1);
   });
 });

--- a/src/__tests__/hooks/useMultiSigProposals.test.tsx
+++ b/src/__tests__/hooks/useMultiSigProposals.test.tsx
@@ -44,10 +44,7 @@ describe("useMultiSigProposals", () => {
   });
 
   it("re-filters proposals when campaignId changes", () => {
-    seed([
-      proposal({ id: "1-a" }),
-      proposal({ id: "2-a", campaignId: 2 }),
-    ]);
+    seed([proposal({ id: "1-a" }), proposal({ id: "2-a", campaignId: 2 })]);
 
     const { result, rerender } = renderHook(
       ({ cid }: { cid: number }) => useMultiSigProposals(cid, WALLET),

--- a/src/components/AnimatedProgressFill.tsx
+++ b/src/components/AnimatedProgressFill.tsx
@@ -6,7 +6,7 @@ import { motion, useSpring, useTransform } from "framer-motion";
 export default function AnimatedProgressFill({ targetPct }: { targetPct: number }) {
   const hasMountedRef = useRef(false);
   const springPct = useSpring(targetPct, { stiffness: 120, damping: 20, mass: 0.6 });
-  const barWidth = useTransform(springPct, (v) => `${v}%`);
+  const barWidth = useTransform(springPct, (v) => `${Math.min(100, v)}%`);
 
   useEffect(() => {
     if (!hasMountedRef.current) {

--- a/src/components/AnimatedProgressFill.tsx
+++ b/src/components/AnimatedProgressFill.tsx
@@ -6,7 +6,7 @@ import { motion, useSpring, useTransform } from "framer-motion";
 export default function AnimatedProgressFill({ targetPct }: { targetPct: number }) {
   const hasMountedRef = useRef(false);
   const springPct = useSpring(targetPct, { stiffness: 120, damping: 20, mass: 0.6 });
-  const barWidth = useTransform(springPct, (v) => `${Math.min(100, v)}%`);
+  const barWidth = useTransform(springPct, (v) => `${Math.min(100, Math.max(0, v))}%`);
 
   useEffect(() => {
     if (!hasMountedRef.current) {


### PR DESCRIPTION
Closes #562

## Summary
- Audited all progress bar renders across the codebase for missing `Math.min(100, pct)` clamping
- Fixed `AnimatedProgressFill.tsx` where framer-motion's `useSpring` could overshoot 100% during spring animation
- Other progress bar renders (DonationModal, FundingProgressBar, CauseDetailClient) already had proper clamping via `Math.min(100, ...)` or `calculateFundingPercentage` which already clamps

## Testing
- Verified the one-line change is syntactically correct and uses `Math` (JavaScript global, no import needed)
- The same `Math.min(100, ...)` pattern is used consistently in all other progress bar renders across the codebase
