### PR TITLE
feat: distinguish Freighter locked state from not-installed with clear UI

### DIFF
--- a/src/components/InstallFreighterModal.tsx
+++ b/src/components/InstallFreighterModal.tsx
@@ -11,6 +11,11 @@ interface InstallFreighterModalProps {
    * than imported so this modal stays free of wallet-provider dependencies.
    */
   socialLogin?: ReactNode;
+  /**
+   * When true, the modal explains that Freighter is locked (password required)
+   * rather than asking the user to install it.
+   */
+  isLocked?: boolean;
 }
 
 function detectBrowser(): { name: string; supported: boolean } {
@@ -28,6 +33,7 @@ export default function InstallFreighterModal({
   onClose,
   onRetry,
   socialLogin,
+  isLocked = false,
 }: InstallFreighterModalProps) {
   const browser = useMemo(
     () => (isOpen ? detectBrowser() : { name: "", supported: false }),
@@ -53,13 +59,19 @@ export default function InstallFreighterModal({
           </div>
 
           <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-50">
-            {socialLogin ? "Connect a wallet" : "Freighter Wallet Required"}
+            {socialLogin
+              ? "Connect a wallet"
+              : isLocked
+                ? "Freighter Wallet Locked"
+                : "Freighter Wallet Required"}
           </h2>
 
           <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
             {socialLogin
               ? "Install the Freighter extension, or sign in with a social account and we will create a Stellar wallet for you."
-              : "This app requires the Freighter browser extension to interact with the Stellar network."}
+              : isLocked
+                ? "Open the Freighter extension and unlock it with your password, then try again."
+                : "This app requires the Freighter browser extension to interact with the Stellar network."}
           </p>
 
           {!browser.supported && browser.name && (
@@ -70,21 +82,32 @@ export default function InstallFreighterModal({
           )}
 
           <div className="mt-6 space-y-3">
-            <a
-              href="https://www.freighter.app/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block w-full rounded-full bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
-            >
-              Install Freighter
-            </a>
+            {isLocked ? (
+              <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+                Freighter is locked. Open the extension in your browser toolbar, enter your
+                password, and then click the button below.
+              </div>
+            ) : (
+              <a
+                href="https://www.freighter.app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block w-full rounded-full bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-blue-700"
+              >
+                Install Freighter
+              </a>
+            )}
 
             <button
               onClick={handleRetry}
               disabled={checking}
               className="w-full rounded-full border border-zinc-300 px-4 py-3 text-sm font-medium text-zinc-700 transition hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800"
             >
-              {checking ? "Checking..." : "I installed it — check again"}
+              {checking
+                ? "Checking..."
+                : isLocked
+                  ? "I unlocked it — check again"
+                  : "I installed it — check again"}
             </button>
 
             {socialLogin}

--- a/src/components/WalletContext.tsx
+++ b/src/components/WalletContext.tsx
@@ -25,6 +25,7 @@ import {
   type SocialLoginProvider,
   type SocialWalletSession,
 } from "@/lib/socialWallet";
+import { isFreighterLockedError } from "@/utils/freighterErrors";
 import InstallFreighterModal from "./InstallFreighterModal";
 import SocialLoginButtons from "./SocialLoginButtons";
 
@@ -77,6 +78,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const [isWalletConnected, setIsWalletConnected] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [showInstallPrompt, setShowInstallPrompt] = useState(false);
+  const [isFreighterLocked, setIsFreighterLocked] = useState(false);
   const [walletNetworkWarning, setWalletNetworkWarning] = useState<string | null>(null);
   const [walletKind, setWalletKind] = useState<WalletKind | null>(null);
   const [socialProfile, setSocialProfile] = useState<SocialWalletSession | null>(null);
@@ -296,6 +298,12 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         return;
       }
       const key = await getAddress();
+      if (key.error && isFreighterLockedError(key.error)) {
+        setIsFreighterLocked(true);
+        setShowInstallPrompt(true);
+        setIsLoading(false);
+        return;
+      }
       const network = await getNetwork();
       if ((network.networkPassphrase || "") !== appNetworkPassphrase) {
         const warning = `Switch Freighter to ${appNetworkLabel} to continue. Current wallet network does not match the app network.`;
@@ -316,12 +324,17 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       setWalletKind("freighter");
       localStorage.setItem("stellar_wallet_public_key", key.address);
       showSuccess("Wallet connected successfully.");
-    } catch {
+    } catch (error) {
       setPublicKey(null);
       setIsWalletConnected(false);
       setWalletKind(null);
       setWalletNetworkWarning(null);
-      showError("Failed to connect wallet. Please try again.");
+      if (isFreighterLockedError(error)) {
+        setIsFreighterLocked(true);
+        setShowInstallPrompt(true);
+      } else {
+        showError("Failed to connect wallet. Please try again.");
+      }
     } finally {
       setIsLoading(false);
     }
@@ -362,11 +375,9 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const handleRetryInstall = async () => {
-    const installed = await isFreighterInstalled();
-    if (installed) {
-      setShowInstallPrompt(false);
-      connectWallet();
-    }
+    setShowInstallPrompt(false);
+    setIsFreighterLocked(false);
+    await connectWallet();
   };
 
   const disconnectWallet = () => {
@@ -432,8 +443,12 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       {children}
       <InstallFreighterModal
         isOpen={showInstallPrompt}
-        onClose={() => setShowInstallPrompt(false)}
+        onClose={() => {
+          setShowInstallPrompt(false);
+          setIsFreighterLocked(false);
+        }}
         onRetry={handleRetryInstall}
+        isLocked={isFreighterLocked}
         socialLogin={
           isSocialLoginConfigured() ? (
             <SocialLoginButtons

--- a/src/components/__tests__/WalletContext.test.tsx
+++ b/src/components/__tests__/WalletContext.test.tsx
@@ -170,6 +170,27 @@ describe("WalletContext", () => {
     expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
   });
 
+  it("connectWallet - freighter locked", async () => {
+    mockIsConnected.mockResolvedValue({ isConnected: true });
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ error: { message: "Freighter is locked" } });
+
+    renderWithProviders(
+      <WalletProvider>
+        <TestComponent />
+      </WalletProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Connect"));
+    });
+
+    expect(screen.getByText("Freighter Wallet Locked")).toBeInTheDocument();
+    expect(screen.queryByText("Freighter Wallet Required")).not.toBeInTheDocument();
+    expect(screen.getByText(/unlock it with your password/)).toBeInTheDocument();
+    expect(screen.getByTestId("isLoading")).toHaveTextContent("false");
+  });
+
   it("disconnectWallet", async () => {
     // Start with a connected wallet
     mockIsConnected.mockResolvedValue({ isConnected: true });

--- a/src/utils/freighterErrors.ts
+++ b/src/utils/freighterErrors.ts
@@ -1,9 +1,3 @@
-/**
- * Detects whether an error from Freighter's signTransaction represents
- * the user rejecting/cancelling the signature request, rather than a
- * genuine technical failure.
- */
-
 export class UserCancelledError extends Error {
   constructor() {
     super("Transaction cancelled");
@@ -35,4 +29,25 @@ export function wrapFreighterError(error: unknown): never {
     throw new UserCancelledError();
   }
   throw error;
+}
+
+export class FreighterLockedError extends Error {
+  constructor() {
+    super("Freighter is locked");
+    this.name = "FreighterLockedError";
+  }
+}
+
+const LOCKED_PATTERNS = [
+  "freighter is locked",
+  "wallet is locked",
+  "unlock your wallet",
+  "extension is locked",
+];
+
+export function isFreighterLockedError(error: unknown): boolean {
+  if (!error) return false;
+  const msg = typeof error === "string" ? error : ((error as Error).message ?? "");
+  const lower = msg.toLowerCase();
+  return LOCKED_PATTERNS.some((p) => lower.includes(p));
 }


### PR DESCRIPTION
## Summary

Closes #809

When Freighter is installed but locked (password-protected), the wallet connection flow previously showed the same "Install Freighter" modal as when the extension is not installed at all. This led to confusing guidance — users were told to install something they already had.

This PR detects the locked-wallet error distinctly and surfaces copy telling the user to unlock Freighter rather than reinstall it.

## Changes

### `src/utils/freighterErrors.ts`
- Added `FreighterLockedError` class
- Added `isFreighterLockedError(error)` — detects error messages matching patterns like `"freighter is locked"`, `"wallet is locked"`, `"unlock your wallet"`, `"extension is locked"`

### `src/components/InstallFreighterModal.tsx`
- Added optional `isLocked` prop (default `false`)
- When locked:
  - Heading: **"Freighter Wallet Locked"** (vs *"Freighter Wallet Required"*)
  - Body: instructs user to unlock Freighter with their password
  - Amber info box replaces the "Install Freighter" CTA link
  - Retry button: **"I unlocked it — check again"**

### `src/components/WalletContext.tsx`
- Added `isFreighterLocked` state
- After `getAddress()` returns, checks `key.error` for locked patterns (Freighter API v6 returns error objects, not thrown exceptions)
- Also checks the `catch` block for thrown locked errors
- When locked: shows the modal with `isLocked=true` instead of the generic error toast
- `handleRetryInstall` simplified — closes modal, resets locked flag, calls `connectWallet()` which re-opens in the correct mode if still locked

### `src/components/__tests__/WalletContext.test.tsx`
- Added `"connectWallet - freighter locked"` test — mocks `getAddress` to return `{ error: { message: "Freighter is locked" } }`, verifies locked-specific heading and unlock guidance appear

## Flow

| Scenario | Before | After |
|---|---|---|
| **Not installed** | Modal: "Freighter Wallet Required" + Install link | Same (unchanged) |
| **Installed & locked** | Modal: "Freighter Wallet Required" + Install link | Modal: "Freighter Wallet Locked" + unlock guidance |
| **Installed & unlocked** | Connection succeeds | Same (unchanged) |