### PR TITLE
fix: repair the botched #771 merge that broke CI on main

### DIFF
--- a/PRE_COMMIT_SETUP.md
+++ b/PRE_COMMIT_SETUP.md
@@ -36,8 +36,6 @@ Extended pre-commit hook to run typecheck and affected tests.
   - Performance tips
   - Troubleshooting
 
-
-
 ## How It Works
 
 ### 1. Get Staged Files

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ To keep our translation files clean, you can run the unused keys script to find 
 ```bash
 node scripts/find-unused-i18n-keys.js
 ```
+
 This script will output a report of keys present in `messages/en.json` but never referenced in `src/`.
 
 ## 🐳 Docker Support

--- a/messages/en.json
+++ b/messages/en.json
@@ -566,5 +566,27 @@
     "opening": "Opening secure checkout…",
     "error": "Could not open the payment provider. Please try again.",
     "poweredBy": "Powered by {provider}"
+  },
+  "Notifications": {
+    "title": "Notifications",
+    "unreadLabel_one": "Notifications, {count} unread",
+    "unreadLabel_other": "Notifications, {count} unread",
+    "markAllRead": "Mark all as read",
+    "noNotifications": "No notifications yet.",
+    "connectWallet": "Connect your wallet to see notifications.",
+    "viewDetails": "View details",
+    "justNow": "Just now",
+    "mAgo_one": "{count} minute ago",
+    "mAgo_other": "{count} minutes ago",
+    "hAgo_one": "{count} hour ago",
+    "hAgo_other": "{count} hours ago",
+    "dAgo_one": "{count} day ago",
+    "dAgo_other": "{count} days ago",
+    "settingsAriaLabel": "Notification settings",
+    "settingsTitle": "Notify me about",
+    "prefContributions": "Contributions to my campaigns",
+    "prefVerified": "When my campaign is verified",
+    "prefRefundAvailable": "When a refund becomes available",
+    "prefRevenueDeposited": "When revenue is deposited"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -566,5 +566,27 @@
     "opening": "Abriendo el pago seguro…",
     "error": "No se pudo abrir el proveedor de pago. Inténtalo de nuevo.",
     "poweredBy": "Con la tecnología de {provider}"
+  },
+  "Notifications": {
+    "title": "Notificaciones",
+    "unreadLabel_one": "Notificaciones, {count} sin leer",
+    "unreadLabel_other": "Notificaciones, {count} sin leer",
+    "markAllRead": "Marcar todas como leídas",
+    "noNotifications": "Aún no hay notificaciones.",
+    "connectWallet": "Conecta tu billetera para ver las notificaciones.",
+    "viewDetails": "Ver detalles",
+    "justNow": "Ahora mismo",
+    "mAgo_one": "hace {count} minuto",
+    "mAgo_other": "hace {count} minutos",
+    "hAgo_one": "hace {count} hora",
+    "hAgo_other": "hace {count} horas",
+    "dAgo_one": "hace {count} día",
+    "dAgo_other": "hace {count} días",
+    "settingsAriaLabel": "Configuración de notificaciones",
+    "settingsTitle": "Notificarme sobre",
+    "prefContributions": "Contribuciones a mis campañas",
+    "prefVerified": "Cuando se verifique mi campaña",
+    "prefRefundAvailable": "Cuando haya un reembolso disponible",
+    "prefRevenueDeposited": "Cuando se deposite un ingreso"
   }
 }

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -1,18 +1,18 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const messagesDir = path.join(__dirname, '../messages');
-const srcDir = path.join(__dirname, '../src');
+const messagesDir = path.join(__dirname, "../messages");
+const srcDir = path.join(__dirname, "../src");
 
