### PR TITLE
feat: add claimable revenue section and claim UI to contributor dashboard (closes #589)

### DIFF
--- a/src/__tests__/components/ClaimableRevenueSection.test.tsx
+++ b/src/__tests__/components/ClaimableRevenueSection.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ClaimableRevenueSection from "@/components/ClaimableRevenueSection";
+import { useContributions, type ContributionHistoryItem } from "@/hooks/useContributions";
+import { claimRevenue } from "@/lib/contractClient";
+import { Category, type Campaign } from "@/types";
+
+jest.mock("@/hooks/useContributions", () => ({
+  useContributions: jest.fn(),
+}));
+
+jest.mock("@/lib/contractClient", () => ({
+  claimRevenue: jest.fn(),
+}));
+
+const mockShowError = jest.fn();
+const mockShowSuccess = jest.fn();
+jest.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    showError: mockShowError,
+    showSuccess: mockShowSuccess,
+    showWarning: jest.fn(),
+    showInfo: jest.fn(),
+  }),
+}));
+
+jest.mock("next-intl", () => ({
+  useLocale: () => "en",
+}));
+
+const mockUseContributions = useContributions as jest.MockedFunction<typeof useContributions>;
+const mockClaimRevenue = claimRevenue as jest.MockedFunction<typeof claimRevenue>;
+const mockRefetch = jest.fn();
+
+const WALLET = "GCONTRIBUTOR11111111111111111111111111111111111111111111";
+
+function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: 1,
+    creator: "GCREATOR",
+    title: "Startup campaign",
+    description: "Campaign description",
+    created_at: 1_700_000_000,
+    status: "funded",
+    funding_goal: BigInt(100_000_000),
+    deadline: Math.floor(Date.now() / 1000) - 3600,
+    amount_raised: BigInt(100_000_000),
+    is_active: false,
+    funds_withdrawn: true,
+    is_cancelled: false,
+    is_verified: true,
+    category: Category.EducationalStartup,
+    has_revenue_sharing: true,
+    revenue_share_percentage: 1000,
+    ...overrides,
+  };
+}
+
+function makeContribution(overrides: Partial<ContributionHistoryItem> = {}): ContributionHistoryItem {
+  const campaign = overrides.campaign ?? makeCampaign();
+  return {
+    campaign,
+    contribution: BigInt(50_000_000),
+    status: campaign.status,
+    canClaimRefund: false,
+    canClaimRevenue: true,
+    claimableRevenue: BigInt(25_000_000),
+    transactions: [],
+    ...overrides,
+  };
+}
+
+function renderSection(
+  contributions: ContributionHistoryItem[],
+  state: Partial<ReturnType<typeof useContributions>> = {},
+) {
+  mockUseContributions.mockReturnValue({
+    contributions,
+    isLoading: false,
+    isRefreshing: false,
+    error: null,
+    refetch: mockRefetch,
+    ...state,
+  });
+  return render(<ClaimableRevenueSection walletAddress={WALLET} />);
+}
+
+describe("ClaimableRevenueSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders a row per EducationalStartup campaign with claimable revenue", () => {
+    renderSection([
+      makeContribution({
+        campaign: makeCampaign({ id: 1, title: "Alpha Startup" }),
+        claimableRevenue: BigInt(25_000_000),
+      }),
+      makeContribution({
+        campaign: makeCampaign({ id: 2, title: "Beta Startup" }),
+        claimableRevenue: BigInt(10_000_000),
+      }),
+    ]);
+
+    expect(screen.getByText("Alpha Startup")).toBeInTheDocument();
+    expect(screen.getByText("Beta Startup")).toBeInTheDocument();
+    // 25_000_000 stroops = 2.5 XLM, 10_000_000 = 1 XLM, total 3.5 XLM
+    expect(screen.getByText(/2\.5 XLM claimable/)).toBeInTheDocument();
+    expect(screen.getByText(/1 XLM claimable/)).toBeInTheDocument();
+    expect(screen.getByText(/3\.5 XLM claimable/)).toBeInTheDocument(); // header total
+    expect(screen.getAllByRole("button", { name: /Claim revenue for/ })).toHaveLength(2);
+  });
+
+  it("excludes non-EducationalStartup campaigns and zero-claimable rows", () => {
+    renderSection([
+      makeContribution({
+        campaign: makeCampaign({ id: 1, title: "Startup With Revenue" }),
+      }),
+      makeContribution({
+        campaign: makeCampaign({ id: 2, title: "Learner Campaign", category: Category.Learner }),
+        canClaimRevenue: true,
+        claimableRevenue: BigInt(9_000_000),
+      }),
+      makeContribution({
+        campaign: makeCampaign({ id: 3, title: "Zero Claimable" }),
+        canClaimRevenue: false,
+        claimableRevenue: BigInt(0),
+      }),
+    ]);
+
+    expect(screen.getByText("Startup With Revenue")).toBeInTheDocument();
+    expect(screen.queryByText("Learner Campaign")).not.toBeInTheDocument();
+    expect(screen.queryByText("Zero Claimable")).not.toBeInTheDocument();
+  });
+
+  it("claims revenue and refetches on success", async () => {
+    mockClaimRevenue.mockResolvedValue("tx-hash-123");
+    renderSection([
+      makeContribution({ campaign: makeCampaign({ id: 5, title: "Gamma Startup" }) }),
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Claim revenue for Gamma Startup" }));
+
+    await waitFor(() => {
+      expect(mockClaimRevenue).toHaveBeenCalledWith(5, WALLET, expect.any(Object));
+    });
+    await waitFor(() => {
+      expect(mockShowSuccess).toHaveBeenCalledWith("Revenue claimed successfully.");
+      expect(mockRefetch).toHaveBeenCalled();
+    });
+    expect(mockShowError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the error on a failed claim", async () => {
+    mockClaimRevenue.mockRejectedValue(new Error("Insufficient revenue pool"));
+    renderSection([
+      makeContribution({ campaign: makeCampaign({ id: 6, title: "Delta Startup" }) }),
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Claim revenue for Delta Startup" }));
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith("Insufficient revenue pool");
+    });
+    expect(mockShowSuccess).not.toHaveBeenCalled();
+    expect(mockRefetch).not.toHaveBeenCalled();
+  });
+
+  it("shows an empty state when there is no claimable revenue", () => {
+    renderSection([]);
+    expect(screen.getByText(/no claimable revenue right now/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Claim revenue for/ })).not.toBeInTheDocument();
+  });
+
+  it("shows a loading state", () => {
+    renderSection([], { isLoading: true });
+    expect(screen.getByText("Loading claimable revenue...")).toBeInTheDocument();
+  });
+
+  it("shows an error state from the hook", () => {
+    renderSection([], { error: "Failed to load" });
+    expect(screen.getByText("Failed to load")).toBeInTheDocument();
+  });
+
+  it("disables sibling claim buttons while one claim is in flight", async () => {
+    let resolveClaim: (v: string) => void = () => {};
+    mockClaimRevenue.mockImplementation(
+      () => new Promise<string>((resolve) => (resolveClaim = resolve)),
+    );
+    renderSection([
+      makeContribution({ campaign: makeCampaign({ id: 1, title: "First Startup" }) }),
+      makeContribution({ campaign: makeCampaign({ id: 2, title: "Second Startup" }) }),
+    ]);
+
+    const firstBtn = screen.getByRole("button", { name: "Claim revenue for First Startup" });
+    const secondBtn = screen.getByRole("button", { name: "Claim revenue for Second Startup" });
+
+    fireEvent.click(firstBtn);
+
+    await waitFor(() => expect(secondBtn).toBeDisabled());
+    expect(firstBtn).toBeDisabled();
+
+    resolveClaim("tx");
+    await waitFor(() => expect(mockRefetch).toHaveBeenCalled());
+  });
+});

