### PR TITLE
[Feature] Add PWA manifest and service worker for offline support and installability

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,87 @@
+const CACHE = "proofofheart-v1";
+const STATIC_ASSETS = ["/", "/manifest.webmanifest"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE);
+      await cache.addAll(STATIC_ASSETS);
+      await self.skipWaiting();
+    })(),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)));
+      await self.clients.claim();
+    })(),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+
+  // Cache-first for static Next.js assets (immutable hashed files)
+  if (url.pathname.startsWith("/_next/static/")) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  // Cache-first for static public assets (images, fonts, etc.)
+  if (/\.(png|jpg|jpeg|gif|svg|ico|woff2?|ttf|eot|mp4|webm|webp)$/i.test(url.pathname)) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  // Network-first for navigation requests (HTML pages)
+  if (request.mode === "navigate") {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  // Network-first for Stellar Soroban RPC calls (campaign data)
+  if (url.pathname.endsWith("/rpc") || url.hostname.includes("stellar.org")) {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+});
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return caches.match(request);
+  }
+}
+
+async function networkFirst(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    // If navigating and no cache, return the offline page
+    if (request.mode === "navigate") {
+      return caches.match("/");
+    }
+    return new Response("Offline", { status: 503 });
+  }
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { WalletProvider } from "@/components/WalletContext";
 import { DevMockPanel } from "@/components/DevMockPanel";
 import OnboardingTour from "@/components/OnboardingTour";
 import MaintenanceBypass from "@/components/MaintenanceBypass";
+import { PwaInstaller } from "@/components/PwaInstaller";
 import ThirdPartyScripts from "@/components/ThirdPartyScripts";
 import { routing } from "@/i18n/routing";
 import { getTextDirection } from "@/lib/direction";
@@ -93,6 +94,7 @@ export default async function RootLayout({
                       <DevMockPanel />
                       <OnboardingTour />
                       <MaintenanceBypass />
+                      <PwaInstaller />
                     </div>
                   </WalletProvider>
                 </ToastProvider>

--- a/src/components/PwaInstaller.tsx
+++ b/src/components/PwaInstaller.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export function PwaInstaller() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstallable, setIsInstallable] = useState(false);
+  const [installed, setInstalled] = useState(false);
+
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch(() => {});
+    }
+
+    const onBeforeInstall = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setIsInstallable(true);
+    };
+
+    const onInstalled = () => {
+      setInstalled(true);
+      setIsInstallable(false);
+      setDeferredPrompt(null);
+    };
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+    window.addEventListener("appinstalled", onInstalled);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      setInstalled(true);
+      setIsInstallable(false);
+    }
+    setDeferredPrompt(null);
+  };
+
+  if (!isInstallable || installed) return null;
+
+  return (
+    <div className="fixed bottom-4 left-4 z-50 flex items-center gap-3 rounded-xl border border-red-200 bg-white px-4 py-3 shadow-lg dark:border-red-800 dark:bg-gray-900">
+      <span className="text-lg">&#9829;</span>
+      <div className="text-sm">
+        <p className="font-medium text-gray-900 dark:text-gray-100">Install ProofOfHeart</p>
+        <p className="text-gray-500 dark:text-gray-400">Add to home screen for the best experience</p>
+      </div>
+      <button
+        onClick={handleInstall}
+        className="rounded-lg bg-red-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-600"
+      >
+        Install
+      </button>
+      <button
+        onClick={() => setIsInstallable(false)}
+        className="text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-300"
+        aria-label="Dismiss"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview
This PR adds a service worker and PWA install prompt to ProofOfHeart, enabling offline support and home-screen installability. A manifest already existed at \src/app/manifest.ts\ but had no service worker — users could not install the app or access it offline.

## Related Issue
Closes #584

## Changes
**Service Worker** — \public/sw.js\
- Precaches the app shell (root, manifest) on install
- Cache-first strategy for \_next/static/*\ assets (immutable build output)
- Cache-first for images, fonts, and other static public assets
- Network-first for navigation requests with offline cache fallback
- Network-first for Stellar Soroban RPC calls used by campaign listing

**Install Prompt** — \src/components/PwaInstaller.tsx\
- Registers the service worker via \
avigator.serviceWorker.register('/sw.js')\
- Listens for \eforeinstallprompt\ to detect installability
- Shows a dismissible install banner with Install / Dismiss buttons
- Listens for \ppinstalled\ to hide the prompt after successful installation

**Layout Integration** — \src/app/[locale]/layout.tsx\
- Added \PwaInstaller\ alongside existing utility components

## Verification Results
\\\
npm run typecheck — no new errors
\\\
No linting or type errors introduced. All pre-existing errors are unrelated to this change.

## Acceptance Criteria
| Status | Criterion |
|--------|-----------|
| ✅ | Service worker is registered on page load |
| ✅ | Static shell is cached on install |
| ✅ | Navigation requests fall back to cache when offline |
| ✅ | \eforeinstallprompt\ is captured and install UI is shown |
| ✅ | Install banner can be dismissed |
| ✅ | \ppinstalled\ event hides the prompt automatically |