### PR TITLE
docs(feature-flags): document feature flags and caching behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,18 @@ Authenticated off-chain mutations send wallet signatures with:
 
 The client retries transient failures and falls back to the existing mock/local stores when `NEXT_PUBLIC_API_URL` is not set.
 
+#### Feature Flags
+
+The project uses a simple feature flag system to gate in-progress features. Flags are controlled by `NEXT_PUBLIC_FEATURE_*` environment variables and default to `false` (disabled) in production.
+
+| Feature   | Environment Variable            | Default | Purpose                                             |
+| --------- | ------------------------------- | ------- | --------------------------------------------------- |
+| votingUI  | `NEXT_PUBLIC_FEATURE_VOTINGUI`  | `false` | Enables the voting UI on cause detail pages         |
+| analytics | `NEXT_PUBLIC_FEATURE_ANALYTICS` | `false` | Enables analytics event tracking                    |
+| embeds    | `NEXT_PUBLIC_FEATURE_EMBEDS`    | `false` | Enables embedded content (e.g. social media embeds) |
+
+> **Note on caching:** Feature flags are read once at module initialization and cached for the lifetime of the process. Changing environment variables during development will not take effect until the dev server is restarted. See [issue #559](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/559) for details.
+
 ## 🚀 Mainnet Launch Checklist
 
 Before going live on the Stellar public network, ensure the following production-readiness items are complete:

--- a/src/app/[locale]/causes/new/NewCauseClient.tsx
+++ b/src/app/[locale]/causes/new/NewCauseClient.tsx
@@ -98,16 +98,35 @@ export default function CreateCampaignPage() {
       milestones,
     });
   }, [
-    title, description, descriptionEs, creatorEmail, fundingGoal, durationDays,
-    category, hasRevenueSharing, revenueSharePercentage, tags, coverImageUrl, milestones,
+    title,
+    description,
+    descriptionEs,
+    creatorEmail,
+    fundingGoal,
+    durationDays,
+    category,
+    hasRevenueSharing,
+    revenueSharePercentage,
+    tags,
+    coverImageUrl,
+    milestones,
     saveDraft,
   ]);
 
   const handleDiscardDraft = () => {
     discardDraft({
-      setTitle, setDescription, setDescriptionEs, setCreatorEmail,
-      setFundingGoal, setDurationDays, setCategory, setHasRevenueSharing,
-      setRevenueSharePercentage, setTags, setCoverImageUrl, setMilestones,
+      setTitle,
+      setDescription,
+      setDescriptionEs,
+      setCreatorEmail,
+      setFundingGoal,
+      setDurationDays,
+      setCategory,
+      setHasRevenueSharing,
+      setRevenueSharePercentage,
+      setTags,
+      setCoverImageUrl,
+      setMilestones,
     });
   };
 
@@ -266,8 +285,15 @@ export default function CreateCampaignPage() {
     setIsSubmitting(false);
     setTxPhase(null);
   }, [
-    reviewData, isWalletConnected, publicKey, showError, showSuccess, t,
-    notifyEmailOptIn, clearDraft, router,
+    reviewData,
+    isWalletConnected,
+    publicKey,
+    showError,
+    showSuccess,
+    t,
+    notifyEmailOptIn,
+    clearDraft,
+    router,
   ]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -279,8 +305,15 @@ export default function CreateCampaignPage() {
     }
 
     const keys = validateForm(
-      title, description, descriptionEs, creatorEmail, fundingGoal,
-      durationDays, hasRevenueSharing, revenueSharePercentage, coverImageUrl,
+      title,
+      description,
+      descriptionEs,
+      creatorEmail,
+      fundingGoal,
+      durationDays,
+      hasRevenueSharing,
+      revenueSharePercentage,
+      coverImageUrl,
     );
 
     if (Object.keys(keys).length > 0) {

--- a/src/components/CampaignReviewModal.tsx
+++ b/src/components/CampaignReviewModal.tsx
@@ -51,9 +51,7 @@ export default function CampaignReviewModal({
           >
             {t("reviewTitle")}
           </h2>
-          <p className="text-sm text-zinc-600 dark:text-zinc-400 mt-1">
-            {t("reviewSubtitle")}
-          </p>
+          <p className="text-sm text-zinc-600 dark:text-zinc-400 mt-1">{t("reviewSubtitle")}</p>
         </div>
 
         <dl className="px-6 py-5 space-y-4">

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -10,8 +10,17 @@
  */
 
 export interface FeatureFlags {
+  /** Controls whether the voting UI is shown on cause detail pages.
+   *  Environment variable: `NEXT_PUBLIC_FEATURE_VOTINGUI`
+   *  Default: `false` */
   votingUI: boolean;
+  /** Controls whether analytics event tracking is enabled.
+   *  Environment variable: `NEXT_PUBLIC_FEATURE_ANALYTICS`
+   *  Default: `false` */
   analytics: boolean;
+  /** Controls whether embedded content (e.g. social media embeds) is enabled.
+   *  Environment variable: `NEXT_PUBLIC_FEATURE_EMBEDS`
+   *  Default: `false` */
   embeds: boolean;
 }
 
@@ -28,6 +37,11 @@ function readFlag(name: string, fallback: boolean): boolean {
   return raw === "true" || raw === "1";
 }
 
+/** Module-level cache populated once at first access.
+ *  Environment variables read during initialization are not re-evaluated
+ *  when they change at runtime. Restart the dev server after modifying
+ *  any `NEXT_PUBLIC_FEATURE_*` variable.
+ *  @see https://github.com/Iris-IV/ProofOfHeart-frontend/issues/559 */
 let cached: FeatureFlags | null = null;
 
 /**


### PR DESCRIPTION
## Summary

Adds documentation for the frontend feature flag system, making available flags easier for contributors to discover and extend.

Closes #841

## Changes

- Added JSDoc documentation to `src/lib/featureFlags.ts` covering:
  - Environment variable names
  - Default values
  - Feature purposes
  - Module-level caching caveat from issue #559

- Added a Feature Flags section to `README.md` with:
  - Complete list of current flags
  - Env variables
  - Defaults
  - Usage descriptions
  - Local development caching notes

## Notes

- No feature flag behavior or application logic was changed.
- Issue #559 caching behavior remains unchanged and is only documented.