### PR TITLE
fix(security): require proof of platform admin on the audit-log route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ NEXT_PUBLIC_STELLAR_NETWORK=testnet
 # Deployed ProofOfHeart contract address (C…)
 NEXT_PUBLIC_CONTRACT_ADDRESS=
 
+# Platform admin address used by the admin-only API routes to authorise callers.
+# Optional: leave unset and the routes read get_admin() from the contract, which
+# keeps them in step with transfer_admin. Set it to authorise without RPC.
+PLATFORM_ADMIN_ADDRESS=
+
 # Stellar network passphrase
 # Testnet: "Test SDF Network ; September 2015"
 # Mainnet: "Public Global Stellar Network ; September 2015"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           src/__tests__/integration/CausesFilterUrlSync.test.tsx
           src/__tests__/components/CauseCard.test.tsx
           src/__tests__/hooks/useCampaignEvents.test.ts
+          src/__tests__/lib/serverAdminAuth.test.ts
+          src/__tests__/app/adminAuditLogRoute.test.ts
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4

--- a/src/__tests__/app/adminAuditLogRoute.test.ts
+++ b/src/__tests__/app/adminAuditLogRoute.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #567 — the audit trail must not leave the server without proof that the
+ * caller is the platform admin.
+ */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import {
+  ADMIN_ADDRESS_HEADER,
+  ADMIN_SIGNATURE_HEADER,
+  ADMIN_TIMESTAMP_HEADER,
+  buildAdminChallenge,
+} from "@/lib/adminAuth";
+
+const ADMIN = StellarSdk.Keypair.random();
+const IMPOSTOR = StellarSdk.Keypair.random();
+const PATH = "/api/admin-audit-log";
+
+const STORED_ENTRIES = [
+  {
+    adminAddress: ADMIN.publicKey(),
+    action: "verify_campaign",
+    txHash: "abc123",
+    timestamp: 1_700_000_000_000,
+    campaignId: 1,
+  },
+];
+
+// Keep the audit store in memory — the route otherwise writes into ./data.
+let fileContents = JSON.stringify(STORED_ENTRIES);
+
+jest.mock("fs", () => ({
+  promises: {
+    mkdir: jest.fn().mockResolvedValue(undefined),
+    access: jest.fn().mockResolvedValue(undefined),
+    readFile: jest.fn().mockImplementation(async () => fileContents),
+    writeFile: jest.fn().mockImplementation(async (_path: string, data: string) => {
+      fileContents = data;
+    }),
+  },
+}));
+
+jest.mock("@/lib/server/platformAdmin", () => ({
+  getPlatformAdminAddress: jest.fn().mockImplementation(async () => ADMIN.publicKey()),
+}));
+
+import { GET, POST } from "@/app/api/admin-audit-log/route";
+
+function authHeaders(keypair: StellarSdk.Keypair, method: string): Record<string, string> {
+  const timestamp = Date.now();
+  const address = keypair.publicKey();
+  const challenge = buildAdminChallenge({ address, method, path: PATH, timestamp });
+
+  return {
+    [ADMIN_ADDRESS_HEADER]: address,
+    [ADMIN_TIMESTAMP_HEADER]: String(timestamp),
+    [ADMIN_SIGNATURE_HEADER]: keypair.sign(Buffer.from(challenge, "utf8")).toString("base64"),
+  };
+}
+
+function request(method: string, headers: Record<string, string>, body?: unknown): Request {
+  return new Request(`https://poh.test${PATH}`, {
+    method,
+    headers: body ? { ...headers, "Content-Type": "application/json" } : headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("/api/admin-audit-log", () => {
+  beforeEach(() => {
+    fileContents = JSON.stringify(STORED_ENTRIES);
+  });
+
+  it("GET refuses an unauthenticated caller and leaks no entries", async () => {
+    const response = await GET(request("GET", {}));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.not.toHaveProperty("entries");
+  });
+
+  it("GET refuses a caller who is not the platform admin", async () => {
+    const response = await GET(request("GET", authHeaders(IMPOSTOR, "GET")));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("GET returns the trail to the platform admin", async () => {
+    const response = await GET(request("GET", authHeaders(ADMIN, "GET")));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ entries: STORED_ENTRIES });
+  });
+
+  it("POST refuses an unauthenticated writer and stores nothing", async () => {
+    const response = await POST(
+      request(
+        "POST",
+        {},
+        { adminAddress: ADMIN.publicKey(), action: "verify_campaign", txHash: "x" },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    expect(JSON.parse(fileContents)).toHaveLength(1);
+  });
+
+  it("POST refuses to record an entry attributed to someone else", async () => {
+    const response = await POST(
+      request("POST", authHeaders(ADMIN, "POST"), {
+        adminAddress: IMPOSTOR.publicKey(),
+        action: "transfer_admin",
+        txHash: "spoofed",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(JSON.parse(fileContents)).toHaveLength(1);
+  });
+
+  it("POST records an entry for the authenticated admin", async () => {
+    const response = await POST(
+      request("POST", authHeaders(ADMIN, "POST"), {
+        adminAddress: ADMIN.publicKey(),
+        action: "update_platform_fee",
+        txHash: "def456",
+        details: "300 bps",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const stored = JSON.parse(fileContents);
+    expect(stored).toHaveLength(2);
+    expect(stored[1]).toMatchObject({
+      adminAddress: ADMIN.publicKey().toUpperCase(),
+      action: "update_platform_fee",
+      txHash: "def456",
+    });
+  });
+});

--- a/src/__tests__/lib/serverAdminAuth.test.ts
+++ b/src/__tests__/lib/serverAdminAuth.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #567 — /api/admin-audit-log used to hand the admin trail to anyone who asked.
+ * The gate below is what stands in the way now, so these cases pin down every
+ * way a request can fail to get through it.
+ */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import {
+  ADMIN_ADDRESS_HEADER,
+  ADMIN_SIGNATURE_HEADER,
+  ADMIN_TIMESTAMP_HEADER,
+  buildAdminChallenge,
+} from "@/lib/adminAuth";
+
+const mockGetPlatformAdminAddress = jest.fn();
+
+jest.mock("@/lib/server/platformAdmin", () => ({
+  getPlatformAdminAddress: () => mockGetPlatformAdminAddress(),
+}));
+
+import { requirePlatformAdmin } from "@/lib/server/adminAuth";
+
+const ADMIN = StellarSdk.Keypair.random();
+const IMPOSTOR = StellarSdk.Keypair.random();
+const URL_UNDER_TEST = "https://poh.test/api/admin-audit-log";
+
+function sign(keypair: StellarSdk.Keypair, challenge: string): string {
+  return keypair.sign(Buffer.from(challenge, "utf8")).toString("base64");
+}
+
+function makeRequest(
+  headers: Record<string, string>,
+  { method = "GET", url = URL_UNDER_TEST }: { method?: string; url?: string } = {},
+): Request {
+  return new Request(url, { method, headers });
+}
+
+function signedHeaders(
+  keypair: StellarSdk.Keypair,
+  {
+    method = "GET",
+    path = "/api/admin-audit-log",
+    timestamp = Date.now(),
+    address = keypair.publicKey(),
+  } = {},
+): Record<string, string> {
+  return {
+    [ADMIN_ADDRESS_HEADER]: address,
+    [ADMIN_TIMESTAMP_HEADER]: String(timestamp),
+    [ADMIN_SIGNATURE_HEADER]: sign(
+      keypair,
+      buildAdminChallenge({ address, method, path, timestamp }),
+    ),
+  };
+}
+
+describe("requirePlatformAdmin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPlatformAdminAddress.mockResolvedValue(ADMIN.publicKey());
+  });
+
+  it("admits the platform admin with a valid signature", async () => {
+    const result = await requirePlatformAdmin(makeRequest(signedHeaders(ADMIN)));
+
+    expect(result).toEqual({ ok: true, address: ADMIN.publicKey() });
+  });
+
+  it("rejects an unauthenticated request with 401", async () => {
+    const result = await requirePlatformAdmin(makeRequest({}));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("rejects a claimed admin address with no signature", async () => {
+    // The admin address is public — readable from the contract — so asserting
+    // it must not be enough on its own.
+    const result = await requirePlatformAdmin(
+      makeRequest({
+        [ADMIN_ADDRESS_HEADER]: ADMIN.publicKey(),
+        [ADMIN_TIMESTAMP_HEADER]: String(Date.now()),
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("rejects a signature made by a different key", async () => {
+    const timestamp = Date.now();
+    const challenge = buildAdminChallenge({
+      address: ADMIN.publicKey(),
+      method: "GET",
+      path: "/api/admin-audit-log",
+      timestamp,
+    });
+
+    const result = await requirePlatformAdmin(
+      makeRequest({
+        [ADMIN_ADDRESS_HEADER]: ADMIN.publicKey(),
+        [ADMIN_TIMESTAMP_HEADER]: String(timestamp),
+        [ADMIN_SIGNATURE_HEADER]: sign(IMPOSTOR, challenge),
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("rejects a stale challenge", async () => {
+    const result = await requirePlatformAdmin(
+      makeRequest(signedHeaders(ADMIN, { timestamp: Date.now() - 10 * 60_000 })),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("rejects a challenge signed for a different method", async () => {
+    const headers = signedHeaders(ADMIN, { method: "GET" });
+
+    const result = await requirePlatformAdmin(makeRequest(headers, { method: "POST" }));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("rejects a challenge signed for a different path", async () => {
+    const headers = signedHeaders(ADMIN, { path: "/api/something-else" });
+
+    const result = await requirePlatformAdmin(makeRequest(headers));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("rejects a correctly signed request from a non-admin with 403", async () => {
+    const result = await requirePlatformAdmin(makeRequest(signedHeaders(IMPOSTOR)));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(403);
+  });
+
+  it("denies rather than admits when the admin address cannot be resolved", async () => {
+    mockGetPlatformAdminAddress.mockRejectedValue(new Error("RPC unreachable"));
+
+    const result = await requirePlatformAdmin(makeRequest(signedHeaders(ADMIN)));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(503);
+  });
+
+  it("accepts a signature over the hashed challenge, as Freighter produces", async () => {
+    const timestamp = Date.now();
+    const challenge = buildAdminChallenge({
+      address: ADMIN.publicKey(),
+      method: "GET",
+      path: "/api/admin-audit-log",
+      timestamp,
+    });
+    const hashed = StellarSdk.hash(Buffer.from(challenge, "utf8"));
+
+    const result = await requirePlatformAdmin(
+      makeRequest({
+        [ADMIN_ADDRESS_HEADER]: ADMIN.publicKey(),
+        [ADMIN_TIMESTAMP_HEADER]: String(timestamp),
+        [ADMIN_SIGNATURE_HEADER]: ADMIN.sign(hashed).toString("base64"),
+      }),
+    );
+
+    expect(result).toEqual({ ok: true, address: ADMIN.publicKey() });
+  });
+
+  it("matches the admin address regardless of header casing", async () => {
+    mockGetPlatformAdminAddress.mockResolvedValue(ADMIN.publicKey().toLowerCase());
+
+    const result = await requirePlatformAdmin(makeRequest(signedHeaders(ADMIN)));
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/__tests__/lib/walletSigner.test.ts
+++ b/src/__tests__/lib/walletSigner.test.ts
@@ -3,7 +3,7 @@
  * wallet serve the same call sites in `contractClient` / `offchainApiClient`.
  */
 
-import { getAddress, signTransaction } from "@stellar/freighter-api";
+import { getAddress, signMessage, signTransaction } from "@stellar/freighter-api";
 import {
   freighterSigner,
   getActiveWalletKind,
@@ -11,6 +11,7 @@ import {
   getSignerAddress,
   setActiveWalletSigner,
   signTransactionXdr,
+  signWalletMessage,
   type WalletSigner,
 } from "@/lib/walletSigner";
 
@@ -21,10 +22,12 @@ jest.mock("@stellar/freighter-api", () => ({
   getAddress: jest.fn(),
   getNetwork: jest.fn().mockResolvedValue({ network: "", networkPassphrase: "" }),
   signTransaction: jest.fn(),
+  signMessage: jest.fn(),
 }));
 
 const mockGetAddress = getAddress as jest.Mock;
 const mockSignTransaction = signTransaction as jest.Mock;
+const mockSignMessage = signMessage as jest.Mock;
 
 const OPTIONS = { networkPassphrase: "Test SDF Network ; September 2015" };
 
@@ -33,6 +36,7 @@ function fakeSigner(): WalletSigner {
     kind: "social",
     getAddress: jest.fn().mockResolvedValue("GSOCIAL"),
     signTransaction: jest.fn().mockResolvedValue("social-signed-xdr"),
+    signMessage: jest.fn().mockResolvedValue("social-signature"),
   };
 }
 
@@ -77,6 +81,42 @@ describe("walletSigner", () => {
 
     expect(getActiveWalletKind()).toBe("freighter");
     await expect(signTransactionXdr("raw-xdr", OPTIONS)).resolves.toBe("freighter-signed-xdr");
+  });
+
+  it("normalises Freighter's v4 base64 message signature", async () => {
+    mockSignMessage.mockResolvedValue({
+      signedMessage: "c2lnbmF0dXJl",
+      signerAddress: "GFREIGHTER",
+    });
+
+    await expect(signWalletMessage("challenge")).resolves.toBe("c2lnbmF0dXJl");
+    expect(mockSignMessage).toHaveBeenCalledWith("challenge");
+  });
+
+  it("normalises Freighter's v3 Buffer message signature to base64", async () => {
+    mockSignMessage.mockResolvedValue({
+      signedMessage: Buffer.from("signature", "utf8"),
+      signerAddress: "GFREIGHTER",
+    });
+
+    await expect(signWalletMessage("challenge")).resolves.toBe(
+      Buffer.from("signature", "utf8").toString("base64"),
+    );
+  });
+
+  it("throws when Freighter declines to sign the message", async () => {
+    mockSignMessage.mockResolvedValue({ signedMessage: null, signerAddress: "GFREIGHTER" });
+
+    await expect(signWalletMessage("challenge")).rejects.toThrow(/no signature/i);
+  });
+
+  it("routes message signing to the installed signer", async () => {
+    const social = fakeSigner();
+    setActiveWalletSigner(social);
+
+    await expect(signWalletMessage("challenge")).resolves.toBe("social-signature");
+    expect(social.signMessage).toHaveBeenCalledWith("challenge");
+    expect(mockSignMessage).not.toHaveBeenCalled();
   });
 
   it("propagates signer rejections so callers can detect user cancellation", async () => {

--- a/src/app/api/admin-audit-log/route.ts
+++ b/src/app/api/admin-audit-log/route.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { NextResponse } from "next/server";
+import { requirePlatformAdmin } from "@/lib/server/adminAuth";
+import { isSameAddress } from "@/lib/stellar";
 
 export const runtime = "nodejs";
 
@@ -52,6 +54,9 @@ function normalizeAddress(address: string): string {
 }
 
 export async function GET(request: Request) {
+  const auth = await requirePlatformAdmin(request);
+  if (!auth.ok) return auth.response;
+
   const url = new URL(request.url);
   const adminAddress = url.searchParams.get("adminAddress");
   const entries = await readEntries();
@@ -69,13 +74,31 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const body = (await request.json()) as Partial<AdminAuditLogEntry>;
+  const auth = await requirePlatformAdmin(request);
+  if (!auth.ok) return auth.response;
+
+  let body: Partial<AdminAuditLogEntry>;
+  try {
+    body = (await request.json()) as Partial<AdminAuditLogEntry>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
   if (!body.adminAddress || !body.action || !body.txHash) {
     return NextResponse.json({ error: "Invalid audit entry." }, { status: 400 });
   }
 
+  // The entry is attributed to the authenticated caller, not to whatever the
+  // body claims, so the trail cannot be written on someone else's behalf.
+  if (!isSameAddress(body.adminAddress, auth.address)) {
+    return NextResponse.json(
+      { error: "Audit entry address does not match the authenticated admin." },
+      { status: 403 },
+    );
+  }
+
   const nextEntry: AdminAuditLogEntry = {
-    adminAddress: normalizeAddress(body.adminAddress),
+    adminAddress: normalizeAddress(auth.address),
     action: body.action,
     txHash: body.txHash,
     timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),

--- a/src/lib/adminAuth.ts
+++ b/src/lib/adminAuth.ts
@@ -9,6 +9,17 @@
  *
  * Both sides build the challenge with `buildAdminChallenge` so the bytes the
  * wallet signs are exactly the bytes the route verifies.
+ *
+ * Replay window — known and accepted. The challenge carries a client timestamp
+ * rather than a server-issued nonce, so anyone who can observe a request may
+ * repeat that exact method and path until the timestamp ages out (see
+ * `ADMIN_CHALLENGE_MAX_AGE_MS`). The client deliberately widens the exposure by
+ * reusing one signature for a run of actions, see `adminLog.ts`. For an
+ * admin-only audit log over HTTPS that trade buys a single wallet prompt per
+ * admin session, and the worst case is a replayed read or a duplicate log
+ * entry. Guarding anything more consequential with this helper — a mutating
+ * admin action, anything with an irreversible effect — needs a server-issued
+ * nonce first.
  */
 
 export const ADMIN_ADDRESS_HEADER = "x-stellar-address";

--- a/src/lib/adminAuth.ts
+++ b/src/lib/adminAuth.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared vocabulary for authenticating platform-admin requests to the
+ * off-chain API routes.
+ *
+ * The browser holds the only copy of the admin's private key, so the server
+ * cannot issue a session it controls. Instead the caller proves ownership of
+ * the address by signing a short-lived, request-bound challenge, and the route
+ * checks that the proven address is the platform admin recorded on-chain.
+ *
+ * Both sides build the challenge with `buildAdminChallenge` so the bytes the
+ * wallet signs are exactly the bytes the route verifies.
+ */
+
+export const ADMIN_ADDRESS_HEADER = "x-stellar-address";
+export const ADMIN_TIMESTAMP_HEADER = "x-stellar-timestamp";
+export const ADMIN_SIGNATURE_HEADER = "x-stellar-signature";
+
+/**
+ * How far a challenge timestamp may sit from the server clock. Wide enough to
+ * absorb clock skew and the time the user spends approving a wallet prompt,
+ * narrow enough that a captured header set stops working quickly.
+ */
+export const ADMIN_CHALLENGE_MAX_AGE_MS = 120_000;
+
+export interface AdminChallengeInput {
+  address: string;
+  /** HTTP method of the request being authorised. */
+  method: string;
+  /** Path of the request being authorised, e.g. "/api/admin-audit-log". */
+  path: string;
+  /** Unix epoch milliseconds. */
+  timestamp: number;
+}
+
+/**
+ * The exact string a wallet signs. Binding the method and path means a
+ * signature captured from a read cannot be replayed against a write.
+ */
+export function buildAdminChallenge({
+  address,
+  method,
+  path,
+  timestamp,
+}: AdminChallengeInput): string {
+  return [
+    "ProofOfHeart admin request",
+    `address: ${address.trim().toUpperCase()}`,
+    `method: ${method.toUpperCase()}`,
+    `path: ${path}`,
+    `timestamp: ${timestamp}`,
+  ].join("\n");
+}

--- a/src/lib/adminLog.ts
+++ b/src/lib/adminLog.ts
@@ -1,3 +1,9 @@
+import {
+  ADMIN_ADDRESS_HEADER,
+  ADMIN_SIGNATURE_HEADER,
+  ADMIN_TIMESTAMP_HEADER,
+  buildAdminChallenge,
+} from "./adminAuth";
 import { normalizeAddress } from "./stellar";
 import {
   readAllEntries,
@@ -5,6 +11,7 @@ import {
   appendTimestamp,
   filterAndSortByTimestamp,
 } from "./logUtil";
+import { signWalletMessage } from "./walletSigner";
 
 export type AdminAuditAction =
   | "verify_campaign"
@@ -25,15 +32,55 @@ const STORAGE_KEY = "proof_of_heart_admin_audit_log_v1";
 const MAX_ENTRIES = 500;
 const API_ENDPOINT = "/api/admin-audit-log";
 
-async function readApiEntries(adminAddress?: string): Promise<AdminAuditLogEntry[]> {
-  const url = new URL(API_ENDPOINT, window.location.origin);
-  if (adminAddress) {
-    url.searchParams.set("adminAddress", adminAddress);
+/**
+ * A signed challenge is reused for a short spell so a run of admin actions does
+ * not put a wallet prompt in front of the user for every request. Kept well
+ * inside the freshness window the route enforces.
+ */
+const CHALLENGE_REUSE_MS = 60_000;
+
+const headerCache = new Map<string, { headers: Record<string, string>; timestamp: number }>();
+
+/**
+ * Proves to the API route that the caller controls `adminAddress` by signing a
+ * challenge bound to this exact request. The route rejects anything unsigned,
+ * so these headers are mandatory rather than best-effort.
+ */
+async function adminAuthHeaders(
+  adminAddress: string,
+  method: string,
+): Promise<Record<string, string>> {
+  const cacheKey = `${normalizeAddress(adminAddress)}:${method}`;
+  const cached = headerCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < CHALLENGE_REUSE_MS) {
+    return cached.headers;
   }
+
+  const timestamp = Date.now();
+  const signature = await signWalletMessage(
+    buildAdminChallenge({ address: adminAddress, method, path: API_ENDPOINT, timestamp }),
+  );
+
+  const headers = {
+    [ADMIN_ADDRESS_HEADER]: adminAddress,
+    [ADMIN_TIMESTAMP_HEADER]: String(timestamp),
+    [ADMIN_SIGNATURE_HEADER]: signature,
+  };
+
+  headerCache.set(cacheKey, { headers, timestamp });
+  return headers;
+}
+
+async function readApiEntries(adminAddress: string): Promise<AdminAuditLogEntry[]> {
+  const url = new URL(API_ENDPOINT, window.location.origin);
+  url.searchParams.set("adminAddress", adminAddress);
 
   const response = await fetch(url.toString(), {
     method: "GET",
-    headers: { Accept: "application/json" },
+    headers: {
+      Accept: "application/json",
+      ...(await adminAuthHeaders(adminAddress, "GET")),
+    },
   });
 
   if (!response.ok) {
@@ -47,7 +94,10 @@ async function readApiEntries(adminAddress?: string): Promise<AdminAuditLogEntry
 async function persistApiEntry(entry: AdminAuditLogEntry): Promise<void> {
   const response = await fetch(API_ENDPOINT, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(await adminAuthHeaders(entry.adminAddress, "POST")),
+    },
     body: JSON.stringify(entry),
   });
 

--- a/src/lib/server/adminAuth.ts
+++ b/src/lib/server/adminAuth.ts
@@ -1,0 +1,106 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { NextResponse } from "next/server";
+import {
+  ADMIN_ADDRESS_HEADER,
+  ADMIN_CHALLENGE_MAX_AGE_MS,
+  ADMIN_SIGNATURE_HEADER,
+  ADMIN_TIMESTAMP_HEADER,
+  buildAdminChallenge,
+} from "../adminAuth";
+import { isSameAddress } from "../stellar";
+import { getPlatformAdminAddress } from "./platformAdmin";
+
+export type AdminAuthResult = { ok: true; address: string } | { ok: false; response: NextResponse };
+
+function deny(status: number, error: string): AdminAuthResult {
+  return { ok: false, response: NextResponse.json({ error }, { status }) };
+}
+
+/**
+ * Verifies an ed25519 signature over `challenge` against a Stellar account.
+ *
+ * Freighter hashes the message before signing while a raw keypair signs the
+ * bytes directly, so both forms are accepted. Either way the signature is only
+ * producible by the holder of the account's secret key.
+ */
+function verifyChallengeSignature(
+  address: string,
+  challenge: string,
+  signatureBase64: string,
+): boolean {
+  let keypair: StellarSdk.Keypair;
+  try {
+    keypair = StellarSdk.Keypair.fromPublicKey(address);
+  } catch {
+    return false;
+  }
+
+  let signature: Buffer;
+  try {
+    signature = Buffer.from(signatureBase64, "base64");
+  } catch {
+    return false;
+  }
+  if (signature.length === 0) return false;
+
+  const raw = Buffer.from(challenge, "utf8");
+  try {
+    return keypair.verify(raw, signature) || keypair.verify(StellarSdk.hash(raw), signature);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gate for routes that expose platform-admin data.
+ *
+ * The caller must present the address it claims plus a signature over a
+ * timestamped, request-bound challenge for that address. Only once the
+ * signature checks out is the address compared against the platform admin, so
+ * naming the admin address — which is public, it is readable from the
+ * contract — is not enough to get in.
+ *
+ * Every failure path denies. If the admin address cannot be resolved the
+ * request is refused rather than allowed through.
+ */
+export async function requirePlatformAdmin(request: Request): Promise<AdminAuthResult> {
+  const address = request.headers.get(ADMIN_ADDRESS_HEADER)?.trim() ?? "";
+  const timestampHeader = request.headers.get(ADMIN_TIMESTAMP_HEADER)?.trim() ?? "";
+  const signature = request.headers.get(ADMIN_SIGNATURE_HEADER)?.trim() ?? "";
+
+  if (!address || !timestampHeader || !signature) {
+    return deny(401, "Admin authentication required.");
+  }
+
+  const timestamp = Number(timestampHeader);
+  if (!Number.isFinite(timestamp)) {
+    return deny(401, "Invalid authentication timestamp.");
+  }
+  if (Math.abs(Date.now() - timestamp) > ADMIN_CHALLENGE_MAX_AGE_MS) {
+    return deny(401, "Authentication challenge expired.");
+  }
+
+  const challenge = buildAdminChallenge({
+    address,
+    method: request.method,
+    path: new URL(request.url).pathname,
+    timestamp,
+  });
+
+  if (!verifyChallengeSignature(address, challenge, signature)) {
+    return deny(401, "Invalid authentication signature.");
+  }
+
+  let adminAddress: string;
+  try {
+    adminAddress = await getPlatformAdminAddress();
+  } catch {
+    return deny(503, "Unable to verify platform admin.");
+  }
+
+  if (!isSameAddress(address, adminAddress)) {
+    return deny(403, "Caller is not the platform admin.");
+  }
+
+  return { ok: true, address };
+}

--- a/src/lib/server/platformAdmin.ts
+++ b/src/lib/server/platformAdmin.ts
@@ -31,13 +31,14 @@ function contractAddress(): string {
   return process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ?? process.env.NEXT_PUBLIC_CONTRACT_ID ?? "";
 }
 
+/**
+ * Server-only vars on purpose. A `NEXT_PUBLIC_` fallback would put the trust
+ * anchor in the client bundle, where anyone shipping a build could see which
+ * address the routes will accept — and, worse, invite the value being set in a
+ * place meant for public configuration.
+ */
 function configuredAdminAddress(): string {
-  return (
-    process.env.PLATFORM_ADMIN_ADDRESS ??
-    process.env.ADMIN_ADDRESS ??
-    process.env.NEXT_PUBLIC_ADMIN_ADDRESS ??
-    ""
-  ).trim();
+  return (process.env.PLATFORM_ADMIN_ADDRESS ?? process.env.ADMIN_ADDRESS ?? "").trim();
 }
 
 async function readAdminFromContract(): Promise<string> {

--- a/src/lib/server/platformAdmin.ts
+++ b/src/lib/server/platformAdmin.ts
@@ -1,0 +1,101 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+/**
+ * Server-side lookup of the platform admin address.
+ *
+ * Deliberately independent of `lib/contractClient`, which pulls in the wallet
+ * signer and other browser-only code that must never load in a route handler.
+ *
+ * `PLATFORM_ADMIN_ADDRESS` short-circuits the lookup for deployments that
+ * would rather not depend on RPC availability to authorise a request. When it
+ * is unset the address is read from the contract, which keeps the API in step
+ * with `transfer_admin` without a redeploy.
+ */
+
+const SOROBAN_RPC_URL =
+  process.env.SOROBAN_RPC_URL ??
+  process.env.TESTNET_RPC_URL ??
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ??
+  process.env.NEXT_PUBLIC_RPC_URL ??
+  "https://soroban-testnet.stellar.org";
+
+const NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
+
+/** Re-reading the contract on every request would make the admin page crawl. */
+const CACHE_TTL_MS = 60_000;
+
+let cached: { address: string; fetchedAt: number } | null = null;
+
+function contractAddress(): string {
+  return process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ?? process.env.NEXT_PUBLIC_CONTRACT_ID ?? "";
+}
+
+function configuredAdminAddress(): string {
+  return (
+    process.env.PLATFORM_ADMIN_ADDRESS ??
+    process.env.ADMIN_ADDRESS ??
+    process.env.NEXT_PUBLIC_ADMIN_ADDRESS ??
+    ""
+  ).trim();
+}
+
+async function readAdminFromContract(): Promise<string> {
+  const address = contractAddress();
+  if (!address) {
+    throw new Error("No contract address configured.");
+  }
+
+  const server = new StellarSdk.rpc.Server(SOROBAN_RPC_URL);
+  const contract = new StellarSdk.Contract(address);
+  const probe = new StellarSdk.Account(StellarSdk.Keypair.random().publicKey(), "0");
+
+  const tx = new StellarSdk.TransactionBuilder(probe, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call("get_admin"))
+    .setTimeout(30)
+    .build();
+
+  const simulated = await server.simulateTransaction(tx);
+  if (StellarSdk.rpc.Api.isSimulationError(simulated)) {
+    throw new Error(simulated.error ?? "get_admin simulation failed.");
+  }
+
+  const retval = (simulated as StellarSdk.rpc.Api.SimulateTransactionSuccessResponse).result
+    ?.retval;
+  if (!retval) {
+    throw new Error("get_admin returned no value.");
+  }
+
+  return StellarSdk.Address.fromScVal(retval).toString();
+}
+
+/**
+ * Resolves the platform admin address, throwing when it cannot be determined.
+ * Callers must treat a throw as "deny", never as "allow" — an unreachable RPC
+ * node must not turn into an open endpoint.
+ */
+export async function getPlatformAdminAddress(): Promise<string> {
+  const configured = configuredAdminAddress();
+  if (configured) return configured;
+
+  const now = Date.now();
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.address;
+  }
+
+  const address = await readAdminFromContract();
+  if (!address) {
+    throw new Error("Contract returned an empty admin address.");
+  }
+
+  cached = { address, fetchedAt: now };
+  return address;
+}
+
+/** Test helper — drops the memoised contract lookup. */
+export function resetPlatformAdminCache(): void {
+  cached = null;
+}

--- a/src/lib/socialWallet.ts
+++ b/src/lib/socialWallet.ts
@@ -218,4 +218,8 @@ export const socialSigner: WalletSigner = {
     tx.sign(keypair);
     return tx.toXDR();
   },
+  async signMessage(message) {
+    if (!keypair) throw new Error("Social wallet is not connected.");
+    return keypair.sign(Buffer.from(message, "utf8")).toString("base64");
+  },
 };

--- a/src/lib/walletSigner.ts
+++ b/src/lib/walletSigner.ts
@@ -1,4 +1,4 @@
-import { getAddress, signTransaction } from "@stellar/freighter-api";
+import { getAddress, signMessage, signTransaction } from "@stellar/freighter-api";
 
 /**
  * The single place that decides *how* a transaction gets signed.
@@ -22,6 +22,13 @@ export interface WalletSigner {
   getAddress(): Promise<string>;
   /** Sign a transaction envelope, returning the signed XDR. */
   signTransaction(xdr: string, options: { networkPassphrase: string }): Promise<string>;
+  /**
+   * Sign an arbitrary message, returning the base64 ed25519 signature.
+   *
+   * Used to prove address ownership to the off-chain API routes, which have no
+   * session of their own to check.
+   */
+  signMessage(message: string): Promise<string>;
 }
 
 /**
@@ -38,6 +45,16 @@ export const freighterSigner: WalletSigner = {
   async signTransaction(xdr, options) {
     const { signedTxXdr } = await signTransaction(xdr, options);
     return signedTxXdr;
+  },
+  async signMessage(message) {
+    const { signedMessage } = await signMessage(message);
+    if (!signedMessage) {
+      throw new Error("Freighter returned no signature for the message.");
+    }
+    // Freighter v3 hands back a Buffer, v4 a base64 string.
+    return typeof signedMessage === "string"
+      ? signedMessage
+      : Buffer.from(signedMessage).toString("base64");
   },
 };
 
@@ -70,4 +87,9 @@ export function signTransactionXdr(
   options: { networkPassphrase: string },
 ): Promise<string> {
   return activeSigner.signTransaction(xdr, options);
+}
+
+/** Sign a plain message with the active wallet, returning a base64 signature. */
+export function signWalletMessage(message: string): Promise<string> {
+  return activeSigner.signMessage(message);
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -6,20 +6,24 @@ globalThis.TextEncoder ??= TextEncoder;
 globalThis.TextDecoder ??= TextDecoder;
 
 // jsdom does not implement matchMedia — stub it so components that use
-// motion / framer-motion don't throw.
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: jest.fn().mockImplementation((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
+// motion / framer-motion don't throw. Guarded because this setup file also runs
+// for suites that declare the node environment, where there is no window and an
+// unguarded reference stops the suite loading at all.
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
 
 // jsdom does not implement Intl.DisplayNames — stub it so locale-aware
 // components can render their language labels in tests.
@@ -45,8 +49,11 @@ class ResizeObserverStub {
 globalThis.ResizeObserver ??= ResizeObserverStub;
 
 // jsdom doesn't implement scrollTo; the window virtualizer calls it when
-// asked to scroll to an offset.
-window.scrollTo ??= () => {};
+// asked to scroll to an offset. Guarded for the same reason as matchMedia
+// above: the node-environment suites have no window.
+if (typeof window !== "undefined") {
+  window.scrollTo ??= () => {};
+}
 
 // Global mock for Freighter API (v6.x returns objects, not primitives)
 jest.mock("@stellar/freighter-api", () => ({


### PR DESCRIPTION
Closes #567

## Problem

`/api/admin-audit-log` had no authentication at all. `GET` served the full admin audit trail — admin address, action, tx hash, timestamps — to anyone who asked, and `POST` accepted entries attributed to any address.

## Fix

Both handlers go through `requirePlatformAdmin()` before doing any work.

**One note on the approach.** The issue suggests comparing the caller's address to the contract admin. On its own that isn't a control: the admin address is public — `Navbar` already reads it from the contract on every page load — so anyone can send `x-stellar-address: <admin>` and get in. The address comparison is kept, but it runs *after* the caller proves it holds the key:

1. Caller signs a challenge bound to the request method, path, and a timestamp.
2. Route rebuilds the same challenge and verifies the ed25519 signature against the claimed address.
3. Only then is the proven address compared to the platform admin.

Method and path are in the signed bytes, so a signature captured from a read can't be replayed against a write, and the timestamp window is 2 minutes.

**Admin resolution** is server-side, from `PLATFORM_ADMIN_ADDRESS` or — when unset — the contract's `get_admin()`, so `transfer_admin` takes effect without a redeploy. Cached for a minute. A failed lookup denies the request; an unreachable RPC node must not turn into an open endpoint.

**POST** attributes each entry to the authenticated caller rather than to whatever the body claims, so the trail can't be written on someone else's behalf. A malformed body now returns 400 instead of throwing.

## Client side

`WalletSigner` gains `signMessage()`, implemented for Freighter (normalising its v3 `Buffer` and v4 base64 response shapes) and for the embedded social wallet. `adminLog.ts` attaches the signed headers, caching a challenge for 60s so a run of admin actions doesn't prompt the wallet each time.

Net UX cost: one signature prompt when an admin opens the admin page. If the user declines, `getAdminAuditLog` already falls back to the localStorage copy, so the page degrades rather than breaking.

## Files

- `src/lib/adminAuth.ts` — challenge format shared by both sides
- `src/lib/server/platformAdmin.ts` — server-side admin lookup
- `src/lib/server/adminAuth.ts` — the gate
- `src/app/api/admin-audit-log/route.ts`, `src/lib/adminLog.ts`, `src/lib/walletSigner.ts`, `src/lib/socialWallet.ts`, `.env.example`

## Testing

17 new cases, signing with real `StellarSdk.Keypair`s:

- `serverAdminAuth.test.ts` (11) — valid admin admitted; no headers → 401; address claimed without a signature → 401; signature from another key → 401; stale challenge → 401; challenge signed for a different method or path → 401; valid signature from a non-admin → 403; unresolvable admin → 503; Freighter's hashed-message form accepted; address casing.
- `adminAuditLogRoute.test.ts` (6) — `GET` unauthenticated returns 401 and no entries; non-admin 403; admin gets the trail; `POST` unauthenticated stores nothing; `POST` attributed to another address 403; `POST` by the admin records the entry.

ESLint, `format:check`, `tsc --noEmit`, `npm run build`, `bundle-size`, and the CI coverage command all pass locally. Full suite matches `main` — same pre-existing failures, no new ones.

## Other commits

**`ci: run the admin auth suites in the coverage job`** — the coverage job runs a fixed list of test files, so these tests would never execute in CI. Worse, the new source files they cover dropped global branch coverage from 50.07% to 49.84%, under the job's 50% floor, failing it. Adding both suites runs them where they matter and puts branch coverage at 52.26%.

**`style: apply prettier`** — unrelated. The Lint job runs `prettier --check` and is red on `main` because of files committed unformatted; without this the job fails here too. Formatting only.

## Follow-ups (not in scope here)

- The same gate should go on `/api/reports` (`GET` is documented as the admin moderation queue and is also open).
- Replay inside the 2-minute window is possible for anyone who can already read the traffic; a server-issued nonce would close it.
- The regression tests added in #846 and #847 are also outside the coverage job's file list. I left that alone to avoid three PRs conflicting on the same block, but it's worth widening.
