### PR TITLE
fix(notifications): abort inflight fetch on unmount (#555)

### DIFF
--- a/src/__tests__/hooks/useNotifications.test.tsx
+++ b/src/__tests__/hooks/useNotifications.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useNotifications } from "@/hooks/useNotifications";
+import type { AppNotification } from "@/lib/notifications";
+
+jest.mock("@/lib/notifications", () => ({
+  fetchNotifications: jest.fn(),
+  markAllNotificationsRead: jest.fn(),
+  markNotificationRead: jest.fn(),
+}));
+
+import { fetchNotifications } from "@/lib/notifications";
+
+const mockFetchNotifications = fetchNotifications as jest.MockedFunction<typeof fetchNotifications>;
+
+const SAMPLE: AppNotification[] = [
+  {
+    id: "n1",
+    type: "contribution_confirmed",
+    campaignId: 1,
+    campaignTitle: "Campaign #1",
+    message: "Contribution confirmed",
+    href: "/causes/1",
+    timestamp: Date.now(),
+    read: false,
+  },
+];
+
+describe("useNotifications", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("loads notifications for a connected wallet", async () => {
+    mockFetchNotifications.mockResolvedValue(SAMPLE);
+
+    const { result } = renderHook(() => useNotifications("GABC123"));
+
+    await waitFor(() => expect(result.current.notifications).toEqual(SAMPLE));
+    expect(result.current.unreadCount).toBe(1);
+    expect(mockFetchNotifications).toHaveBeenCalledWith("GABC123", {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("clears notifications when walletAddress is null", async () => {
+    const { result } = renderHook(() => useNotifications(null));
+
+    await waitFor(() => expect(result.current.notifications).toEqual([]));
+    expect(mockFetchNotifications).not.toHaveBeenCalled();
+  });
+
+  it("aborts the inflight fetch on unmount so setState is not called after cleanup", async () => {
+    let resolveFetch!: (value: AppNotification[]) => void;
+    mockFetchNotifications.mockImplementation(
+      (_wallet, options) =>
+        new Promise<AppNotification[]>((resolve, reject) => {
+          resolveFetch = resolve;
+          options?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+
+    const { unmount } = renderHook(() => useNotifications("GABC123"));
+
+    await waitFor(() => expect(mockFetchNotifications).toHaveBeenCalled());
+
+    unmount();
+
+    // Completing after unmount must not throw (no stale setState) and must have been aborted.
+    const signal = mockFetchNotifications.mock.calls[0]?.[1]?.signal;
+    expect(signal?.aborted).toBe(true);
+
+    await act(async () => {
+      resolveFetch(SAMPLE);
+    });
+  });
+
+  it("aborts the previous inflight fetch when the wallet address changes", async () => {
+    const controllers: AbortSignal[] = [];
+    mockFetchNotifications.mockImplementation((_wallet, options) => {
+      if (options?.signal) controllers.push(options.signal);
+      return new Promise(() => {});
+    });
+
+    const { rerender } = renderHook(
+      ({ wallet }: { wallet: string | null }) => useNotifications(wallet),
+      { initialProps: { wallet: "GABC123" as string | null } },
+    );
+
+    await waitFor(() => expect(controllers).toHaveLength(1));
+
+    rerender({ wallet: "GDEF456" });
+
+    await waitFor(() => expect(controllers).toHaveLength(2));
+    expect(controllers[0]?.aborted).toBe(true);
+    expect(controllers[1]?.aborted).toBe(false);
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -10,28 +10,48 @@ import {
 
 const POLL_INTERVAL_MS = 30_000;
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 export function useNotifications(walletAddress: string | null) {
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
 
-  const refresh = useCallback(async () => {
-    if (!walletAddress) {
-      setNotifications([]);
-      return;
-    }
+  const refresh = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!walletAddress) {
+        setNotifications([]);
+        return;
+      }
 
-    const nextNotifications = await fetchNotifications(walletAddress);
-    setNotifications(nextNotifications);
-  }, [walletAddress]);
+      try {
+        const nextNotifications = await fetchNotifications(walletAddress, { signal });
+        if (signal?.aborted) return;
+        setNotifications(nextNotifications);
+      } catch (error) {
+        // Inflight fetch aborted on unmount / remount — do not touch state.
+        if (signal?.aborted || isAbortError(error)) return;
+      }
+    },
+    [walletAddress],
+  );
 
   useEffect(() => {
-    void refresh();
-    if (!walletAddress) return;
+    const controller = new AbortController();
+
+    void refresh(controller.signal);
+    if (!walletAddress) {
+      return () => controller.abort();
+    }
 
     const id = setInterval(() => {
-      void refresh();
+      void refresh(controller.signal);
     }, POLL_INTERVAL_MS);
 
-    return () => clearInterval(id);
+    return () => {
+      clearInterval(id);
+      controller.abort();
+    };
   }, [refresh, walletAddress]);
 
   const unreadCount = notifications.filter((notification) => !notification.read).length;
@@ -55,5 +75,9 @@ export function useNotifications(walletAddress: string | null) {
     [walletAddress],
   );
 
-  return { notifications, unreadCount, markAllRead, markRead, refresh };
+  const refreshManual = useCallback(async () => {
+    await refresh();
+  }, [refresh]);
+
+  return { notifications, unreadCount, markAllRead, markRead, refresh: refreshManual };
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -102,7 +102,14 @@ function walletActionToNotification(
   }
 }
 
-async function fetchRemoteNotifications(walletAddress: string): Promise<AppNotification[] | null> {
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+async function fetchRemoteNotifications(
+  walletAddress: string,
+  signal?: AbortSignal,
+): Promise<AppNotification[] | null> {
   try {
     const url = new URL(REMOTE_FEED_ENDPOINT, window.location.origin);
     url.searchParams.set("walletAddress", walletAddress);
@@ -112,6 +119,7 @@ async function fetchRemoteNotifications(walletAddress: string): Promise<AppNotif
         Accept: "application/json",
       },
       cache: "no-store",
+      signal,
     });
 
     if (!response.ok) {
@@ -127,7 +135,11 @@ async function fetchRemoteNotifications(walletAddress: string): Promise<AppNotif
         ...item,
         read: Boolean(item.read),
       }));
-  } catch {
+  } catch (error) {
+    // Propagate aborts so callers can skip setState instead of falling back to local data.
+    if (signal?.aborted || isAbortError(error)) {
+      throw error instanceof Error ? error : new DOMException("Aborted", "AbortError");
+    }
     return null;
   }
 }
@@ -151,11 +163,21 @@ function deriveLocalNotifications(walletAddress: string): AppNotification[] {
     .filter(Boolean) as AppNotification[];
 }
 
-export async function fetchNotifications(walletAddress: string): Promise<AppNotification[]> {
+export async function fetchNotifications(
+  walletAddress: string,
+  options?: { signal?: AbortSignal },
+): Promise<AppNotification[]> {
   const normalizedWallet = normalizeAddress(walletAddress);
   if (!normalizedWallet) return [];
 
-  const remoteNotifications = await fetchRemoteNotifications(normalizedWallet);
+  if (options?.signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  const remoteNotifications = await fetchRemoteNotifications(
+    normalizedWallet,
+    options?.signal,
+  );
   const notifications = remoteNotifications ?? deriveLocalNotifications(normalizedWallet);
   const readIds = readNotificationIds(normalizedWallet);
 


### PR DESCRIPTION
## Summary
- Abort in-flight `fetchNotifications` on unmount/wallet change via `AbortController` so remounts cannot call `setNotifications` after cleanup
- Propagate abort signals through remote notification fetch (no local fallback on abort)
- Add regression tests for unmount and wallet-change abort paths

Closes #555

## Type of Change
- [x] Bug fix

## Test plan
- [x] `npm test -- --runTestsByPath src/__tests__/hooks/useNotifications.test.tsx`
- [ ] Confirm notification bell still polls while connected
- [ ] Rapidly navigate away/back while notifications are loading and verify no console stale-state warnings