### PR TITLE
[Feature] Add service worker and install prompt for offline support

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -20,6 +20,12 @@
     "socialLoginHint": "Creates a Stellar wallet secured by your social account — no extension needed.",
     "signedInAs": "Signed in as {name}"
   },
+  "PwaInstaller": {
+    "installTitle": "Install ProofOfHeart",
+    "installSubtitle": "Add to home screen for the best experience",
+    "installButton": "Install",
+    "dismissButton": "Dismiss"
+  },
   "Home": {
     "heroTitle": "Decentralized validation for heart-driven causes.",
     "heroSubtitle": "The community validates, you contribute, and impact is recorded on-chain.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -261,7 +261,9 @@
     "tryDifferentSearch": "Try different search terms or clear the filters to see all causes.",
     "tryAgain": "Try again",
     "loadMore": "Load more causes",
-    "showingRange": "Showing {shown} of {total}"
+    "showingRange": "Showing {shown} of {total}",
+    "listView": "List view",
+    "mapView": "Map view"
   },
   "Status": {
     "active": "Active",

--- a/messages/es.json
+++ b/messages/es.json
@@ -261,7 +261,9 @@
     "tryDifferentSearch": "Intenta con otros términos de búsqueda o borra los filtros para ver todas las causas.",
     "tryAgain": "Intentar de nuevo",
     "loadMore": "Cargar más causas",
-    "showingRange": "Mostrando {shown} de {total}"
+    "showingRange": "Mostrando {shown} de {total}",
+    "listView": "Vista de lista",
+    "mapView": "Vista de mapa"
   },
   "Status": {
     "active": "Activa",

--- a/messages/es.json
+++ b/messages/es.json
@@ -20,6 +20,12 @@
     "socialLoginHint": "Crea una billetera Stellar protegida por tu cuenta social, sin necesidad de extensión.",
     "signedInAs": "Sesión iniciada como {name}"
   },
+  "PwaInstaller": {
+    "installTitle": "Instalar ProofOfHeart",
+    "installSubtitle": "Añade a la pantalla de inicio para disfrutar de la mejor experiencia",
+    "installButton": "Instalar",
+    "dismissButton": "Descartar"
+  },
   "Home": {
     "heroTitle": "Validación descentralizada para causas impulsadas por el corazón.",
     "heroSubtitle": "La comunidad valida, tú contribuyes y el impacto se registra en la cadena.",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,106 @@
+// Versioning: bump this string whenever the caching strategy changes so that
+// old caches are pruned on activate. New sw.js versions are picked up via
+// registration.update() (see PwaInstaller) without a hard reload.
+const CACHE = "proofofheart-v1";
+
+// Only immutable, versioned assets are safe to cache at install time. The
+// homepage is intentionally excluded: it depends on the locale/state of the
+// installing user and addAll would reject on the first offline visit or a
+// redirect, failing the whole install. "/" is cached lazily by networkFirst.
+const STATIC_ASSETS = ["/manifest.webmanifest"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE);
+      await cache.addAll(STATIC_ASSETS);
+      await self.skipWaiting();
+    })(),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)));
+      await self.clients.claim();
+    })(),
+  );
+});
+
+function isStellarRpcHost(hostname) {
+  if (hostname === "soroban-testnet.stellar.org") return true;
+  if (hostname === "mainnet.stellar.validationcloud.io") return true;
+  if (hostname.endsWith(".stellar.org")) return true;
+  return false;
+}
+
+function safeRespondWith(event, promise) {
+  event.respondWith(promise.catch(() => fetch(event.request)));
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+
+  // Cache-first for static Next.js assets (immutable hashed files)
+  if (url.pathname.startsWith("/_next/static/")) {
+    safeRespondWith(event, cacheFirst(request));
+    return;
+  }
+
+  // Cache-first for static public assets (images, fonts, etc.)
+  if (/\.(png|jpg|jpeg|gif|svg|ico|woff2?|ttf|eot|mp4|webm|webp)$/i.test(url.pathname)) {
+    safeRespondWith(event, cacheFirst(request));
+    return;
+  }
+
+  // Network-first for navigation requests (HTML pages)
+  if (request.mode === "navigate") {
+    safeRespondWith(event, networkFirst(request));
+    return;
+  }
+
+  // Network-first for Stellar Soroban RPC calls (campaign data)
+  if (url.pathname.endsWith("/rpc") || isStellarRpcHost(url.hostname)) {
+    safeRespondWith(event, networkFirst(request));
+    return;
+  }
+});
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return caches.match(request);
+  }
+}
+
+async function networkFirst(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    // If navigating and no cache, return the offline page
+    if (request.mode === "navigate") {
+      return caches.match("/");
+    }
+    return new Response("Offline", { status: 503 });
+  }
+}