-function getAllKeys(obj, prefix = '') {
+function getAllKeys(obj, prefix = "") {
   return Object.keys(obj).reduce((acc, key) => {
     const value = obj[key];
     const newKey = prefix ? `${prefix}.${key}` : key;
-    if (typeof value === 'object' && value !== null) {
+    if (typeof value === "object" && value !== null) {
       acc.push(...getAllKeys(value, newKey));
     } else {
       acc.push(newKey);
@@ -36,19 +36,19 @@ function getAllFiles(dir, files = []) {
 }
 
 function checkUnusedKeys() {
-  const enPath = path.join(messagesDir, 'en.json');
-  const enObj = JSON.parse(fs.readFileSync(enPath, 'utf8'));
+  const enPath = path.join(messagesDir, "en.json");
+  const enObj = JSON.parse(fs.readFileSync(enPath, "utf8"));
   const allKeys = getAllKeys(enObj);
 
   const files = getAllFiles(srcDir);
-  const fileContents = files.map((f) => fs.readFileSync(f, 'utf8')).join('\n');
+  const fileContents = files.map((f) => fs.readFileSync(f, "utf8")).join("\n");
 
   const unusedKeys = [];
 
   for (const fullKey of allKeys) {
-    const parts = fullKey.split('.');
+    const parts = fullKey.split(".");
     const key = parts[parts.length - 1];
-    const namespace = parts.length > 1 ? parts[0] : '';
+    const namespace = parts.length > 1 ? parts[0] : "";
 
     // Check if the key appears in the source code
     // It could be t('key') or t("key") or next-intl dynamic keys
@@ -61,17 +61,17 @@ function checkUnusedKeys() {
   }
 
   // Filter out known dynamic keys to avoid false positives
-  const knownDynamicPrefixes = ['step_'];
+  const knownDynamicPrefixes = ["step_"];
   const filteredUnused = unusedKeys.filter((k) => {
-    const key = k.split('.').pop();
+    const key = k.split(".").pop();
     return !knownDynamicPrefixes.some((prefix) => key.startsWith(prefix));
   });
 
   if (filteredUnused.length > 0) {
-    console.warn('⚠️  Potentially unused translation keys found:');
+    console.warn("⚠️  Potentially unused translation keys found:");
     filteredUnused.forEach((k) => console.warn(`  - ${k}`));
   } else {
-    console.log('✅ No unused translation keys detected.');
+    console.log("✅ No unused translation keys detected.");
   }
 }
 

--- a/scripts/find-unused-i18n-keys.js
+++ b/scripts/find-unused-i18n-keys.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 function getFiles(dir, fileList = []) {
   const files = fs.readdirSync(dir);
@@ -14,10 +14,10 @@ function getFiles(dir, fileList = []) {
   return fileList;
 }
 
-function flattenKeys(obj, prefix = '') {
+function flattenKeys(obj, prefix = "") {
   return Object.keys(obj).reduce((acc, k) => {
-    const pre = prefix.length ? prefix + '.' : '';
-    if (typeof obj[k] === 'object' && obj[k] !== null) {
+    const pre = prefix.length ? prefix + "." : "";
+    if (typeof obj[k] === "object" && obj[k] !== null) {
       Object.assign(acc, flattenKeys(obj[k], pre + k));
     } else {
       acc[pre + k] = obj[k];
@@ -27,36 +27,36 @@ function flattenKeys(obj, prefix = '') {
 }
 
 function findUnusedKeys() {
-  const messagesPath = path.join(__dirname, '../messages/en.json');
-  const srcPath = path.join(__dirname, '../src');
+  const messagesPath = path.join(__dirname, "../messages/en.json");
+  const srcPath = path.join(__dirname, "../src");
 
   if (!fs.existsSync(messagesPath)) {
-    console.error('en.json not found at', messagesPath);
+    console.error("en.json not found at", messagesPath);
     process.exit(1);
   }
 
-  const enJson = JSON.parse(fs.readFileSync(messagesPath, 'utf8'));
+  const enJson = JSON.parse(fs.readFileSync(messagesPath, "utf8"));
   const flatKeys = flattenKeys(enJson);
   const keys = Object.keys(flatKeys);
-  
+
   const files = getFiles(srcPath);
-  const fileContents = files.map(f => fs.readFileSync(f, 'utf8'));
+  const fileContents = files.map((f) => fs.readFileSync(f, "utf8"));
 
   const unusedKeys = [];
 
   for (const key of keys) {
-    const parts = key.split('.');
+    const parts = key.split(".");
     const leaf = parts[parts.length - 1];
-    
+
     // Check if the leaf key or the full key is present in any file.
-    let isUsed = fileContents.some(content => content.includes(leaf) || content.includes(key));
+    let isUsed = fileContents.some((content) => content.includes(leaf) || content.includes(key));
 
     // Heuristic for dynamic keys (like step_connect_title or level_Bronze)
     // If the exact leaf is not found, check if its underscore-separated parts are all present in a single file
-    if (!isUsed && leaf.includes('_')) {
-      const leafParts = leaf.split('_');
-      isUsed = fileContents.some(content => {
-        return leafParts.every(p => content.includes(p));
+    if (!isUsed && leaf.includes("_")) {
+      const leafParts = leaf.split("_");
+      isUsed = fileContents.some((content) => {
+        return leafParts.every((p) => content.includes(p));
       });
     }
 
@@ -67,11 +67,13 @@ function findUnusedKeys() {
 
   if (unusedKeys.length > 0) {
     console.log(`Found ${unusedKeys.length} potentially unused i18n keys:\n`);
-    unusedKeys.forEach(k => console.log(`- ${k}`));
-    console.log('\nNote: Some dynamic keys might be incorrectly flagged if they are constructed in complex ways.');
+    unusedKeys.forEach((k) => console.log(`- ${k}`));
+    console.log(
+      "\nNote: Some dynamic keys might be incorrectly flagged if they are constructed in complex ways.",
+    );
     // Don't exit with error code so it doesn't fail CI if wired later
   } else {
-    console.log('No unused i18n keys found! 🎉');
+    console.log("No unused i18n keys found! 🎉");
   }
 }
 

--- a/src/__tests__/components/CauseCard.test.tsx
+++ b/src/__tests__/components/CauseCard.test.tsx
@@ -37,15 +37,33 @@ jest.mock("@/components/DeadlineCountdown", () => ({
   default: () => <span data-testid="deadline-countdown" />,
 }));
 
+const mockToggleSaved = jest.fn<void, [number]>();
+const mockIsSaved = jest.fn<boolean, [number]>(() => false);
+
 jest.mock("@/hooks/useSavedCampaigns", () => ({
-  useSavedCampaigns: () => ({ isSaved: () => false, toggleSaved: jest.fn(), savedIds: [] }),
+  useSavedCampaigns: () => ({
+    isSaved: (id: number) => mockIsSaved(id),
+    toggleSaved: (id: number) => mockToggleSaved(id),
+    savedIds: [],
+  }),
 }));
+
+const mockShowError = jest.fn();
+const mockShowWarning = jest.fn();
 
 jest.mock("@/components/ToastProvider", () => ({
   useToast: () => ({
-    showError: jest.fn(),
+    showError: (msg: string) => mockShowError(msg),
+    showWarning: (msg: string) => mockShowWarning(msg),
   }),
 }));
+
+beforeEach(() => {
+  mockToggleSaved.mockClear();
+  mockIsSaved.mockClear().mockReturnValue(false);
+  mockShowError.mockClear();
+  mockShowWarning.mockClear();
+});
 
 jest.mock("@/components/cancelCampaignModal", () => ({
   __esModule: true,
@@ -353,6 +371,23 @@ describe("static card content", () => {
     expect(screen.getByText("Helping the world.")).toBeInTheDocument();
   });
 
+  it("trims surrounding whitespace from the description", () => {
+    renderCard(makeCampaign({ description: "   Helping the world.\n" }));
+    expect(screen.getByTestId("campaign-description")).toHaveTextContent("Helping the world.");
+  });
+
+  // #645 — a description that renders as blank space leaves the same awkward
+  // gap as a missing one, so both fall back to the placeholder.
+  it.each([
+    ["empty", ""],
+    ["whitespace only", "   \n\t "],
+    ["markdown punctuation with no words", "---"],
+  ])("shows the fallback when the description is %s", (_label, description) => {
+    renderCard(makeCampaign({ description }));
+    expect(screen.getByTestId("campaign-description-fallback")).toBeInTheDocument();
+    expect(screen.queryByTestId("campaign-description")).not.toBeInTheDocument();
+  });
+
   it("renders a truncated creator address", () => {
     renderCard(makeCampaign({ creator: "GABCDE123456789WXYZ" }));
     // formatAddress keeps first 6 and last 4 chars
@@ -362,5 +397,65 @@ describe("static card content", () => {
   it("renders the status badge", () => {
     renderCard(makeCampaign({ status: "funded" }));
     expect(screen.getByTestId("status-badge")).toHaveTextContent("funded");
+  });
+
+  it("renders the cover image when the campaign has one", () => {
+    renderCard(makeCampaign({ cover_image_url: "https://example.com/cover.png", title: "Cover" }));
+    expect(screen.getByAltText("Cover")).toBeInTheDocument();
+  });
+
+  it("falls back to the category icon when there is no cover image", () => {
+    renderCard(makeCampaign({ cover_image_url: "", category: Category.Learner }));
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});
+
+// ── Save button ───────────────────────────────────────────────────────────────
+
+describe("save button", () => {
+  it("warns instead of saving when no wallet is connected", () => {
+    renderCard(makeCampaign(), null);
+    fireEvent.click(screen.getByTitle("Save campaign"));
+    expect(mockShowWarning).toHaveBeenCalledWith("Please connect your wallet to save campaigns.");
+    expect(mockToggleSaved).not.toHaveBeenCalled();
+  });
+
+  it("toggles the campaign when a wallet is connected", () => {
+    renderCard(makeCampaign({ id: 7 }), "GSOMEWALLET");
+    fireEvent.click(screen.getByTitle("Save campaign"));
+    expect(mockToggleSaved).toHaveBeenCalledWith(7);
+    expect(mockShowWarning).not.toHaveBeenCalled();
+  });
+
+  it('reads "Remove from saved" once the campaign is saved', () => {
+    mockIsSaved.mockReturnValue(true);
+    renderCard(makeCampaign(), "GSOMEWALLET");
+    expect(screen.getByTitle("Remove from saved")).toBeInTheDocument();
+  });
+});
+
+// ── Async action failures ─────────────────────────────────────────────────────
+
+describe("action error handling", () => {
+  it("surfaces an error when voting fails", async () => {
+    const onVote = jest.fn(() => Promise.reject(new Error("vote exploded")));
+    renderCard(makeCampaign({ status: "active" }), CONTRIBUTOR, { onVote });
+    fireEvent.click(screen.getByTestId("voting-component"));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+  });
+
+  it("surfaces an error when cancelling fails", async () => {
+    const onCancel = jest.fn(() => Promise.reject(new Error("cancel exploded")));
+    renderCard(makeCampaign({ status: "active" }), CREATOR, { onCancel });
+    fireEvent.click(screen.getByRole("button", { name: /cancel campaign/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm cancel/i }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+  });
+
+  it("surfaces an error when claiming a refund fails", async () => {
+    const onClaimRefund = jest.fn(() => Promise.reject(new Error("refund exploded")));
+    renderCard(makeCampaign({ status: "cancelled" }), CONTRIBUTOR, { onClaimRefund });
+    fireEvent.click(screen.getByRole("button", { name: /claim refund/i }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalled());
   });
 });

--- a/src/__tests__/hooks/usePlatformFee.test.tsx
+++ b/src/__tests__/hooks/usePlatformFee.test.tsx
@@ -1,7 +1,11 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { usePlatformFee, DEFAULT_PLATFORM_FEE_BPS, PLATFORM_FEE_QUERY_KEY } from "@/hooks/usePlatformFee";
+import {
+  usePlatformFee,
+  DEFAULT_PLATFORM_FEE_BPS,
+  PLATFORM_FEE_QUERY_KEY,
+} from "@/hooks/usePlatformFee";
 
 jest.mock("@/lib/contractClient", () => ({
   getPlatformFee: jest.fn(),

--- a/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
+++ b/src/app/[locale]/causes/[id]/CauseDetailClient.tsx
@@ -1,23 +1,3 @@
-'use client';
-
-import Link from 'next/link';
-import { useState, useEffect } from 'react';
-import CampaignActions from '@/components/CampaignActions';
-import CampaignDescription from '@/components/CampaignDescription';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
-import CampaignStatusBadge from '@/components/CampaignStatusBadge';
-import DeadlineCountdown from '@/components/DeadlineCountdown';
-import DonationModal from '@/components/DonationModal';
-import FundingProgressBar from '@/components/FundingProgressBar';
-import RevenueSharingPanel from '@/components/RevenueSharingPanel';
-import UpdatesSection from '@/components/UpdatesSection';
-import { useToast } from '@/components/ToastProvider';
-import VotingComponent from '@/components/VotingComponent';
-import { useWallet } from '@/components/WalletContext';
-import { useCampaign } from '@/hooks/useCampaign';
-import { usePlatformFee } from '@/hooks/usePlatformFee';
 "use client";
 
 import Link from "next/link";
@@ -60,21 +40,6 @@ import {
   verifyCampaignWithVotes,
   getContribution,
   claimRefund,
-} from '@/lib/contractClient';
-import VotingComponent from '@/components/VotingComponent';
-import CampaignStatusBadge from '@/components/CampaignStatusBadge';
-import DeadlineCountdown from '@/components/DeadlineCountdown';
-import FundingProgressBar from '@/components/FundingProgressBar';
-import { useWallet } from '@/components/WalletContext';
-import CampaignActions from '@/components/CampaignActions';
-import RevenueSharingPanel from '@/components/RevenueSharingPanel';
-import DonationModal from '@/components/DonationModal';
-import { Campaign, Vote, CATEGORY_LABELS, stroopsToXlm } from '@/types';
-import { parseContractError } from '@/utils/contractErrors';
-
-function formatDate(ts: number) {
-  return new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' }).format(new Date(ts * 1000));
-}
   cancelCampaign,
 } from "@/lib/contractClient";
 import { useTranslations, useLocale } from "next-intl";
@@ -363,12 +328,6 @@ export default function CauseDetailClient({ id }: { id: string }) {
                 </span>
                 <CampaignStatusBadge campaign={campaign} />
               </div>
-              <h1 className="text-2xl sm:text-3xl font-bold text-zinc-900 dark:text-zinc-50 mb-4 leading-tight">{campaign.title}</h1>
-              <CampaignDescription description={campaign.description}>
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
-                  {campaign.description}
-                </ReactMarkdown>
-              </CampaignDescription>
               {campaign.cover_image_url && (
                 <div className="relative w-full aspect-video rounded-lg overflow-hidden mb-4 bg-zinc-100 dark:bg-zinc-700">
                   <Image

--- a/src/components/CampaignMap.tsx
+++ b/src/components/CampaignMap.tsx
@@ -86,9 +86,7 @@ export default function CampaignMap({ campaigns }: CampaignMapProps) {
         <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50 mb-2">
           {t("emptyTitle")}
         </h3>
-        <p className="text-zinc-600 dark:text-zinc-400 max-w-md">
-          {t("emptyBody")}
-        </p>
+        <p className="text-zinc-600 dark:text-zinc-400 max-w-md">{t("emptyBody")}</p>
       </div>
     );
   }

--- a/src/components/CancelDonationBanner.tsx
+++ b/src/components/CancelDonationBanner.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import { PendingDonation } from '../hooks/useDonationGracePeriod';
+import React, { useState, useEffect } from "react";
+import { PendingDonation } from "../hooks/useDonationGracePeriod";
 
 interface CancelDonationBannerProps {
   pendingDonations: PendingDonation[];
@@ -31,10 +31,7 @@ export function CancelDonationBanner({
       className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-md w-full px-4"
     >
       {pendingDonations.map((donation) => {
-        const remainingSeconds = Math.max(
-          0,
-          Math.ceil((donation.expiresAt - Date.now()) / 1000)
-        );
+        const remainingSeconds = Math.max(0, Math.ceil((donation.expiresAt - Date.now()) / 1000));
 
         return (
           <div

--- a/src/components/CauseCard.tsx
+++ b/src/components/CauseCard.tsx
@@ -1,14 +1,5 @@
 "use client";
 
-import { memo, useState } from 'react';
-import { formatAddress } from '@/lib/formatAddress';
-import { Campaign, Vote, CATEGORY_LABELS } from '../types';
-import CampaignDescription from './CampaignDescription';
-import CampaignStatusBadge from './CampaignStatusBadge';
-import CancelCampaignModal from './cancelCampaignModal';
-import DeadlineCountdown from './DeadlineCountdown';
-import FundingProgressBar from './FundingProgressBar';
-import VotingComponent from './VotingComponent';
 import Image from "next/image";
 import { memo, useState } from "react";
 import { Bookmark } from "lucide-react";
@@ -20,6 +11,7 @@ import { parseContractError } from "@/utils/contractErrors";
 import { Campaign, Vote, CATEGORY_LABELS, calculateFundingPercentage } from "../types";
 import Amount from "./Amount";
 import AsyncButtonContent from "./AsyncButtonContent";
+import CampaignDescription from "./CampaignDescription";
 import CampaignStatusBadge from "./CampaignStatusBadge";
 import CancelCampaignModal from "./cancelCampaignModal";
 import DeadlineCountdown from "./DeadlineCountdown";
@@ -50,7 +42,6 @@ const CATEGORY_ICONS: Record<string, string> = {
 function formatDate(ts: number, locale: string) {
   return formatShortDate(ts, locale);
 }
-
 
 function CauseCard({
   campaign,
@@ -177,10 +168,10 @@ function CauseCard({
         </h3>
 
         {/* Description */}
-        <CampaignDescription description={campaign.description} />
-        <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-3 leading-relaxed break-words h-[4.5rem]">
-          {campaign.description}
-        </p>
+        <CampaignDescription
+          description={campaign.description}
+          className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-3 leading-relaxed break-words h-[4.5rem]"
+        />
 
         {/* Funding progress */}
         <div className="space-y-1.5">
@@ -298,7 +289,6 @@ function CauseCard({
  * global state changes (#648). Cards are rendered in long lists, so this is
  * where an unnecessary render is most expensive.
  */
-export default memo(CauseCard);
 function causeCardPropsAreEqual(prev: CauseCardProps, next: CauseCardProps): boolean {
   const prevCampaign = prev.campaign;
   const nextCampaign = next.campaign;

--- a/src/components/ContributorLeaderboard.tsx
+++ b/src/components/ContributorLeaderboard.tsx
@@ -85,9 +85,7 @@ export default function ContributorLeaderboard({
 
       {contributors.length === 0 ? (
         <div className="text-center py-6 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            {t("emptyMessage")}
-          </p>
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">{t("emptyMessage")}</p>
         </div>
       ) : (
         <ul className="space-y-2.5" aria-label="Top supporters list">
@@ -113,7 +111,9 @@ export default function ContributorLeaderboard({
                     <p className="font-mono text-zinc-800 dark:text-zinc-200 truncate flex items-center gap-1.5">
                       <span>{item.truncatedAddress}</span>
                       {(() => {
-                        const amountXlm = item.totalAmountStroops ? Number(item.totalAmountStroops) / 10_000_000 : 0;
+                        const amountXlm = item.totalAmountStroops
+                          ? Number(item.totalAmountStroops) / 10_000_000
+                          : 0;
                         const profile = calculateGamificationProfile(amountXlm);
                         return (
                           <span className="px-1.5 py-0.5 rounded bg-rose-500/10 text-rose-600 dark:text-rose-400 text-[10px] font-sans font-medium border border-rose-500/20">
@@ -164,9 +164,7 @@ export default function ContributorLeaderboard({
 
         <p className="text-[11px] text-zinc-400 dark:text-zinc-500 leading-tight flex items-start gap-1">
           <ShieldCheck className="w-3.5 h-3.5 text-zinc-400 shrink-0 mt-0.5" />
-          <span>
-            {t("optOutTooltip")}
-          </span>
+          <span>{t("optOutTooltip")}</span>
         </p>
       </div>
     </div>

--- a/src/components/DonationModal.tsx
+++ b/src/components/DonationModal.tsx
@@ -11,11 +11,7 @@ import { useToast } from "./ToastProvider";
 import { useWallet } from "./WalletContext";
 import { usePlatformFee } from "../hooks/usePlatformFee";
 import { parseContractError } from "../utils/contractErrors";
-import {
-  INTERVAL_LABELS,
-  RecurringInterval,
-  createSchedule,
-} from "../lib/recurringDonations";
+import { INTERVAL_LABELS, RecurringInterval, createSchedule } from "../lib/recurringDonations";
 
 const EXPLORER_BASE =
   process.env.NEXT_PUBLIC_EXPLORER_URL ?? "https://stellar.expert/explorer/testnet/tx";
@@ -259,8 +255,15 @@ export default function DonationModal({
     trackReviewContribution(campaign.id);
 
     try {
-      const stroops = xlmToStroops(amountNum);
-      const hash = await contribute(campaign.id, publicKey, stroops);
+      const stroops = xlmToStroops(amountToSend);
+      const hash = await contribute(campaign.id, publicKey, stroops, {
+        onStatus: ({ phase }) => {
+          setTxPhase(phase);
+          if (phase === "signing") {
+            trackSignTransaction(campaign.id);
+          }
+        },
+      });
 
       // Only record the schedule once this cycle actually settled, so a failed
       // donation never leaves a subscription behind.
@@ -274,15 +277,6 @@ export default function DonationModal({
         });
       }
 
-      const stroops = xlmToStroops(amountToSend);
-      const hash = await contribute(campaign.id, publicKey, stroops, {
-        onStatus: ({ phase }) => {
-          setTxPhase(phase);
-          if (phase === "signing") {
-            trackSignTransaction(campaign.id);
-          }
-        },
-      });
       setTxHash(hash);
       setStep("confirmed");
       trackContributionConfirmed(campaign.id);
@@ -529,8 +523,8 @@ export default function DonationModal({
                 </p>
                 {isRecurring && (
                   <p className="text-sm text-blue-600 dark:text-blue-400 mt-2">
-                    {INTERVAL_LABELS[recurringInterval]} donation set up. We&apos;ll remind you when the
-                    next one is due.
+                    {INTERVAL_LABELS[recurringInterval]} donation set up. We&apos;ll remind you when
+                    the next one is due.
                   </p>
                 )}
                 <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">{t("thankYou")}</p>

--- a/src/components/DonatorBadges.tsx
+++ b/src/components/DonatorBadges.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import React from 'react';
-import { calculateGamificationProfile } from '../lib/gamification';
-import { useTranslations } from 'next-intl';
+import React from "react";
+import { calculateGamificationProfile } from "../lib/gamification";
+import { useTranslations } from "next-intl";
 
 interface DonatorBadgesProps {
   totalDonated: number;
@@ -15,8 +15,8 @@ export function DonatorBadges({
   donationCount = 0,
   isEarlyBacker = false,
 }: DonatorBadgesProps) {
-  const t = useTranslations('DonatorBadges');
-  const tGamification = useTranslations('Gamification');
+  const t = useTranslations("DonatorBadges");
+  const tGamification = useTranslations("Gamification");
   const profile = calculateGamificationProfile(totalDonated, donationCount, isEarlyBacker);
 
   return (
@@ -26,7 +26,10 @@ export function DonatorBadges({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-rose-500/20 text-rose-400 border border-rose-500/30">
-              {t("level", { levelNumber: profile.levelNumber, levelName: tGamification(`level_${profile.levelId}`) })}
+              {t("level", {
+                levelNumber: profile.levelNumber,
+                levelName: tGamification(`level_${profile.levelId}`),
+              })}
             </span>
             <span className="text-xs text-slate-400">
               {t("totalXlm", { amount: profile.totalDonated })}
@@ -60,14 +63,14 @@ export function DonatorBadges({
               className={`flex items-center gap-2.5 p-2.5 rounded-xl border transition-all ${
                 badge.unlocked
                   ? `${badge.color} shadow-sm`
-                  : 'bg-slate-900/40 text-slate-500 border-slate-800/60 opacity-60'
+                  : "bg-slate-900/40 text-slate-500 border-slate-800/60 opacity-60"
               }`}
             >
               <span className="text-xl leading-none">{badge.icon}</span>
               <div className="flex flex-col min-w-0">
                 <span className="text-xs font-semibold truncate">{tGamification(badge.name)}</span>
                 <span className="text-[10px] text-slate-400 truncate">
-                  {badge.unlocked ? tGamification(badge.description) : tGamification('locked')}
+                  {badge.unlocked ? tGamification(badge.description) : tGamification("locked")}
                 </span>
               </div>
             </div>

--- a/src/components/DonorBadges.tsx
+++ b/src/components/DonorBadges.tsx
@@ -26,7 +26,11 @@ function DonorBadges({ donations, variant = "full" }: DonorBadgesProps) {
           {progress.current.icon} {progress.current.name}
         </span>
         {badges.map((badge) => (
-          <span key={badge.id} title={`${badge.label}: ${badge.description}`} aria-label={badge.label}>
+          <span
+            key={badge.id}
+            title={`${badge.label}: ${badge.description}`}
+            aria-label={badge.label}
+          >
             {badge.icon}
           </span>
         ))}

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -26,12 +26,15 @@ export default function NotificationSettings() {
     [publicKey],
   );
 
-  const PREF_LABELS: Record<keyof NotificationPreferences, string> = useMemo(() => ({
-    contributions: t("prefContributions"),
-    verified: t("prefVerified"),
-    refundAvailable: t("prefRefundAvailable"),
-    revenueDeposited: t("prefRevenueDeposited"),
-  }), [t]);
+  const PREF_LABELS: Record<keyof NotificationPreferences, string> = useMemo(
+    () => ({
+      contributions: t("prefContributions"),
+      verified: t("prefVerified"),
+      refundAvailable: t("prefRefundAvailable"),
+      revenueDeposited: t("prefRevenueDeposited"),
+    }),
+    [t],
+  );
   const [localPrefs, setLocalPrefs] = useState<NotificationPreferences | null>(null);
 
   const prefs = localPrefs ?? storedPrefs;

--- a/src/components/RecentActivityFeed.tsx
+++ b/src/components/RecentActivityFeed.tsx
@@ -31,7 +31,7 @@ export default function RecentActivityFeed() {
     .map((c) => ({
       id: c.id,
       label: `New cause: ${c.title}`,
-      raised: c.amount_raised ?? c.raised_amount ?? BigInt(0),
+      raised: c.amount_raised ?? BigInt(0),
     }));
 
   useEffect(() => {
@@ -75,9 +75,7 @@ export default function RecentActivityFeed() {
               aria-label={`Activity ${i + 1}`}
               onClick={() => setActiveIndex(i)}
               className={`w-1.5 h-1.5 rounded-full transition-colors ${
-                i === activeIndex
-                  ? "bg-zinc-700 dark:bg-zinc-200"
-                  : "bg-zinc-300 dark:bg-zinc-600"
+                i === activeIndex ? "bg-zinc-700 dark:bg-zinc-200" : "bg-zinc-300 dark:bg-zinc-600"
               }`}
             />
           ))}

--- a/src/components/ThirdPartyScripts.tsx
+++ b/src/components/ThirdPartyScripts.tsx
@@ -43,12 +43,14 @@ export default function ThirdPartyScripts() {
         // thread before hydration — exactly the problem this component exists to
         // solve. Any misconfigured entry is demoted to `lazyOnload` at runtime
         // and flagged in the dev console so it can be fixed in thirdParty.ts.
+        // `ScriptStrategy` already excludes it, so the compare is widened to
+        // `string` to keep the runtime check for config that bypasses the type.
         const safeStrategy =
-          strategy === "beforeInteractive"
+          (strategy as string) === "beforeInteractive"
             ? (process.env.NODE_ENV !== "production" &&
                 console.warn(
                   `[ThirdPartyScripts] Script "${id}" uses "beforeInteractive" which blocks` +
-                    ` the main thread. Downgraded to "lazyOnload". Fix the strategy in thirdParty.ts.`
+                    ` the main thread. Downgraded to "lazyOnload". Fix the strategy in thirdParty.ts.`,
                 ),
               "lazyOnload" as const)
             : strategy;

--- a/src/components/WalletContext.tsx
+++ b/src/components/WalletContext.tsx
@@ -459,7 +459,7 @@ export const useWallet = () => {
   const actions = useContext(WalletActionsContext);
   const value = useMemo(
     () => (state && actions ? { ...state, ...actions } : null),
-    [state, actions]
+    [state, actions],
   );
   if (!value) throw new Error("useWallet must be used within a WalletProvider");
   return value;

--- a/src/components/WalletContext.tsx
+++ b/src/components/WalletContext.tsx
@@ -1,17 +1,15 @@
 "use client";
-import { getAddress, isConnected, isAllowed } from "@stellar/freighter-api";
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  ReactNode,
-} from "react";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { getAddress, getNetwork, isConnected, isAllowed } from "@stellar/freighter-api";
-import React, { createContext, useContext, useEffect, useState, useMemo, ReactNode, useRef } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useMemo,
+  ReactNode,
+  useRef,
+} from "react";
 import { useToast } from "./ToastProvider";
 import { useQueryClient } from "@tanstack/react-query";
 import { IS_MOCK_MODE } from "@/lib/runtimeEnv";
@@ -35,8 +33,8 @@ import SocialLoginButtons from "./SocialLoginButtons";
  * consumer — including components that only ever call `connectWallet` and never
  * read state. Splitting means:
  *
- *   - `useWalletState()`   re-renders when publicKey / connected / loading change
- *   - `useWalletActions()` never re-renders: the value is created once
+ *   - `useWalletState()`   re-renders when connection state changes
+ *   - `useWalletActions()` re-renders only when an action identity changes
  *
  * Both values are memoized, so a re-render of `WalletProvider` itself does not
  * cascade into consumers unless the data they read actually changed.
@@ -45,19 +43,7 @@ import SocialLoginButtons from "./SocialLoginButtons";
 interface WalletState {
   publicKey: string | null;
   isWalletConnected: boolean;
-  isLoading: boolean;
-}
-
-interface WalletActions {
-  connectWallet: () => Promise<void>;
-  disconnectWallet: () => void;
-}
-
-const WalletStateContext = createContext<WalletState | undefined>(undefined);
-const WalletActionsContext = createContext<WalletActions | undefined>(undefined);
   walletNetworkWarning: string | null;
-  connectWallet: () => Promise<void>;
-  disconnectWallet: () => void;
   isLoading: boolean;
   /** Which wallet backs the current session — null when disconnected. */
   walletKind: WalletKind | null;
@@ -65,12 +51,18 @@ const WalletActionsContext = createContext<WalletActions | undefined>(undefined)
   socialProfile: SocialWalletSession | null;
   /** Whether social login is available (a Web3Auth client id is configured). */
   isSocialLoginAvailable: boolean;
+}
+
+interface WalletActions {
+  connectWallet: () => Promise<void>;
+  disconnectWallet: () => void;
   connectWithSocial: (provider: SocialLoginProvider) => Promise<void>;
 }
 
 const MOCK_PUBLIC_KEY = IS_MOCK_MODE ? StellarSdk.Keypair.random().publicKey() : null;
 
-const WalletContext = createContext<WalletContextType | undefined>(undefined);
+const WalletStateContext = createContext<WalletState | undefined>(undefined);
+const WalletActionsContext = createContext<WalletActions | undefined>(undefined);
 
 export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const [publicKey, setPublicKey] = useState<string | null>(null);
@@ -94,7 +86,6 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       ? "Testnet"
       : "the app network";
 
-  const checkWalletConnection = useCallback(async () => {
   useEffect(() => {
     if (IS_MOCK_MODE) {
       const storedKey =
@@ -258,14 +249,9 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     } catch {
       return false;
     }
-  }, []);
+  };
 
-  useEffect(() => {
-    // Always re-verify with Freighter rather than blindly trusting localStorage (#97)
-    checkWalletConnection();
-  }, [checkWalletConnection]);
-
-  const connectWallet = useCallback(async () => {
+  const connectWallet = async () => {
     setIsLoading(true);
     try {
       if (IS_MOCK_MODE) {
@@ -325,9 +311,8 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     } finally {
       setIsLoading(false);
     }
-  }, [showError, showSuccess, showWarning]);
+  };
 
-  const disconnectWallet = useCallback(() => {
   /**
    * #649 — Create or restore an embedded wallet from a Google or X account, so
    * visitors without a browser extension can still contribute.
@@ -396,56 +381,51 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     showWarning(
       "Disconnected. To fully revoke Freighter access, open the extension and remove this site from Connected Sites.",
     );
-  }, [showWarning]);
+  };
 
   const state = useMemo<WalletState>(
-    () => ({ publicKey, isWalletConnected, isLoading }),
-    [publicKey, isWalletConnected, isLoading]
-  );
-
-  const actions = useMemo<WalletActions>(
-    () => ({ connectWallet, disconnectWallet }),
-    [connectWallet, disconnectWallet]
-  );
-
-  const contextValue = useMemo(
     () => ({
       publicKey,
       isWalletConnected,
       walletNetworkWarning,
-      connectWallet,
-      disconnectWallet,
       isLoading,
       walletKind,
       socialProfile,
       isSocialLoginAvailable: isSocialLoginConfigured(),
+    }),
+    [publicKey, isWalletConnected, walletNetworkWarning, isLoading, walletKind, socialProfile],
+  );
+
+  const actions = useMemo<WalletActions>(
+    () => ({
+      connectWallet,
+      disconnectWallet,
       connectWithSocial,
     }),
-    [publicKey, isWalletConnected, walletNetworkWarning, isLoading, walletKind, socialProfile, connectWithSocial]
+    [connectWithSocial],
   );
 
   return (
     <WalletStateContext.Provider value={state}>
-      <WalletActionsContext.Provider value={actions}>{children}</WalletActionsContext.Provider>
+      <WalletActionsContext.Provider value={actions}>
+        {children}
+        <InstallFreighterModal
+          isOpen={showInstallPrompt}
+          onClose={() => setShowInstallPrompt(false)}
+          onRetry={handleRetryInstall}
+          socialLogin={
+            isSocialLoginConfigured() ? (
+              <SocialLoginButtons
+                available
+                disabled={isLoading}
+                onSelect={connectWithSocial}
+                onConnected={() => setShowInstallPrompt(false)}
+              />
+            ) : undefined
+          }
+        />
+      </WalletActionsContext.Provider>
     </WalletStateContext.Provider>
-    <WalletContext.Provider value={contextValue}>
-      {children}
-      <InstallFreighterModal
-        isOpen={showInstallPrompt}
-        onClose={() => setShowInstallPrompt(false)}
-        onRetry={handleRetryInstall}
-        socialLogin={
-          isSocialLoginConfigured() ? (
-            <SocialLoginButtons
-              available
-              disabled={isLoading}
-              onSelect={connectWithSocial}
-              onConnected={() => setShowInstallPrompt(false)}
-            />
-          ) : undefined
-        }
-      />
-    </WalletContext.Provider>
   );
 };
 
@@ -457,8 +437,8 @@ export const useWalletState = (): WalletState => {
 };
 
 /**
- * Subscribe to wallet actions only. Never causes a re-render — prefer this in
- * components that only trigger connect/disconnect (buttons, menu items).
+ * Subscribe to wallet actions only. Prefer this in components that only trigger
+ * connect/disconnect (buttons, menu items) and never read connection state.
  */
 export const useWalletActions = (): WalletActions => {
   const ctx = useContext(WalletActionsContext);
@@ -472,7 +452,15 @@ export const useWalletActions = (): WalletActions => {
  * a component only needs one half.
  */
 export const useWallet = () => {
-  const state = useWalletState();
-  const actions = useWalletActions();
-  return useMemo(() => ({ ...state, ...actions }), [state, actions]);
+  // Reads the contexts directly rather than composing the two hooks above, so a
+  // call outside the provider still reports `useWallet` — the name the caller
+  // actually used — instead of leaking the split into the error message.
+  const state = useContext(WalletStateContext);
+  const actions = useContext(WalletActionsContext);
+  const value = useMemo(
+    () => (state && actions ? { ...state, ...actions } : null),
+    [state, actions]
+  );
+  if (!value) throw new Error("useWallet must be used within a WalletProvider");
+  return value;
 };

--- a/src/context/DonationContext.tsx
+++ b/src/context/DonationContext.tsx
@@ -1,11 +1,13 @@
-'use client';
+"use client";
 
-import React, { createContext, useContext, useMemo, ReactNode } from 'react';
-import { useDonationGracePeriod, PendingDonation } from '../hooks/useDonationGracePeriod';
+import React, { createContext, useContext, useMemo, ReactNode } from "react";
+import { useDonationGracePeriod, PendingDonation } from "../hooks/useDonationGracePeriod";
 
 interface DonationContextType {
   pendingDonations: PendingDonation[];
-  startGracePeriod: (donation: Omit<PendingDonation, 'id' | 'timestamp' | 'expiresAt'>) => PendingDonation;
+  startGracePeriod: (
+    donation: Omit<PendingDonation, "id" | "timestamp" | "expiresAt">,
+  ) => PendingDonation;
   cancelDonation: (id: string) => PendingDonation | undefined;
   finalizeDonation: (id: string) => void;
 }
@@ -24,7 +26,7 @@ export function DonationProvider({ children }: { children: ReactNode }) {
       cancelDonation,
       finalizeDonation,
     }),
-    [pendingDonations, startGracePeriod, cancelDonation, finalizeDonation]
+    [pendingDonations, startGracePeriod, cancelDonation, finalizeDonation],
   );
 
   return <DonationContext.Provider value={value}>{children}</DonationContext.Provider>;
@@ -33,7 +35,7 @@ export function DonationProvider({ children }: { children: ReactNode }) {
 export function useDonationContext() {
   const context = useContext(DonationContext);
   if (!context) {
-    throw new Error('useDonationContext must be used within a DonationProvider');
+    throw new Error("useDonationContext must be used within a DonationProvider");
   }
   return context;
 }

--- a/src/hooks/useDonationGracePeriod.ts
+++ b/src/hooks/useDonationGracePeriod.ts
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from "react";
 
 export interface PendingDonation {
   id: string;
@@ -28,7 +28,7 @@ export function useDonationGracePeriod(gracePeriodMs: number = DEFAULT_GRACE_PER
   }, []);
 
   const startGracePeriod = useCallback(
-    (donation: Omit<PendingDonation, 'id' | 'timestamp' | 'expiresAt'>) => {
+    (donation: Omit<PendingDonation, "id" | "timestamp" | "expiresAt">) => {
       const now = Date.now();
       const newDonation: PendingDonation = {
         ...donation,
@@ -40,7 +40,7 @@ export function useDonationGracePeriod(gracePeriodMs: number = DEFAULT_GRACE_PER
       setPendingDonations((prev) => [newDonation, ...prev]);
       return newDonation;
     },
-    [gracePeriodMs]
+    [gracePeriodMs],
   );
 
   const cancelDonation = useCallback((id: string) => {

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -127,7 +127,9 @@ export function earnedBadges(donations: DonationRecord[]): Badge[] {
 
   const earned: BadgeId[] = ["first-donation"];
 
-  if (donations.some((d) => typeof d.backerRank === "number" && d.backerRank <= EARLY_BACKER_RANK)) {
+  if (
+    donations.some((d) => typeof d.backerRank === "number" && d.backerRank <= EARLY_BACKER_RANK)
+  ) {
     earned.push("early-backer");
   }
 

--- a/src/lib/gamification.ts
+++ b/src/lib/gamification.ts
@@ -19,17 +19,17 @@ export interface UserGamificationProfile {
 }
 
 export const LEVEL_THRESHOLDS = [
-  { levelId: 'Bronze', levelNumber: 1, min: 0, max: 100 },
-  { levelId: 'Silver', levelNumber: 2, min: 100, max: 500 },
-  { levelId: 'Gold', levelNumber: 3, min: 500, max: 2000 },
-  { levelId: 'Platinum', levelNumber: 4, min: 2000, max: 5000 },
-  { levelId: 'Diamond', levelNumber: 5, min: 5000, max: Infinity },
+  { levelId: "Bronze", levelNumber: 1, min: 0, max: 100 },
+  { levelId: "Silver", levelNumber: 2, min: 100, max: 500 },
+  { levelId: "Gold", levelNumber: 3, min: 500, max: 2000 },
+  { levelId: "Platinum", levelNumber: 4, min: 2000, max: 5000 },
+  { levelId: "Diamond", levelNumber: 5, min: 5000, max: Infinity },
 ];
 
 export function calculateGamificationProfile(
   totalDonated: number,
   donationCount: number = 0,
-  isEarlyBacker: boolean = false
+  isEarlyBacker: boolean = false,
 ): UserGamificationProfile {
   let currentLevel = LEVEL_THRESHOLDS[0];
 
@@ -41,44 +41,45 @@ export function calculateGamificationProfile(
 
   const nextLevel = LEVEL_THRESHOLDS.find((t) => t.levelNumber === currentLevel.levelNumber + 1);
   const nextLevelThreshold = nextLevel ? nextLevel.min : currentLevel.max;
-  
+
   const currentLevelRange = (nextLevel ? nextLevel.min : currentLevel.max) - currentLevel.min;
   const progressAmount = Math.max(0, totalDonated - currentLevel.min);
-  const progressPercent = currentLevelRange === Infinity 
-    ? 100 
-    : Math.min(100, Math.round((progressAmount / currentLevelRange) * 100));
+  const progressPercent =
+    currentLevelRange === Infinity
+      ? 100
+      : Math.min(100, Math.round((progressAmount / currentLevelRange) * 100));
 
   const badges: Badge[] = [
     {
-      id: 'early_backer',
-      name: 'badge_early_backer_name',
-      description: 'badge_early_backer_desc',
-      icon: '🌱',
-      color: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/30',
+      id: "early_backer",
+      name: "badge_early_backer_name",
+      description: "badge_early_backer_desc",
+      icon: "🌱",
+      color: "bg-emerald-500/10 text-emerald-500 border-emerald-500/30",
       unlocked: isEarlyBacker || donationCount > 0,
     },
     {
-      id: 'streak_master',
-      name: 'badge_streak_master_name',
-      description: 'badge_streak_master_desc',
-      icon: '🔥',
-      color: 'bg-amber-500/10 text-amber-500 border-amber-500/30',
+      id: "streak_master",
+      name: "badge_streak_master_name",
+      description: "badge_streak_master_desc",
+      icon: "🔥",
+      color: "bg-amber-500/10 text-amber-500 border-amber-500/30",
       unlocked: donationCount >= 3,
     },
     {
-      id: 'whale',
-      name: 'badge_whale_name',
-      description: 'badge_whale_desc',
-      icon: '🐋',
-      color: 'bg-blue-500/10 text-blue-500 border-blue-500/30',
+      id: "whale",
+      name: "badge_whale_name",
+      description: "badge_whale_desc",
+      icon: "🐋",
+      color: "bg-blue-500/10 text-blue-500 border-blue-500/30",
       unlocked: totalDonated >= 1000,
     },
     {
-      id: 'heart_champion',
-      name: 'badge_heart_champion_name',
-      description: 'badge_heart_champion_desc',
-      icon: '💎',
-      color: 'bg-purple-500/10 text-purple-500 border-purple-500/30',
+      id: "heart_champion",
+      name: "badge_heart_champion_name",
+      description: "badge_heart_champion_desc",
+      icon: "💎",
+      color: "bg-purple-500/10 text-purple-500 border-purple-500/30",
       unlocked: totalDonated >= 5000,
     },
   ];

--- a/src/lib/recurringDonations.ts
+++ b/src/lib/recurringDonations.ts
@@ -49,7 +49,7 @@ export function addMonths(timestampMs: number, months: number): number {
   result.setUTCMonth(result.getUTCMonth() + months);
 
   const daysInTargetMonth = new Date(
-    Date.UTC(result.getUTCFullYear(), result.getUTCMonth() + 1, 0)
+    Date.UTC(result.getUTCFullYear(), result.getUTCMonth() + 1, 0),
   ).getUTCDate();
 
   result.setUTCDate(Math.min(targetDay, daysInTargetMonth));
@@ -112,7 +112,7 @@ export function createSchedule(input: {
   };
 
   const all = readAll().filter(
-    (s) => !(s.walletAddress === schedule.walletAddress && s.campaignId === schedule.campaignId)
+    (s) => !(s.walletAddress === schedule.walletAddress && s.campaignId === schedule.campaignId),
   );
   writeAll([...all, schedule]);
 
@@ -143,7 +143,7 @@ export function markCycleCompleted(id: string, now: number = Date.now()): void {
             nextRunAt: nextRunAfter(now, s.interval),
             cyclesCompleted: s.cyclesCompleted + 1,
           }
-        : s
-    )
+        : s,
+    ),
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -52,7 +52,7 @@ export default function middleware(req: NextRequest) {
   if (process.env.NODE_ENV === "production") {
     response.headers.set(
       "Strict-Transport-Security",
-      "max-age=63072000; includeSubDomains; preload"
+      "max-age=63072000; includeSubDomains; preload",
     );
   }
 

--- a/tests/e2e/withdrawal.spec.ts
+++ b/tests/e2e/withdrawal.spec.ts
@@ -20,11 +20,16 @@ test.describe("Creator Withdrawal Flow E2E Test", () => {
     // Dismiss onboarding tour and pre-set connected wallet state
     await page.addInitScript(() => {
       localStorage.setItem("onboarding_tour_dismissed", "1");
-      localStorage.setItem("stellar_wallet_public_key", "GCREATOR1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ123");
+      localStorage.setItem(
+        "stellar_wallet_public_key",
+        "GCREATOR1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ123",
+      );
     });
   });
 
-  test("should allow creator to navigate to dashboard and trigger withdrawal flow", async ({ page }) => {
+  test("should allow creator to navigate to dashboard and trigger withdrawal flow", async ({
+    page,
+  }) => {
     // Step 1: Navigate to Dashboard page
     await page.goto("/en/dashboard");
     await expect(page).toHaveURL(/\/dashboard/);
@@ -35,7 +40,9 @@ test.describe("Creator Withdrawal Flow E2E Test", () => {
     await expect(dashboardHeader).toBeVisible();
 
     // Step 3: Check for withdrawal action button or navigate directly to withdraw tab
-    const withdrawBtn = page.getByRole("button", { name: /withdraw|claim/i }).or(page.locator("body"));
+    const withdrawBtn = page
+      .getByRole("button", { name: /withdraw|claim/i })
+      .or(page.locator("body"));
     await expect(withdrawBtn).toBeVisible();
 
     // Step 4: Validate mock mode response and withdrawal UI readiness

--- a/tests/e2e/withdrawal.spec.ts
+++ b/tests/e2e/withdrawal.spec.ts
@@ -35,14 +35,21 @@ test.describe("Creator Withdrawal Flow E2E Test", () => {
     await expect(page).toHaveURL(/\/dashboard/);
     await expect(page.locator("body")).toBeVisible();
 
-    // Step 2: Ensure dashboard elements load
-    const dashboardHeader = page.getByRole("heading", { level: 1 }).or(page.locator("body"));
+    // Step 2: Ensure dashboard elements load.
+    // `.first()` because `.or()` yields every match from both sides — once the
+    // page renders an h1 alongside body, strict mode rejects the two-element
+    // result. Same for the button below.
+    const dashboardHeader = page
+      .getByRole("heading", { level: 1 })
+      .or(page.locator("body"))
+      .first();
     await expect(dashboardHeader).toBeVisible();
 
     // Step 3: Check for withdrawal action button or navigate directly to withdraw tab
     const withdrawBtn = page
       .getByRole("button", { name: /withdraw|claim/i })
-      .or(page.locator("body"));
+      .or(page.locator("body"))
+      .first();
     await expect(withdrawBtn).toBeVisible();
 
     // Step 4: Validate mock mode response and withdrawal UI readiness


### PR DESCRIPTION
## Why CI is red everywhere

`main` has been failing every job that compiles the tree, and because GitHub runs PR checks against the PR *merged into* `main`, this also fails every open PR — #846, #847 and #848 all fail the same six checks while their own changes are fine.

## Root cause

`9ceebfd` — "Merge branch 'main' into feat/donor-engagement-and-campaign-ux", merged as #771 — resolved its conflicts by keeping **both sides verbatim**. Git reported no conflict markers, so the damage went unnoticed, but four files were left holding two interleaved copies of themselves and stopped parsing. Both parents of `9ceebfd` parse cleanly; the merge result does not.

The #771 branch had forked from a very old point (its `WalletContext.tsx` was 151 lines against main's 398), so the resolution spliced an ancient lineage into a much newer file.

| File | Damage |
|---|---|
| `WalletContext.tsx` | Orphaned `WalletContextType` members after the new split contexts; `connectWallet`/`isFreighterInstalled` opened as one form and closed as another; two sibling providers in the return |
| `CauseDetailClient.tsx` | A stale import header and a duplicate `formatDate` spliced into the middle of the `contractClient` import |
| `CauseCard.tsx` | Duplicated imports, two default exports |
| `DonationModal.tsx` | Two `contribute()` calls, redeclaring `stroops` and `hash` |

## How it was resolved

Main's side is the base, with the #648/#645/#671 work re-applied on top — not patched until it parsed:

- **WalletContext** keeps main's social-login provider and gains the real state/actions split. `useWallet` reads both contexts directly so a call outside the provider still reports `useWallet`, matching the existing test.
- **CauseDetailClient** keeps main's `SafeMarkdown` + `isBlankMarkdown` rendering, which supersedes the `CampaignDescription` wrapper.
- **CauseCard** keeps main's memo comparator and renders `CampaignDescription` with main's card layout classes, preserving the #645 empty-state fallback.
- **DonationModal** keeps main's `contribute()` with `onStatus`, recording the recurring schedule only after it settles.

Also fixes two unrelated type errors from `98d1e88` (#775) that block the same jobs: a fallback to a nonexistent `Campaign.raised_amount`, and a comparison against a strategy `ScriptStrategy` does not admit.

## Formatting and coverage

The Lint job runs `prettier --check`; several files had landed unformatted and the syntax errors were masking most of them, because prettier aborted before reaching them. Second commit is `npm run format` output only.

Repairing the merge also changed which lines the coverage gate can instrument. On `main` all four thresholds failed (statements 5.55/15, branches 36.07/50, functions 11.4/20, lines 5.55/15). With the syntax fixed only branches still fell short, at 49.15% against a 50% floor. Rather than lower the floor, the third commit covers real gaps in files the gate already measures — the #645 description fallback, the save button, and the catch arms of the three async handlers. Branches: 49.15% → **50.44%**.

## Verification

Run locally on this branch:

| Gate | Result |
|---|---|
| `typecheck` | pass |
| `lint` | pass |
| `format:check` | pass |
| `build` | pass |
| `test:coverage` (the four suites CI runs) | pass — 58/58, thresholds met |
| `bundle-size` | pass |
| `i18n:check` | pass |

Note: the full local suite still has 11 failing files / 42 tests. Those are older and unrelated — they fail identically at `2cb0a60`, before #771 — and none are in the four files the CI job runs.

Once this lands, #846, #847 and #848 should go green on re-run without changes of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)