### PR TITLE
fix(ui/ux): address issues #821, #822, #824, #826

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -424,7 +424,8 @@
     "processing": "Processing…",
     "withdrawalSuccess": "Withdrawal successful! You received {amount} XLM.",
     "errorNoSigners": "Please add at least one co-signer address.",
-    "errorInvalidThreshold": "Required signatures must be between 1 and the number of co-signers."
+    "errorInvalidThreshold": "Required signatures must be between 1 and the number of co-signers.",
+    "you": "You"
   },
   "Voting": {
     "title": "Vote on this cause",
@@ -521,7 +522,8 @@
   },
   "CampaignMap": {
     "emptyTitle": "No campaigns with location data",
-    "emptyBody": "Campaigns with coordinates will appear on this map. Switch to list view to browse all campaigns."
+    "emptyBody": "Campaigns with coordinates will appear on this map. Switch to list view to browse all campaigns.",
+    "loading": "Loading map…"
   },
   "Gamification": {
     "level_Bronze": "Bronze",

--- a/messages/es.json
+++ b/messages/es.json
@@ -424,7 +424,8 @@
     "processing": "Procesando…",
     "withdrawalSuccess": "¡Retiro exitoso! Recibiste {amount} XLM.",
     "errorNoSigners": "Por favor agrega al menos una dirección de co-firmante.",
-    "errorInvalidThreshold": "Las firmas requeridas deben estar entre 1 y el número de co-firmantes."
+    "errorInvalidThreshold": "Las firmas requeridas deben estar entre 1 y el número de co-firmantes.",
+    "you": "Tú"
   },
   "Voting": {
     "title": "Vota por esta causa",
@@ -521,7 +522,8 @@
   },
   "CampaignMap": {
     "emptyTitle": "No hay campañas con datos de ubicación",
-    "emptyBody": "Las campañas con coordenadas aparecerán en este mapa. Cambia a la vista de lista para ver todas las campañas."
+    "emptyBody": "Las campañas con coordenadas aparecerán en este mapa. Cambia a la vista de lista para ver todas las campañas.",
+    "loading": "Cargando mapa…"
   },
   "Gamification": {
     "level_Bronze": "Bronce",

--- a/src/components/AnimatedProgressFill.tsx
+++ b/src/components/AnimatedProgressFill.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useRef } from "react";
 import { motion, useSpring, useTransform } from "framer-motion";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 
 export default function AnimatedProgressFill({ targetPct }: { targetPct: number }) {
+  const prefersReducedMotion = useReducedMotion();
   const hasMountedRef = useRef(false);
   const springPct = useSpring(targetPct, { stiffness: 120, damping: 20, mass: 0.6 });
   const barWidth = useTransform(springPct, (v) => `${v}%`);
@@ -16,6 +18,16 @@ export default function AnimatedProgressFill({ targetPct }: { targetPct: number 
     }
     springPct.set(targetPct);
   }, [targetPct, springPct]);
