### PR TITLE
fix(wallet): validate new admin address format in TransferAdminModal

### DIFF
--- a/src/__tests__/components/TransferAdminModal.test.tsx
+++ b/src/__tests__/components/TransferAdminModal.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StrKey } from "@stellar/stellar-sdk";
+import TransferAdminModal from "@/components/TransferAdminModal";
+
+// The modal reads a few labels from the "Admin" namespace; everything else
+// arrives via props. Mirror the real translations so assertions read naturally.
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const map: Record<string, string> = {
+      requiredWord: "CONFIRM",
+      invalidAddress: "Invalid address",
+      newAdminAddress: "New Admin Address",
+      transferring: "Transferring…",
+    };
+    return map[key] ?? key;
+  },
+}));
+
+// A guaranteed well-formed Stellar public key (correct prefix, length, checksum).
+const VALID_ADDRESS = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 7));
+const INVALID_ADDRESS = "GNOTAREALSTELLARADDRESS";
+
+const baseProps = {
+  isOpen: true,
+  isTransferring: false,
+  onClose: jest.fn(),
+  title: "Transfer admin",
+  body: "Confirm the transfer.",
+  confirmLabel: "Type CONFIRM to proceed",
+  typeConfirmPlaceholder: "CONFIRM",
+  cancelLabel: "Cancel",
+  confirmButtonLabel: "Transfer",
+};
+
+describe("TransferAdminModal address validation", () => {
+  it("accepts a valid Stellar public key: no error, submit enabled after typing CONFIRM", () => {
+    const onConfirm = jest.fn();
+    render(
+      <TransferAdminModal {...baseProps} onConfirm={onConfirm} newAdminAddress={VALID_ADDRESS} />,
+    );
+
+    expect(screen.queryByText("Invalid address")).not.toBeInTheDocument();
+
+    const confirmButton = screen.getByRole("button", { name: "Transfer" });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("CONFIRM"), { target: { value: "CONFIRM" } });
+    expect(confirmButton).toBeEnabled();
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an invalid address: shows an inline error and keeps submit disabled", () => {
+    const onConfirm = jest.fn();
+    render(
+      <TransferAdminModal {...baseProps} onConfirm={onConfirm} newAdminAddress={INVALID_ADDRESS} />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Invalid address");
+
+    const confirmButton = screen.getByRole("button", { name: "Transfer" });
+    fireEvent.change(screen.getByPlaceholderText("CONFIRM"), { target: { value: "CONFIRM" } });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/validators.test.ts
+++ b/src/__tests__/unit/validators.test.ts
@@ -1,5 +1,7 @@
+import { StrKey } from "@stellar/stellar-sdk";
 import {
   validateStellarAddress,
+  isValidStellarPublicKey,
   validateAmount,
   validateFundingGoal,
   validateDuration,
@@ -17,6 +19,19 @@ describe("Validators", () => {
       new ContractErrorException(ContractError.ValidationFailed),
     );
     expect(() => validateStellarAddress("G" + "A".repeat(55))).not.toThrow();
+  });
+
+  it("isValidStellarPublicKey", () => {
+    const valid = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 7));
+    expect(isValidStellarPublicKey(valid)).toBe(true);
+    // Tolerates surrounding whitespace from copy/paste.
+    expect(isValidStellarPublicKey(`  ${valid}  `)).toBe(true);
+
+    // Wrong prefix, too short, bad checksum, and empty all fail.
+    expect(isValidStellarPublicKey("")).toBe(false);
+    expect(isValidStellarPublicKey("GABC")).toBe(false);
+    expect(isValidStellarPublicKey("G" + "A".repeat(55))).toBe(false);
+    expect(isValidStellarPublicKey("MNOTAVALIDADDRESS")).toBe(false);
   });
 
   it("validateAmount", () => {

--- a/src/components/TransferAdminModal.tsx
+++ b/src/components/TransferAdminModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import Modal from "./ui/Modal";
+import { isValidStellarPublicKey } from "@/utils/validators";
 
 interface TransferAdminModalProps {
   newAdminAddress?: string;
@@ -45,7 +46,11 @@ export default function TransferAdminModal({
   const [confirmInput, setConfirmInput] = useState("");
 
   const requiredWord = t("requiredWord");
-  const canConfirm = confirmInput.trim() === requiredWord;
+  // When an address is supplied, it must be a well-formed Stellar public key
+  // before submit is allowed. This catches invalid input client-side instead of
+  // failing only after a Freighter signature prompt and a wasted transaction.
+  const isAddressValid = !newAdminAddress || isValidStellarPublicKey(newAdminAddress);
+  const canConfirm = confirmInput.trim() === requiredWord && isAddressValid;
 
   // Reset input when modal opens
   useEffect(() => {
@@ -75,6 +80,11 @@ export default function TransferAdminModal({
             {newAdminAddress}
           </p>
         </div>
+      ) : null}
+      {newAdminAddress && !isAddressValid ? (
+        <p role="alert" className="text-sm font-medium text-red-600 dark:text-red-400">
+          {t("invalidAddress")}
+        </p>
       ) : null}
       <div>
         <label

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,3 +1,4 @@
+import { StrKey } from "@stellar/stellar-sdk";
 import { ContractError, ContractErrorException } from "./contractErrors";
 
 export function validateStellarAddress(
@@ -7,6 +8,18 @@ export function validateStellarAddress(
   if (!address || address.length !== 56 || !address.startsWith("G")) {
     throw new ContractErrorException(errorToThrow);
   }
+}
+
+/**
+ * Non-throwing check that `address` is a syntactically valid Stellar ed25519
+ * public key — starts with `G`, has the correct length, and a valid StrKey
+ * checksum. Intended for client-side form validation where an inline error is
+ * shown rather than an exception thrown (see TransferAdminModal). Unlike
+ * {@link validateStellarAddress}, this verifies the checksum, not just the
+ * length and prefix.
+ */
+export function isValidStellarPublicKey(address: string): boolean {
+  return typeof address === "string" && StrKey.isValidEd25519PublicKey(address.trim());
 }
 
 export function validateAmount(amount: number | bigint): void {


### PR DESCRIPTION
## Summary

`TransferAdminModal` accepted the target Stellar address without validating its format client-side. An invalid value only failed **after** a Freighter signature prompt and a wasted transaction attempt. This adds up-front validation with an inline error.

## Changes
- **`src/utils/validators.ts`** — add `isValidStellarPublicKey(address)`, a non-throwing check that uses `StrKey.isValidEd25519PublicKey` to verify the `G` prefix, correct length, **and checksum** (the existing `validateStellarAddress` only checks prefix/length). Tolerates surrounding whitespace.
- **`src/components/TransferAdminModal.tsx`** — when a `newAdminAddress` is supplied, validate it before submit: render an inline `role="alert"` error (reusing the existing `Admin.invalidAddress` translation) and keep the confirm button disabled until the address is well-formed. The fee-confirmation usage (no address) is unaffected.

## Acceptance criteria
- [x] Validate the address is a syntactically valid Stellar public key (G…, correct checksum/length) before allowing submit
- [x] Show an inline error for invalid addresses
- [x] Add a test covering both valid and invalid address input

## Tests
- `src/__tests__/components/TransferAdminModal.test.tsx` (new) — valid key: no error, submit enabled after typing CONFIRM, `onConfirm` fires; invalid address: inline error shown, submit stays disabled, `onConfirm` never fires.
- `src/__tests__/unit/validators.test.ts` — direct coverage of `isValidStellarPublicKey` for valid, whitespace-padded, empty, wrong-prefix, and bad-checksum inputs.

Valid test vectors are generated with `StrKey.encodeEd25519PublicKey` so they always carry a correct checksum.

## Out of scope
- The on-chain 2-step transfer-accept flow (tracked in #577).

Closes #810