### PR TITLE
test: add unit tests for localizedDescription selection logic

### DIFF
--- a/src/__tests__/utils/localizedDescription.test.ts
+++ b/src/__tests__/utils/localizedDescription.test.ts
@@ -1,0 +1,56 @@
+import { getLocalizedDescription, encodeLocalizedDescription } from "@/utils/localizedDescription";
+
+describe("localizedDescription", () => {
+  describe("getLocalizedDescription", () => {
+    it("returns the requested locale's description when it exists", () => {
+      const description = "[lang:en]English text[lang:es]Texto en español";
+      expect(getLocalizedDescription(description, "en")).toBe("English text");
+      expect(getLocalizedDescription(description, "es")).toBe("Texto en español");
+    });
+
+    it("returns plain text as-is when there are no language markers", () => {
+      const description = "A plain campaign description";
+      expect(getLocalizedDescription(description, "en")).toBe(description);
+      expect(getLocalizedDescription(description, "fr")).toBe(description);
+    });
+
+    it("falls back to the default locale when the requested locale is missing", () => {
+      const description = "[lang:en]English text[lang:es]Texto en español";
+      expect(getLocalizedDescription(description, "fr")).toBe("English text");
+    });
+
+    it("falls back to the default locale when the requested locale is empty", () => {
+      expect(getLocalizedDescription("[lang:en]English text[lang:fr] ", "fr")).toBe("English text");
+      expect(getLocalizedDescription("[lang:fr][lang:en]English text", "fr")).toBe("English text");
+    });
+
+    it("falls back to the raw description when the default locale is also empty", () => {
+      expect(getLocalizedDescription("[lang:fr]", "fr")).toBe("[lang:fr]");
+    });
+  });
+
+  describe("encodeLocalizedDescription", () => {
+    it("encodes translations into the on-chain marker format", () => {
+      expect(encodeLocalizedDescription({ en: "English", es: "Español" })).toBe(
+        "[lang:en]English[lang:es]Español",
+      );
+    });
+
+    it("omits empty or whitespace-only translations", () => {
+      expect(encodeLocalizedDescription({ en: "English", fr: "", de: "   " })).toBe(
+        "[lang:en]English",
+      );
+    });
+
+    it("returns an empty string when there are no non-empty translations", () => {
+      expect(encodeLocalizedDescription({})).toBe("");
+      expect(encodeLocalizedDescription({ fr: "", de: " " })).toBe("");
+    });
+  });
+
+  it("round-trips encode then decode for each locale", () => {
+    const encoded = encodeLocalizedDescription({ en: "Hello", es: "Hola" });
+    expect(getLocalizedDescription(encoded, "en")).toBe("Hello");
+    expect(getLocalizedDescription(encoded, "es")).toBe("Hola");
+  });
+});

--- a/src/utils/localizedDescription.ts
+++ b/src/utils/localizedDescription.ts
@@ -27,11 +27,13 @@ function parse(description: string): LocalizedMap | null {
 /**
  * Returns the description text for the given locale, falling back to English,
  * then to the raw description string if no language markers are present.
+ * A requested locale whose translation is missing or empty falls back to the
+ * default locale (English).
  */
 export function getLocalizedDescription(description: string, locale: string): string {
   const map = parse(description);
   if (!map) return description;
-  return map[locale] ?? map["en"] ?? description;
+  return map[locale] || map["en"] || description;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #799 — [Testing] Add unit tests for `localizedDescription` selection logic.

`src/utils/localizedDescription.ts` had no test coverage for its locale-selection / fallback behavior. This PR adds a unit-test suite and fixes a small fallback bug it exposed: an **empty** translation for the requested locale was returned as `""` instead of falling back to the default locale.

## Changes

**`src/utils/localizedDescription.ts`**
- `getLocalizedDescription()` now uses `map[locale] || map["en"] || description` instead of `??`. Because `parse()` stores trimmed values, an empty / whitespace-only translation is represented as `""`, so `??` (nullish coalescing) let the empty string through. The logical-or treats **missing and empty** translations identically, both falling back to the default locale (English), then to the raw description string. (Verified compatible with the existing consumer in `CauseDetailClient.tsx`, which then runs `isBlankMarkdown`.)

**`src/__tests__/utils/localizedDescription.test.ts`** (new)
- `getLocalizedDescription`:
  - returns the requested locale's description when it exists
  - returns plain text as-is when there are no language markers
  - **falls back to the default locale when the requested locale is missing**
  - **falls back to the default locale when the requested locale is empty** (e.g. `[lang:fr] ` / `[lang:fr]` with no text)
  - falls back to the raw description when the default locale is also empty
- `encodeLocalizedDescription`:
  - encodes translations into the `[lang:xx]...` marker format
  - omits empty / whitespace-only translations
  - returns `""` when there are no non-empty translations
- round-trip test: encode → decode returns the correct per-locale text

> Note: placed at `src/__tests__/utils/localizedDescription.test.ts` (the repo's existing convention, e.g. `exportCsv.test.ts`) rather than the literal `src/tests/` path from the issue, since the repo has no `src/tests` directory and Jest ignores only the root `tests/` e2e dir.

## Acceptance criteria

- [x] Add `src/tests/utils/localizedDescription.test.ts` (see note above — added under `src/__tests__/utils/` per repo convention).
- [x] Cover the case where the requested locale's description exists.
- [x] Cover fallback to the default locale when the requested locale's description is missing **or empty**.

## Verification

- New suite: **9 tests pass** (`npx jest src/__tests__/utils/localizedDescription.test.ts`).
- `eslint` clean and `prettier --check` clean on both touched files.
- `tsc --noEmit` shows only the pre-existing errors in `CauseDetailClient.tsx` / `WalletContext.tsx` (unrelated, present on `main`).

## Out of scope

Adding a translation UI for campaign descriptions (explicitly out of scope in the issue).