+
+  if (prefersReducedMotion) {
+    return (
+      <div
+        aria-hidden="true"
+        className="bg-linear-to-r from-blue-500 to-purple-500 h-1.5 rounded-full"
+        style={{ width: `${targetPct}%` }}
+      />
+    );
+  }
 
   return (
     <motion.div

--- a/src/components/CampaignMap.tsx
+++ b/src/components/CampaignMap.tsx
@@ -63,9 +63,10 @@ export function filterByValidCoordinates(
 
 interface CampaignMapProps {
   campaigns: Campaign[];
+  isLoading?: boolean;
 }
 
-export default function CampaignMap({ campaigns }: CampaignMapProps) {
+export default function CampaignMap({ campaigns, isLoading = false }: CampaignMapProps) {
   const t = useTranslations("CampaignMap");
   const validCampaigns = useMemo(() => filterByValidCoordinates(campaigns), [campaigns]);
 
@@ -75,6 +76,32 @@ export default function CampaignMap({ campaigns }: CampaignMapProps) {
     const lngSum = validCampaigns.reduce((s, c) => s + c.longitude, 0);
     return [latSum / validCampaigns.length, lngSum / validCampaigns.length];
   }, [validCampaigns]);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl overflow-hidden border border-zinc-200 dark:border-zinc-700">
+        <div className="h-[500px] w-full flex items-center justify-center bg-zinc-50 dark:bg-zinc-800">
+          <div className="flex flex-col items-center gap-3">
+            <svg
+              className="w-8 h-8 text-blue-500 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">{t("loading")}</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (validCampaigns.length === 0) {
     return (

--- a/src/components/MultiSigWithdrawalPanel.tsx
+++ b/src/components/MultiSigWithdrawalPanel.tsx
@@ -299,43 +299,58 @@ export default function MultiSigWithdrawalPanel({
           </div>
 
           <ul className="space-y-1.5">
-            {activeProposal.signers.map((signer) => (
-              <li key={signer.address} className="flex items-center gap-2 text-xs">
-                {signer.signedAt ? (
-                  <svg
-                    className="w-3.5 h-3.5 text-green-500 shrink-0"
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                ) : (
-                  <svg
-                    className="w-3.5 h-3.5 text-zinc-300 dark:text-zinc-600 shrink-0"
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 18a8 8 0 100-16 8 8 0 000 16z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                )}
-                <span className="font-mono text-zinc-600 dark:text-zinc-400 break-all">
-                  {signer.address.slice(0, 8)}…{signer.address.slice(-6)}
-                </span>
-                {signer.signedAt && (
-                  <span className="text-zinc-400 dark:text-zinc-500">
-                    {new Date(signer.signedAt * 1000).toLocaleDateString()}
+            {activeProposal.signers.map((signer) => {
+              const isMe = isSameAddress(signer.address, walletAddress);
+              return (
+                <li
+                  key={signer.address}
+                  className={`flex items-center gap-2 text-xs px-3 py-2 rounded-lg ${
+                    isMe
+                      ? "bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800"
+                      : ""
+                  }`}
+                >
+                  {signer.signedAt ? (
+                    <svg
+                      className="w-3.5 h-3.5 text-green-500 shrink-0"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  ) : (
+                    <svg
+                      className="w-3.5 h-3.5 text-zinc-300 dark:text-zinc-600 shrink-0"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M10 18a8 8 0 100-16 8 8 0 000 16z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  )}
+                  <span className="font-mono text-zinc-600 dark:text-zinc-400 break-all">
+                    {signer.address.slice(0, 8)}…{signer.address.slice(-6)}
                   </span>
-                )}
-              </li>
-            ))}
+                  {isMe && (
+                    <span className="ml-auto text-xs font-medium text-blue-600 dark:text-blue-400 shrink-0">
+                      {t("you")}
+                    </span>
+                  )}
+                  {signer.signedAt && (
+                    <span className="text-zinc-400 dark:text-zinc-500 shrink-0">
+                      {new Date(signer.signedAt * 1000).toLocaleDateString()}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
 
           <div className="flex flex-col sm:flex-row gap-2">

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -9,110 +9,6 @@ interface ShareButtonsProps {
   walletAddress?: string;
 }
 
-function QRModal({
-  url,
-  walletAddress,
-  onClose,
-}: {
-  url: string;
-  walletAddress?: string;
-  onClose: () => void;
-}) {
-  const qrBase = "https://api.qrserver.com/v1/create-qr-code/?size=200x200&ecc=M&data=";
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    },
-    [onClose],
-  );
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-      onClick={onClose}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="QR codes"
-        className="relative bg-white dark:bg-zinc-900 rounded-2xl shadow-xl p-6 max-w-md w-full mx-4 flex flex-col gap-6"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close QR modal"
-          className="absolute top-3 right-3 p-1.5 rounded-lg text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <line x1="18" y1="6" x2="6" y2="18" />
-            <line x1="6" y1="6" x2="18" y2="18" />
-          </svg>
-        </button>
-
-        <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">QR Codes</h2>
-
-        <div className={`flex gap-6 ${walletAddress ? "flex-wrap sm:flex-nowrap" : ""}`}>
-          {/* Campaign URL QR */}
-          <div className="flex flex-col items-center gap-2 flex-1">
-            <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Campaign URL</p>
-            <img
-              src={`${qrBase}${encodeURIComponent(url)}`}
-              alt="QR code for campaign URL"
-              width={200}
-              height={200}
-              className="rounded-lg border border-zinc-200 dark:border-zinc-700"
-            />
-            <a
-              href={`${qrBase}${encodeURIComponent(url)}`}
-              download="campaign-qr.png"
-              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-            >
-              Download
-            </a>
-          </div>
-
-          {/* Wallet address QR */}
-          {walletAddress && (
-            <div className="flex flex-col items-center gap-2 flex-1">
-              <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                Contribution Address
-              </p>
-              <img
-                src={`${qrBase}${encodeURIComponent(walletAddress)}`}
-                alt="QR code for contribution wallet address"
-                width={200}
-                height={200}
-                className="rounded-lg border border-zinc-200 dark:border-zinc-700"
-              />
-              <a
-                href={`${qrBase}${encodeURIComponent(walletAddress)}`}
-                download="wallet-qr.png"
-                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                Download
-              </a>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export default function ShareButtons({ url, title, walletAddress }: ShareButtonsProps) {
   const { showSuccess } = useToast();
   const [copied, setCopied] = useState(false);
@@ -130,7 +26,6 @@ export default function ShareButtons({ url, title, walletAddress }: ShareButtons
       showSuccess("Copied!");
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // fallback for older browsers
       const el = document.createElement("textarea");
       el.value = url;
       document.body.appendChild(el);
@@ -157,8 +52,10 @@ export default function ShareButtons({ url, title, walletAddress }: ShareButtons
 
   const isMobile = typeof navigator !== "undefined" && /Mobi|Android/i.test(navigator.userAgent);
 
+  const qrBase = "https://api.qrserver.com/v1/create-qr-code/?size=200x200&ecc=M&data=";
+
   return (
-    <>
+    <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0">
           Share:
@@ -212,7 +109,6 @@ export default function ShareButtons({ url, title, walletAddress }: ShareButtons
           aria-label="Share on X"
           className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
         >
-          {/* X logo */}
           <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.911-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
           </svg>
@@ -227,7 +123,6 @@ export default function ShareButtons({ url, title, walletAddress }: ShareButtons
           aria-label="Share on LinkedIn"
           className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
         >
-          {/* LinkedIn logo */}
           <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
           </svg>
@@ -237,7 +132,9 @@ export default function ShareButtons({ url, title, walletAddress }: ShareButtons
         {/* QR */}
         <button
           type="button"
-          onClick={() => setQrOpen(true)}
+          onClick={() => setQrOpen((prev) => !prev)}
+          aria-expanded={qrOpen}
+          aria-controls="qr-panel"
           aria-label="Show QR code"
           className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
         >
@@ -263,8 +160,56 @@ export default function ShareButtons({ url, title, walletAddress }: ShareButtons
       </div>
 
       {qrOpen && (
-        <QRModal url={url} walletAddress={walletAddress} onClose={() => setQrOpen(false)} />
+        <div
+          id="qr-panel"
+          role="region"
+          aria-label="QR codes"
+          className="flex flex-col gap-4 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+        >
+          <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">QR Codes</h3>
+          <div className={`flex gap-6 ${walletAddress ? "flex-wrap sm:flex-nowrap" : ""}`}>
+            <div className="flex flex-col items-center gap-2 flex-1">
+              <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Campaign URL</p>
+              <img
+                src={`${qrBase}${encodeURIComponent(url)}`}
+                alt="QR code for campaign URL"
+                width={200}
+                height={200}
+                className="rounded-lg border border-zinc-200 dark:border-zinc-700"
+              />
+              <a
+                href={`${qrBase}${encodeURIComponent(url)}`}
+                download="campaign-qr.png"
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Download
+              </a>
+            </div>
+
+            {walletAddress && (
+              <div className="flex flex-col items-center gap-2 flex-1">
+                <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                  Contribution Address
+                </p>
+                <img
+                  src={`${qrBase}${encodeURIComponent(walletAddress)}`}
+                  alt="QR code for contribution wallet address"
+                  width={200}
+                  height={200}
+                  className="rounded-lg border border-zinc-200 dark:border-zinc-700"
+                />
+                <a
+                  href={`${qrBase}${encodeURIComponent(walletAddress)}`}
+                  download="wallet-qr.png"
+                  className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Download
+                </a>
+              </div>
+            )}
+          </div>
+        </div>
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/__tests__/AnimatedProgressFill.test.tsx
+++ b/src/components/__tests__/AnimatedProgressFill.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import AnimatedProgressFill from "../AnimatedProgressFill";
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ style, ...props }: React.ComponentProps<"div">) => (
+      <div data-testid="motion-div" style={style} {...props} />
+    ),
+  },
+  useSpring: (initial: number) => ({
+    get: () => initial,
+    set: jest.fn(),
+    jump: jest.fn(),
+  }),
+  useTransform: (val: { get: () => number }) => `${val.get()}%`,
+}));
+
+jest.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: jest.fn(),
+}));
+
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+const mockUseReducedMotion = useReducedMotion as jest.MockedFunction<
+  typeof useReducedMotion
+>;
+
+describe("AnimatedProgressFill", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the final width immediately when reduced motion is preferred", () => {
+    mockUseReducedMotion.mockReturnValue(true);
+
+    render(<AnimatedProgressFill targetPct={75} />);
+
+    const div = document.querySelector('[style*="width: 75%"]');
+    expect(div).toBeInTheDocument();
+  });
+
+  it("renders the final width immediately when reduced motion is not preferred", () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    render(<AnimatedProgressFill targetPct={50} />);
+
+    const div = screen.getByTestId("motion-div");
+    expect(div).toHaveStyle({ width: "50%" });
+  });
+
+  it("renders with aria-hidden", () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    render(<AnimatedProgressFill targetPct={60} />);
+
+    expect(screen.getByTestId("motion-div")).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/src/components/__tests__/CampaignMap.test.tsx
+++ b/src/components/__tests__/CampaignMap.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import MapErrorBoundary from "../MapErrorBoundary";
-import { hasValidCoordinates, filterByValidCoordinates } from "../CampaignMap";
+import CampaignMap, { hasValidCoordinates, filterByValidCoordinates } from "../CampaignMap";
 import { Campaign, Category } from "@/types";
 
 // Leaflet and react-leaflet use browser APIs not available in jsdom.
@@ -243,5 +243,57 @@ describe("MapErrorBoundary", () => {
     fireEvent.click(screen.getByText("Try Again"));
 
     expect(screen.getByTestId("recovered")).toHaveTextContent("Recovered");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CampaignMap loading state
+// ---------------------------------------------------------------------------
+
+describe("CampaignMap loading state", () => {
+  it("shows a loading indicator when isLoading is true", () => {
+    render(<CampaignMap campaigns={[]} isLoading={true} />);
+
+    expect(screen.getByText("loading")).toBeInTheDocument();
+  });
+
+  it("clears the loading state and renders the map when loading completes with valid campaigns", () => {
+    const { rerender } = render(
+      <CampaignMap campaigns={[]} isLoading={true} />,
+    );
+
+    expect(screen.getByText("loading")).toBeInTheDocument();
+
+    rerender(
+      <CampaignMap
+        campaigns={[
+          {
+            ...makeCampaign(),
+            id: 1,
+            latitude: 40.7128,
+            longitude: -74.006,
+          },
+        ]}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.queryByText("loading")).not.toBeInTheDocument();
+    expect(screen.getByTestId("map")).toBeInTheDocument();
+  });
+
+  it("clears the loading state and shows empty state when loading completes with no valid campaigns", () => {
+    const { rerender } = render(
+      <CampaignMap campaigns={[]} isLoading={true} />,
+    );
+
+    expect(screen.getByText("loading")).toBeInTheDocument();
+
+    rerender(
+      <CampaignMap campaigns={[]} isLoading={false} />,
+    );
+
+    expect(screen.queryByText("loading")).not.toBeInTheDocument();
+    expect(screen.getByText("emptyTitle")).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/MultiSigWithdrawalPanel.test.tsx
+++ b/src/components/__tests__/MultiSigWithdrawalPanel.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen } from "@testing-library/react";
+import MultiSigWithdrawalPanel from "../MultiSigWithdrawalPanel";
+
+jest.mock("../../hooks/useMultiSigProposals", () => ({
+  useMultiSigProposals: jest.fn(),
+}));
+
+jest.mock("../../hooks/useWriteGuard", () => ({
+  useWriteGuard: () => ({
+    invoke: jest.fn(),
+    isPending: () => false,
+  }),
+}));
+
+jest.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+  }),
+}));
+
+jest.mock("../../lib/contractClient", () => ({
+  withdrawFunds: jest.fn(),
+}));
+
+jest.mock("../../lib/stellar", () => ({
+  isSameAddress: (a: string, b: string) => a === b,
+}));
+
+jest.mock("../../utils/contractErrors", () => ({
+  parseContractError: (err: unknown) => String(err),
+}));
+
+jest.mock("@/lib/stellarAmount", () => ({
+  stroopsToXlmNumber: (v: bigint) => Number(v) / 10_000_000,
+}));
+
+jest.mock("@/lib/formatters", () => ({
+  formatNumber: (v: number) => v.toFixed(2),
+}));
+
+jest.mock("@/utils/explorer", () => ({
+  explorerTxUrl: (hash: string) => `https://explorer.stellar.org/tx/${hash}`,
+}));
+
+import { useMultiSigProposals } from "../../hooks/useMultiSigProposals";
+
+const mockUseMultiSigProposals = useMultiSigProposals as jest.MockedFunction<
+  typeof useMultiSigProposals
+>;
+
+const mockCampaign = {
+  id: 1,
+  creator: "GABC12345678901234567890123456789012345678901234567890",
+  title: "Test Campaign",
+  description: "A test campaign.",
+  created_at: 1_000_000,
+  status: "active" as const,
+  funding_goal: BigInt(100_000_000_000),
+  deadline: 2_000_000_000,
+  amount_raised: BigInt(200_000_000_000),
+  is_active: true,
+  funds_withdrawn: false,
+  is_cancelled: false,
+  is_verified: false,
+  category: "Learner" as const,
+  has_revenue_sharing: false,
+  revenue_share_percentage: 0,
+};
+
+function setupProposal(signers: Array<{ address: string; signedAt?: number }>) {
+  return {
+    id: "prop-1",
+    campaignId: 1,
+    proposedBy: "GABC12345678901234567890123456789012345678901234567890",
+    createdAt: 1_000_000,
+    signers,
+    requiredSignatures: 2,
+    status: "pending" as const,
+  };
+}
+
+describe("MultiSigWithdrawalPanel", () => {
+  it("renders per-signer rows with address and status", () => {
+    mockUseMultiSigProposals.mockReturnValue({
+      activeProposal: setupProposal([
+        { address: "GABC12345678901234567890123456789012345678901234567890" },
+        {
+          address: "GDEF9876543210987654321098765432109876543210987654321",
+          signedAt: 1_700_000_000,
+        },
+      ]),
+      createProposal: jest.fn(),
+      signProposal: jest.fn(),
+      cancelProposal: jest.fn(),
+      markExecuted: jest.fn(),
+    });
+
+    render(
+      <MultiSigWithdrawalPanel
+        campaign={mockCampaign}
+        walletAddress="GABC12345678901234567890123456789012345678901234567890"
+      />,
+    );
+
+    expect(screen.getByText("you")).toBeInTheDocument();
+  });
+
+  it("visually distinguishes the current wallet signer with a highlight", () => {
+    mockUseMultiSigProposals.mockReturnValue({
+      activeProposal: setupProposal([
+        { address: "GABC12345678901234567890123456789012345678901234567890" },
+        {
+          address: "GDEF9876543210987654321098765432109876543210987654321",
+          signedAt: 1_700_000_000,
+        },
+      ]),
+      createProposal: jest.fn(),
+      signProposal: jest.fn(),
+      cancelProposal: jest.fn(),
+      markExecuted: jest.fn(),
+    });
+
+    render(
+      <MultiSigWithdrawalPanel
+        campaign={mockCampaign}
+        walletAddress="GABC12345678901234567890123456789012345678901234567890"
+      />,
+    );
+
+    const youBadge = screen.getByText("you");
+    expect(youBadge).toBeInTheDocument();
+  });
+
+  it("renders all signer rows correctly", () => {
+    mockUseMultiSigProposals.mockReturnValue({
+      activeProposal: setupProposal([
+        { address: "GABC12345678901234567890123456789012345678901234567890" },
+        {
+          address: "GDEF9876543210987654321098765432109876543210987654321",
+          signedAt: 1_700_000_000,
+        },
+        { address: "GHI555555555555555555555555555555555555555555555555555" },
+      ]),
+      createProposal: jest.fn(),
+      signProposal: jest.fn(),
+      cancelProposal: jest.fn(),
+      markExecuted: jest.fn(),
+    });
+
+    render(
+      <MultiSigWithdrawalPanel
+        campaign={mockCampaign}
+        walletAddress="GABC12345678901234567890123456789012345678901234567890"
+      />,
+    );
+
+    expect(screen.getByText("you")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ShareButtons.test.tsx
+++ b/src/components/__tests__/ShareButtons.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ShareButtons from "../ShareButtons";
+
+jest.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+  }),
+}));
+
+describe("ShareButtons", () => {
+  it("renders both social share buttons and QR entry point from the same panel", () => {
+    render(
+      <ShareButtons
+        url="https://example.com/campaign/1"
+        title="Test Campaign"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Copy link" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Share on X" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Share on LinkedIn" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show QR code" })).toBeInTheDocument();
+  });
+
+  it("toggles the QR panel inline within the share panel", async () => {
+    const user = userEvent.setup();
+    render(
+      <ShareButtons
+        url="https://example.com/campaign/1"
+        title="Test Campaign"
+      />,
+    );
+
+    const qrButton = screen.getByRole("button", { name: "Show QR code" });
+    expect(qrButton).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(qrButton);
+
+    expect(qrButton).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("region", { name: "QR codes" })).toBeInTheDocument();
+    expect(screen.getByText("QR Codes")).toBeInTheDocument();
+  });
+
+  it("renders wallet QR code when walletAddress is provided", async () => {
+    const user = userEvent.setup();
+    render(
+      <ShareButtons
+        url="https://example.com/campaign/1"
+        title="Test Campaign"
+        walletAddress="GABC12345678901234567890123456789012345678901234567890"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show QR code" }));
+
+    expect(screen.getByAltText("QR code for campaign URL")).toBeInTheDocument();
+    expect(
+      screen.getByAltText("QR code for contribution wallet address"),
+    ).toBeInTheDocument();
+  });
+
+  it("has accessible QR panel with aria-controls", () => {
+    render(
+      <ShareButtons
+        url="https://example.com/campaign/1"
+        title="Test Campaign"
+      />,
+    );
+
+    const qrButton = screen.getByRole("button", { name: "Show QR code" });
+    expect(qrButton).toHaveAttribute("aria-controls", "qr-panel");
+  });
+});


### PR DESCRIPTION
## Summary

Implements four UI/UX fixes for the ProofOfHeart-frontend:

## Issues Closed

- Closes [🦀 [UI/UX] CampaignMap has no visible loading state while markers load #821](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/821) - CampaignMap loading state
- Closes [🦀 [UI/UX] MultiSigWithdrawalPanel does not show who has and hasn't signed a proposal #822](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/822) - Per-signer status display
- Closes [🦀 [UI/UX] ShareButtons and QR code entry points are not co-located #824](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/824) - QR co-location
- Closes [🦀 [UI/UX] AnimatedProgressFill ignores prefers-reduced-motion on individual instances #826](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/826) - Reduced motion support

## Changes

### Issue [#821](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/821): CampaignMap has no visible loading state while markers load

- Added an `isLoading` prop to `CampaignMap` (defaults to `false` for backward compatibility)
- When `isLoading` is true, a spinner overlay with "Loading map…" text is shown over the map container
- The loading state clears correctly on both success (valid campaigns render the map) and error (empty state renders)
- Added tests covering the loading-to-loaded transition

### Issue [#822](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/822): MultiSigWithdrawalPanel does not show who has and hasn't signed a proposal

- Added visual distinction for the current wallet's signer row with a blue highlight background and a "You" badge
- Per-signer rows already displayed approve/pending status; now the current user's row is clearly highlighted
- Added tests asserting per-signer rows render correctly with the current wallet's visual distinction

### Issue [#824](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/824): ShareButtons and QR code entry points are not co-located

- Replaced the separate QR modal overlay with an inline QR panel that is part of the share panel itself
- The QR panel is toggled by the same QR button and renders below the social share buttons in the same container
- Added `aria-expanded`, `aria-controls`, and `role="region"` attributes for keyboard and screen-reader accessibility
- Added tests asserting both entry points (social share buttons and QR) render from the same trigger/panel

### Issue [#826](https://github.com/Iris-IV/ProofOfHeart-frontend/issues/826): AnimatedProgressFill ignores prefers-reduced-motion on individual instances

- Imported and used the `useReducedMotion` hook in `AnimatedProgressFill`
- When `prefers-reduced-motion` is preferred, the component renders the final width immediately as a plain `<div>` instead of using Framer Motion spring animations
- When reduced motion is not preferred, the existing Framer Motion animation behavior is preserved
- Added tests covering both the animated and reduced-motion render paths

## Testing

All new and existing tests pass.