### PR TITLE
fix(donation): route amount validation errors through i18n keys

### DIFF
--- a/src/__tests__/components/DonationModal.test.tsx
+++ b/src/__tests__/components/DonationModal.test.tsx
@@ -37,6 +37,8 @@ jest.mock("next-intl", () => ({
       title: "Fund This Cause",
       confirmedTitle: "Donation Confirmed",
       amountLabel: "Amount (XLM)",
+      amountPlaceholder: "e.g. 10",
+      closeAriaLabel: "Close",
       percentFunded: `${values?.percent}% funded`,
       afterDonation: `After your donation: ${values?.percent}% funded`,
       goalReached: "Goal reached!",
@@ -63,7 +65,9 @@ jest.mock("next-intl", () => ({
       amountExceedsRemainingGoal: "Amount exceeds the remaining funding goal.",
       campaignAlreadyFunded: "This cause is already fully funded.",
     };
-    return map[key] ?? key;
+    // Surface anything that is not a known message key so hard-coded English
+    // strings reaching the translator fail loudly instead of passing through.
+    return map[key] ?? `MISSING(${key})`;
   },
 }));
 
@@ -148,6 +152,22 @@ describe("DonationModal", () => {
     expect(error).toHaveAttribute("role", "alert");
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(input).toHaveAttribute("aria-describedby", "donation-amount-error");
+  });
+
+  it.each([
+    ["1e5", "Scientific notation is not allowed."],
+    ["-5", "Amount must be greater than zero."],
+    ["1.12345678", "Maximum 7 decimal places allowed."],
+    ["9999", "Amount exceeds the remaining funding goal."],
+  ])("renders a translated message for %s instead of an untranslated string", (value, expected) => {
+    render(<DonationModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByLabelText("Amount (XLM)"), { target: { value } });
+
+    const error = screen.getByRole("alert");
+    expect(error).toHaveTextContent(expected);
+    expect(error.textContent).not.toMatch(/^MISSING\(/);
+    expect(error.textContent).not.toBe("undefined");
   });
 
   it("renders the platform fee explanation", () => {

--- a/src/__tests__/components/DonationModal.test.tsx
+++ b/src/__tests__/components/DonationModal.test.tsx
@@ -55,6 +55,7 @@ jest.mock("next-intl", () => ({
       donatedSuccess: `${values?.amount} XLM donated successfully`,
       thankYou: "Thank you for supporting this cause.",
       viewExplorer: "View on Stellar Explorer →",
+      downloadReceipt: "Download Tax Receipt (PDF)",
       close: "Close",
       scientificNotation: "Scientific notation is not allowed.",
       invalidNumber: "Please enter a valid number.",

--- a/src/components/DonationModal.tsx
+++ b/src/components/DonationModal.tsx
@@ -215,13 +215,14 @@ export default function DonationModal({
 
   const validation = validateAmount(amount);
   const isFullyFunded = raised >= goal;
-  const amountError =
-    error ||
-    (isFullyFunded
-      ? "campaignAlreadyFunded"
-      : amount.trim() && !validation.valid
-        ? validation.errorKey || "Please enter a valid amount."
-        : null);
+  // Always a translation key so formatError() can resolve it through next-intl —
+  // never a hard-coded English sentence.
+  const validationErrorKey: DonationValidationKey | null = isFullyFunded
+    ? "campaignAlreadyFunded"
+    : amount.trim() && !validation.valid
+      ? (validation.errorKey ?? "invalidAmount")
+      : null;
+  const amountError = error || validationErrorKey;
   const amountNum = validation.amount || 0;
   const newRaised = raised + amountNum;
   const newPct = goal > 0 ? Math.min(100, Math.round((newRaised / goal) * 100)) : 0;


### PR DESCRIPTION
Closes #549

## Problem

`DonationModal` builds its amount error from `validateAmount()` and renders it through `formatError()`, which resolves the value as a `DonationModal` message key. The fallback branch produced a raw English sentence instead:

```ts
? validation.errorKey || "Please enter a valid amount."
```

That string is not a message key, so it bypasses i18n entirely and cannot resolve in any locale. (The `validation.error` → `validation.errorKey` half of the issue landed earlier in `14ed418`; the untranslated fallback the issue also calls out was still there.)

## Fix

- The fallback uses the existing `invalidAmount` message key.
- The derived value is typed `DonationValidationKey | null`, so a hard-coded sentence can't be reintroduced without a type error.

## Why it went unnoticed

The suite's fake translator returned `map[key] ?? key`, echoing any unknown string straight back — an untranslated sentence looked identical to a resolved one. It now returns `MISSING(key)`, and new cases assert each validation message renders translated.

## Second commit: `style: apply prettier`

Unrelated to the fix. The Lint job runs `prettier --check` and is red on `main` because of files committed unformatted; without this the job fails here too. Formatting only.

## Testing

- `npx jest src/__tests__/components/DonationModal.test.tsx` — 14 passed.
- ESLint, `format:check`, `tsc --noEmit`, `npm run build`, `bundle-size`, and the CI coverage command all pass locally.
- Full suite matches `main`: same pre-existing failing suites before and after, no new ones.
