### PR TITLE
fix(security): add auth to observability API routes

### DIFF
--- a/src/app/api/observability/events/route.ts
+++ b/src/app/api/observability/events/route.ts
@@ -5,7 +5,26 @@ import { createRateLimiter, rateLimitKeyFromRequest } from "@/lib/rateLimit";
 
 const observabilityRateLimiter = createRateLimiter(60_000, 10);
 
+/**
+ * Check x-metrics-token against METRICS_SECRET_TOKEN.
+ * If the env var is not set, the endpoint is effectively disabled.
+ */
+function requireMetricsAuth(req: NextRequest): NextResponse | null {
+  const secret = process.env.METRICS_SECRET_TOKEN;
+  if (!secret) {
+    return NextResponse.json({ message: "Observability is not configured" }, { status: 503 });
+  }
+  const token = req.headers.get("x-metrics-token");
+  if (!token || token !== secret) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
 export async function POST(req: NextRequest) {
+  const authError = requireMetricsAuth(req);
+  if (authError) return authError;
+
   const rateLimitKey = rateLimitKeyFromRequest(req);
   if (!observabilityRateLimiter.check(rateLimitKey)) {
     return NextResponse.json({ message: "Too many requests. Please slow down." }, { status: 429 });

--- a/src/app/api/observability/metrics/route.ts
+++ b/src/app/api/observability/metrics/route.ts
@@ -1,7 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getObservabilityMetricsSnapshot } from "@/lib/observability/metricsStore";
 
+/**
+ * Check x-metrics-token against METRICS_SECRET_TOKEN.
+ * If the env var is not set, the endpoint is effectively disabled.
+ */
+function requireMetricsAuth(req: NextRequest): NextResponse | null {
+  const secret = process.env.METRICS_SECRET_TOKEN;
+  if (!secret) {
+    return NextResponse.json({ message: "Observability is not configured" }, { status: 503 });
+  }
+  const token = req.headers.get("x-metrics-token");
+  if (!token || token !== secret) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
 export async function GET(req: NextRequest) {
+  const authError = requireMetricsAuth(req);
+  if (authError) return authError;
+
   const url = new URL(req.url);
   const windowMs = Number(url.searchParams.get("windowMs") ?? 5 * 60_000);
   const snapshot = getObservabilityMetricsSnapshot(


### PR DESCRIPTION
## Overview

Split out from the original combined PR per review feedback — this PR is scoped to the **security fix only** (issue #566). The campaign transfer UI (issue #577) has been moved to a separate PR.

## Related Issues

Closes #566

## Changes

- **[MODIFY]** `src/app/api/observability/metrics/route.ts`
  - Added `requireMetricsAuth()` — checks `x-metrics-token` header against `METRICS_SECRET_TOKEN` env var
  - Returns **401** if token is missing/wrong, **503** if env var not configured
- **[MODIFY]** `src/app/api/observability/events/route.ts`
  - Same auth guard applied to the POST events endpoint

## Verification

- TypeScript: no type errors
- Prettier + ESLint: clean on modified files
- Rebased onto latest upstream `main`

| Acceptance Criteria (Issue #566) | Status |
| --- | --- |
| Metrics endpoint requires x-metrics-token | Yes |
| Events endpoint requires x-metrics-token | Yes |
| Misconfigured env returns 503 | Yes |
| Missing/wrong token returns 401 | Yes |