--- a/src/app/[locale]/dashboard/DashboardClient.tsx
+++ b/src/app/[locale]/dashboard/DashboardClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import React, { useMemo, useState } from "react";
+import ClaimableRevenueSection from "@/components/ClaimableRevenueSection";
 import MyContributionsSection from "@/components/MyContributionsSection";
 import TransactionHistorySection from "@/components/TransactionHistorySection";
 import { Spinner, DashboardSkeleton } from "@/components/Skeleton";
@@ -94,6 +95,8 @@ export default function DashboardPage() {
 
       {/* Overview tab */}
       <TabPanel tabId="overview" idPrefix="dashboard" active={activeTab === "overview"}>
+        <ClaimableRevenueSection walletAddress={publicKey} />
+
         <section className="mb-8">
           <h2 className="text-xl font-semibold mb-2">{t("walletBalance")}</h2>
           {balanceLoading ? (

--- a/src/components/ClaimableRevenueSection.tsx
+++ b/src/components/ClaimableRevenueSection.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useLocale } from "next-intl";
+import { claimRevenue, type TransactionLifecyclePhase } from "../lib/contractClient";
+import { useContributions } from "../hooks/useContributions";
+import { formatAmount } from "@/lib/formatters";
+import { Category } from "../types";
+import { Button, Card } from "./ui";
+import { useToast } from "./ToastProvider";
+import { parseContractError } from "../utils/contractErrors";
+
+interface ClaimableRevenueSectionProps {
+  walletAddress: string;
+}
+
+/**
+ * Dashboard section listing every EducationalStartup campaign where the
+ * connected contributor has unclaimed revenue-sharing revenue, with a
+ * one-click Claim button per campaign.
+ *
+ * Reuses the canonical claimable computation from `useContributions`
+ * (get_contribution × get_revenue_pool ÷ amount_raised − get_revenue_claimed)
+ * and the existing `claimRevenue` binding — no new data source is invented.
+ */
+export default function ClaimableRevenueSection({ walletAddress }: ClaimableRevenueSectionProps) {
+  const locale = useLocale();
+  const { showError, showSuccess } = useToast();
+  const { contributions, isLoading, isRefreshing, error, refetch } =
+    useContributions(walletAddress);
+
+  // Campaign id currently being claimed, and the tx lifecycle phase for its label.
+  const [pendingCampaignId, setPendingCampaignId] = useState<number | null>(null);
+  const [txPhase, setTxPhase] = useState<TransactionLifecyclePhase | null>(null);
+
+  const claimable = useMemo(
+    () =>
+      contributions.filter(
+        (item) =>
+          item.campaign.category === Category.EducationalStartup &&
+          item.canClaimRevenue &&
+          item.claimableRevenue > BigInt(0),
+      ),
+    [contributions],
+  );
+
+  const totalClaimable = useMemo(
+    () => claimable.reduce((sum, item) => sum + item.claimableRevenue, BigInt(0)),
+    [claimable],
+  );
+
+  const handleClaim = async (campaignId: number) => {
+    setPendingCampaignId(campaignId);
+    setTxPhase(null);
+    try {
+      await claimRevenue(campaignId, walletAddress, {
+        onStatus: ({ phase }) => setTxPhase(phase),
+      });
+      showSuccess("Revenue claimed successfully.");
+      // Refetch so the claimed row recomputes to 0 and drops out of the list.
+      refetch();
+    } catch (err) {
+      showError(parseContractError(err));
+    } finally {
+      setPendingCampaignId(null);
+      setTxPhase(null);
+    }
+  };
+
+  const claimLabel = (isPending: boolean): string => {
+    if (!isPending) return "Claim";
+    if (txPhase === "signing") return "Signing...";
+    if (txPhase === "confirming") return "Confirming...";
+    return "Processing...";
+  };
+
+  return (
+    <section className="mb-8" aria-labelledby="claimable-revenue-heading">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h2 id="claimable-revenue-heading" className="text-xl font-semibold">
+          Claimable Revenue
+        </h2>
+        {claimable.length > 0 && (
+          <div className="text-sm text-zinc-500 dark:text-zinc-400">
+            {claimable.length} campaign{claimable.length === 1 ? "" : "s"} ·{" "}
+            {formatAmount(totalClaimable, locale, { maximumFractionDigits: 4 })} XLM claimable
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <p className="text-zinc-500 dark:text-zinc-400">Loading claimable revenue...</p>
+      ) : error ? (
+        <div className="rounded-xl border border-red-300 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {error}
+        </div>
+      ) : claimable.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-5 text-sm text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+          You have no claimable revenue right now. Revenue from Educational Startup campaigns you
+          contributed to will appear here once it is available to claim.
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {claimable.map((item) => {
+            const isPending = pendingCampaignId === item.campaign.id;
+            return (
+              <li key={item.campaign.id}>
+                <Card padding="sm" className="bg-zinc-50 dark:bg-zinc-900">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                      <Link
+                        href={`/causes/${item.campaign.id}`}
+                        className="font-semibold text-zinc-900 hover:text-blue-600 dark:text-zinc-50 dark:hover:text-blue-400"
+                      >
+                        {item.campaign.title}
+                      </Link>
+                      <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-300">
+                        {formatAmount(item.claimableRevenue, locale, {
+                          maximumFractionDigits: 4,
+                        })}{" "}
+                        XLM claimable
+                      </p>
+                    </div>
+                    <Button
+                      variant="success"
+                      size="sm"
+                      onClick={() => handleClaim(item.campaign.id)}
+                      disabled={pendingCampaignId !== null}
+                      isLoading={isPending}
+                      loadingLabel={claimLabel(true)}
+                      aria-label={`Claim revenue for ${item.campaign.title}`}
+                    >
+                      {claimLabel(false)}
+                    </Button>
+                  </div>
+                </Card>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {isRefreshing && !isLoading && (
+        <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+          Refreshing claimable revenue...
+        </p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
closes #589 

## Description

Adds a "Claimable Revenue" section to the contributor dashboard, showing all EducationalStartup campaigns with unclaimed revenue and a one-click Claim button per campaign. Closes #589.

## Changes

- `src/components/ClaimableRevenueSection.tsx` (new, ~155 lines) — dashboard section that reads from the existing `useContributions` hook, filters to `category === EducationalStartup && canClaimRevenue && claimable > 0`, and renders a card/row per campaign with the campaign title, formatted claimable amount (XLM), a per-row Claim button, and a header total.
- `src/app/[locale]/dashboard/DashboardClient.tsx` (modified, +3 lines) — one import + render call to mount the new section at the top of the dashboard.
- `src/__tests__/components/ClaimableRevenueSection.test.tsx` (new, 8 tests) — covers rendering, header total, filtering (excludes non-EducationalStartup and zero-claimable rows), success path, empty state, loading state, and sibling-button disabling during an in-flight claim.

## Recon Notes

- **Claim binding:** the issue references `claim_creator_revenue`, but the actual wired binding in this frontend is `claimRevenue(campaignId, contributor, options?)` (`src/lib/contractClient.ts:937`), which invokes the on-chain method `claim_revenue`. It builds and signs a Soroban transaction through the active wallet signer (Freighter/social login), returns a `txHash`, throws parsed contract errors, and accepts an `onStatus` lifecycle callback. No binding changes were needed — naming discrepancy noted for visibility only, not a blocker.
- **Claimable read:** no single view returns "claimable" directly. The app already computes it canonically in `useContributions`, combining three real contract views — `get_contribution`, `get_revenue_pool`, `get_revenue_claimed` — via `claimable = (contribution × pool) ÷ ...`. Reused this existing hook rather than fabricating a new data source.
- **Decimal/unit handling:** stroops (1 XLM = 10⁷ stroops), displayed via the existing audited `formatAmount(stroops, locale, { maximumFractionDigits: 4 })` utility — no new formatter written.
- **Conventions followed:** shared loading/error/empty-state patterns, `Card` component, Tailwind, `useToast` (`showSuccess`/`showError`), React Query for data fetching, `useWallet()` for signer state.

## Claim Flow States

- **Pending:** clicking Claim shows a spinner with phase-aware labels (`Signing…` → `Confirming…`); all claim buttons disable during any in-flight claim (`disabled={pendingCampaignId !== null}`).
- **Success:** `showSuccess()` toast fires, then `refetch()` — the claimed row's amount recomputes to 0 and drops out of the list without a page reload.
- **Failure:** the actual parsed contract error is surfaced via `showError()` — no silent failures.
- **Empty:** dashed-border empty state, consistent with the existing `ContributionsSection` pattern. Hook loading and error states are also handled.

## Blockers

- **None for this feature** — the claimable-revenue read and the claim binding both already existed and were simply wired up.
- **Pre-existing, unrelated issue flagged (not touched):** `src/components/WalletContext.tsx` has a type gap (`WalletContextType` missing `walletKind`/`socialProfile`/`isSocialLoginAvailable`/`connectWithSocial`) that fails `tsc`/the Next build step. This was present in the baseline before this change and is out of scope — fixing it here would be scope creep. My new component compiles cleanly on its own.

## Test Results

New suite: **8/8 passing.**

Full suite: 10 failed / 51 passed (suites), consistent with baseline's 10 pre-existing failing suites — **no regressions introduced.** +8 new passing tests from this change.

- **Lint:** 0 errors on new files (48 pre-existing, unrelated).
- **Typecheck:** clean except the pre-existing `WalletContext.tsx:373` error noted above.
- **Build:** compiles successfully; fails only at the pre-existing `WalletContext.tsx:373` typecheck step, same as baseline.

## Checklist

- [x] Dashboard shows a "Claimable Revenue" section (`ClaimableRevenueSection.tsx:98`)
- [x] Lists all campaigns with unclaimed revenue, filtered correctly (`ClaimableRevenueSection.tsx`)
- [x] Correctly-formatted claimable amount (stroops → XLM)
- [x] One-click Claim button calls `claimRevenue(campaignId, walletAddress, { onStatus })` with correct args
- [x] Pending/loading, success, and error states all handled and visible (`:56-70` handler, `:75-79` labels, `:92-93` loading)
- [x] Empty state handled (`:99-101`)
- [x] No contract binding/logic changes — `git status` shows only the new component, its test, and the 3-line dashboard integration