### PR TITLE
fix(campaigns): gate donate button on is_verified and show pending verification banner

### DIFF
--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -571,7 +571,7 @@ export default function CauseDetailClient({ id }: { id: string }) {
               isVerifying={isVerifying}
             />
 
-            {campaign.is_active && !campaign.is_cancelled && (
+            {campaign.is_active && campaign.is_verified && !campaign.is_cancelled && (
               <button
                 onClick={() => {
                   if (!userWalletAddress) {
@@ -584,6 +584,25 @@ export default function CauseDetailClient({ id }: { id: string }) {
               >
                 💜 Fund This Cause
               </button>
+            )}
+
+            {campaign.is_active && !campaign.is_verified && !campaign.is_cancelled && (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-950/40">
+                <div className="flex items-center gap-3">
+                  <span className="text-amber-600 dark:text-amber-400 text-lg" aria-hidden="true">
+                    ⏳
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+                      Pending Verification
+                    </p>
+                    <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
+                      This campaign is awaiting verification. Donations will be enabled once
+                      verified by the community or an admin.
+                    </p>
+                  </div>
+                </div>
+              </div>
             )}
 
             <CampaignActions campaign={campaign} onActionSuccess={refetch} />

--- a/src/components/CampaignActions.tsx
+++ b/src/components/CampaignActions.tsx
@@ -99,9 +99,11 @@ export default function CampaignActions({ campaign, onActionSuccess }: CampaignA
     ? "Creators cannot contribute to their own campaign."
     : campaign.is_cancelled
       ? "This campaign has been cancelled."
-      : !campaign.is_active || campaign.funds_withdrawn || isExpired
-        ? "This campaign is no longer accepting contributions."
-        : null;
+      : !campaign.is_verified
+        ? "This campaign is pending verification and cannot accept contributions yet."
+        : !campaign.is_active || campaign.funds_withdrawn || isExpired
+          ? "This campaign is no longer accepting contributions."
+          : null;
 
   const handleContribute = useCallback(async () => {
     const parsedAmount = Number(contributionAmount);


### PR DESCRIPTION
## Summary

Closes #552

### Problem

The donation button rendered based on `campaign.is_active` without checking `campaign.is_verified`. Clicking "Fund This Cause" on an unverified campaign would let a user sign with Freighter, submit a transaction, and then receive a `CampaignNotVerified` error from the contract.

### Changes

1. **CauseDetailClient.tsx** — Gate the "Fund This Cause" button on `campaign.is_verified` in addition to `is_active`. Show a "Pending Verification" amber banner for active-but-unverified campaigns explaining why donations are disabled.

2. **CampaignActions.tsx** — Add `!campaign.is_verified` to the `contributionDisabledReason` so the contribution input also surfaces the pending-verification reason instead of a generic inactive message.

### After the fix

Active, unverified campaign now shows:
- No "Fund This Cause" button
- An amber "⏳ Pending Verification" banner: *"This campaign is awaiting verification. Donations will be enabled once verified by the community or an admin."*

### Testing

- TypeScript typecheck passes (no new errors in edited files)
- ESLint passes (no new issues in edited files)
- Code review confirms logic and messaging are correct