--- a/src/__tests__/components/CauseCard.test.tsx
+++ b/src/__tests__/components/CauseCard.test.tsx
@@ -37,15 +37,33 @@ jest.mock("@/components/DeadlineCountdown", () => ({
   default: () => <span data-testid="deadline-countdown" />,
 }));
 
+const mockToggleSaved = jest.fn<void, [number]>();
+const mockIsSaved = jest.fn<boolean, [number]>(() => false);
+
 jest.mock("@/hooks/useSavedCampaigns", () => ({
-  useSavedCampaigns: () => ({ isSaved: () => false, toggleSaved: jest.fn(), savedIds: [] }),
+  useSavedCampaigns: () => ({
+    isSaved: (id: number) => mockIsSaved(id),
+    toggleSaved: (id: number) => mockToggleSaved(id),
+    savedIds: [],
+  }),
 }));
+
+const mockShowError = jest.fn();
+const mockShowWarning = jest.fn();
 
 jest.mock("@/components/ToastProvider", () => ({
   useToast: () => ({
-    showError: jest.fn(),
+    showError: (msg: string) => mockShowError(msg),
+    showWarning: (msg: string) => mockShowWarning(msg),
   }),
 }));
+
+beforeEach(() => {
+  mockToggleSaved.mockClear();
+  mockIsSaved.mockClear().mockReturnValue(false);
+  mockShowError.mockClear();
+  mockShowWarning.mockClear();
+});
 
 jest.mock("@/components/cancelCampaignModal", () => ({
   __esModule: true,
@@ -362,5 +380,62 @@ describe("static card content", () => {
   it("renders the status badge", () => {
     renderCard(makeCampaign({ status: "funded" }));
     expect(screen.getByTestId("status-badge")).toHaveTextContent("funded");
+  });
+});
+
+// ── Save (bookmark) ──────────────────────────────────────────────────────────
+
+describe("save button", () => {
+  it("warns instead of toggling when no wallet is connected", () => {
+    renderCard(makeCampaign(), null);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(mockShowWarning).toHaveBeenCalled();
+    expect(mockToggleSaved).not.toHaveBeenCalled();
+  });
+
+  it("calls toggleSaved when a wallet is connected", () => {
+    renderCard(makeCampaign(), CONTRIBUTOR);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(mockToggleSaved).toHaveBeenCalledWith(1);
+  });
+});
+
+// ── Cover image ───────────────────────────────────────────────────────────────
+
+describe("cover image", () => {
+  it("renders the image when a cover image url is present", () => {
+    renderCard(makeCampaign({ cover_image_url: "/cover.png" }));
+    expect(screen.getByRole("img", { name: "Test Campaign" })).toBeInTheDocument();
+  });
+
+  it("shows a category icon fallback when no cover image url is set", () => {
+    renderCard(makeCampaign({ cover_image_url: null as unknown as string }));
+    expect(screen.queryByRole("img", { name: "Test Campaign" })).not.toBeInTheDocument();
+  });
+});
+
+// ── Async action error paths ─────────────────────────────────────────────────
+
+describe("async action error handling", () => {
+  it("shows an error toast when onVote rejects", async () => {
+    const onVote = jest.fn(() => Promise.reject(new Error("vote failed")));
+    renderCard(makeCampaign({ status: "active" }), CONTRIBUTOR, { onVote });
+    fireEvent.click(screen.getByTestId("voting-component"));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+  });
+
+  it("shows an error toast when onCancel rejects", async () => {
+    const onCancel = jest.fn(() => Promise.reject(new Error("cancel failed")));
+    renderCard(makeCampaign({ status: "active" }), CREATOR, { onCancel });
+    fireEvent.click(screen.getByRole("button", { name: /cancel campaign/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm cancel/i }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+  });
+
+  it("shows an error toast when onClaimRefund rejects", async () => {
+    const onClaimRefund = jest.fn(() => Promise.reject(new Error("refund failed")));
+    renderCard(makeCampaign({ status: "cancelled" }), CONTRIBUTOR, { onClaimRefund });
+    fireEvent.click(screen.getByRole("button", { name: /claim refund/i }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
   });
 });

--- a/src/__tests__/hooks/useMultiSigProposals.test.tsx
+++ b/src/__tests__/hooks/useMultiSigProposals.test.tsx
@@ -44,10 +44,7 @@ describe("useMultiSigProposals", () => {
   });
 
   it("re-filters proposals when campaignId changes", () => {
-    seed([
-      proposal({ id: "1-a" }),
-      proposal({ id: "2-a", campaignId: 2 }),
-    ]);
+    seed([proposal({ id: "1-a" }), proposal({ id: "2-a", campaignId: 2 })]);
 
     const { result, rerender } = renderHook(
       ({ cid }: { cid: number }) => useMultiSigProposals(cid, WALLET),

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { WalletProvider } from "@/components/WalletContext";
 import { DevMockPanel } from "@/components/DevMockPanel";
 import OnboardingTour from "@/components/OnboardingTour";
 import MaintenanceBypass from "@/components/MaintenanceBypass";
+import { PwaInstaller } from "@/components/PwaInstaller";
 import ThirdPartyScripts from "@/components/ThirdPartyScripts";
 import { routing } from "@/i18n/routing";
 import { getTextDirection } from "@/lib/direction";
@@ -93,6 +94,7 @@ export default async function RootLayout({
                       <DevMockPanel />
                       <OnboardingTour />
                       <MaintenanceBypass />
+                      <PwaInstaller />
                     </div>
                   </WalletProvider>
                 </ToastProvider>

--- a/src/components/PwaInstaller.tsx
+++ b/src/components/PwaInstaller.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export function PwaInstaller() {
+  const t = useTranslations("PwaInstaller");
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstallable, setIsInstallable] = useState(false);
+  const [installed, setInstalled] = useState(false);
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_USE_MOCKS === "true") {
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.getRegistrations().then((regs) => {
+          regs.forEach((r) => r.unregister());
+        });
+      }
+      return;
+    }
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").then(
+        (registration) => {
+          // Check for a newer sw.js on load so users pick up new versions
+          // without waiting for the next page visit.
+          registration.update().catch(() => {});
+        },
+        () => {},
+      );
+    }
+
+    const onBeforeInstall = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setIsInstallable(true);
+    };
+
+    const onInstalled = () => {
+      setInstalled(true);
+      setIsInstallable(false);
+      setDeferredPrompt(null);
+    };
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+    window.addEventListener("appinstalled", onInstalled);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      setInstalled(true);
+      setIsInstallable(false);
+    }
+    setDeferredPrompt(null);
+  };
+
+  if (!isInstallable || installed) return null;
+
+  return (
+    <div className="fixed bottom-4 left-4 z-50 flex items-center gap-3 rounded-xl border border-red-200 bg-white px-4 py-3 shadow-lg dark:border-red-800 dark:bg-gray-900">
+      <span className="text-lg">&#9829;</span>
+      <div className="text-sm">
+        <p className="font-medium text-gray-900 dark:text-gray-100">{t("installTitle")}</p>
+        <p className="text-gray-500 dark:text-gray-400">{t("installSubtitle")}</p>
+      </div>
+      <button
+        onClick={handleInstall}
+        className="rounded-lg bg-red-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-600"
+      >
+        {t("installButton")}
+      </button>
+      <button
+        onClick={() => setIsInstallable(false)}
+        className="text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-300"
+        aria-label={t("dismissButton")}
+      >
+        &times;
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview
This PR adds a service worker and PWA install prompt to ProofOfHeart, enabling offline support and home-screen installability. A manifest already exists at `src/app/manifest.ts`, so no manifest is added here — this PR wires up the missing service worker.

## Related Issue
Closes #584

## Changes

**Service Worker** — `public/sw.js`
- Caches only immutable, versioned assets at install time (`/manifest.webmanifest`). The homepage is cached lazily via `networkFirst` so install never fails on the first offline visit or a redirect.
- Cache-first for `/_next/static/*` assets (immutable hashed build output)
- Cache-first for images, fonts, and other static public assets
- Network-first for navigation requests with offline cache fallback
- Network-first for Stellar Soroban RPC calls used by campaign listing
- `activate` prunes caches from older `CACHE` versions; bumping the version string is the documented invalidation mechanism
- `safeRespondWith` falls back to a plain fetch so a service-worker bug can never brick the app

**Install Prompt** — `src/components/PwaInstaller.tsx`
- Registers the service worker via `navigator.serviceWorker.register("/sw.js")` and calls `registration.update()` on load so new versions are picked up without a hard reload
- Unregisters the service worker in mock mode (`NEXT_PUBLIC_USE_MOCKS`) for the e2e suite
- Listens for `beforeinstallprompt` to detect installability
- Shows a dismissible install banner with localized copy (via the new `PwaInstaller` message namespace)
- Listens for `appinstalled` to hide the prompt after successful installation

**Layout Integration** — `src/app/[locale]/layout.tsx`
- Added `<PwaInstaller />` alongside existing utility components

**i18n** — `messages/en.json`, `messages/es.json`
- Added the `PwaInstaller` namespace: `installTitle`, `installSubtitle`, `installButton`, `dismissButton`

## Verification
- `npm run typecheck` — no errors
- ESLint on changed files — no errors
- Prettier — formatted
- `node scripts/check-i18n.mjs` — passes (no unused keys)
- `node scripts/bundle-size-check.mjs` — within budget (-0.3 KB)
- `npm run build` — succeeds