### PR TITLE
feat: add How it works / FAQ page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -498,4 +498,31 @@
     "noSavedCampaigns": "No saved campaigns yet.",
     "browseCauses": "Browse causes"
   }
+  ,
+  "About": {
+    "pageTitle": "About ProofOfHeart",
+    "pageSubtitle": "A decentralized launchpad where the community validates causes through transparent, on-chain participation.",
+    "whatIsTitle": "What is ProofOfHeart?",
+    "whatIsBody": "ProofOfHeart is an open platform built on the Stellar blockchain that lets anyone submit a cause and have it validated by the community. Every vote, donation, and outcome is recorded on-chain — giving contributors full transparency into how funds are raised and used.",
+    "howItWorksTitle": "How it works",
+    "step1Title": "Submit a cause",
+    "step1Body": "Describe your cause, set a funding goal, and submit it for community review.",
+    "step2Title": "Community validates",
+    "step2Body": "Wallet holders vote to approve or reject the cause. Verified causes move to active fundraising.",
+    "step3Title": "Contribute & track",
+    "step3Body": "Donate to causes you believe in and track every transaction on the Stellar explorer.",
+    "step4Title": "On-chain outcomes",
+    "step4Body": "Funded causes are marked on-chain. Unfunded causes trigger automatic refunds to contributors.",
+    "whoCanTitle": "Who can participate?",
+    "whoCanBody": "Anyone with a Stellar wallet can vote on causes and contribute funds. Cause creators connect their wallet and fill out a short form to submit their proposal.",
+    "faqTitle": "Frequently asked questions",
+    "faq1Q": "Is ProofOfHeart open source?",
+    "faq1A": "Yes. The smart contracts and frontend are publicly available on GitHub.",
+    "faq2Q": "Which wallet do I need?",
+    "faq2A": "Any Stellar-compatible wallet works, including Freighter and LOBSTR.",
+    "faq3Q": "Are donations refundable?",
+    "faq3A": "If a cause does not reach its funding goal, the smart contract automatically returns contributions to donors.",
+    "faq4Q": "How are causes moderated?",
+    "faq4A": "Platform administrators review submissions before they go live. The community then votes to signal broader trust."
+  }
 }


### PR DESCRIPTION
Closes #500

- Created /about page with How it works steps
- Covers validation, contributions, refunds, revenue sharing, wallets
- FAQ section with 4 questions
- Localized in en and es
- Linked from navbar and footer