### PR TITLE
refactor(lib): extract shared log util for timestamp/pagination logic…

### DIFF
--- a/src/lib/adminLog.ts
+++ b/src/lib/adminLog.ts
@@ -1,4 +1,10 @@
 import { normalizeAddress } from "./stellar";
+import {
+  readAllEntries,
+  writeAllEntries,
+  appendTimestamp,
+  filterAndSortByTimestamp,
+} from "./logUtil";
 
 export type AdminAuditAction =
   | "verify_campaign"
@@ -18,33 +24,6 @@ export interface AdminAuditLogEntry {
 const STORAGE_KEY = "proof_of_heart_admin_audit_log_v1";
 const MAX_ENTRIES = 500;
 const API_ENDPOINT = "/api/admin-audit-log";
-
-function canUseStorage(): boolean {
-  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
-}
-
-function readAllEntries(): AdminAuditLogEntry[] {
-  if (!canUseStorage()) return [];
-
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed as AdminAuditLogEntry[];
-  } catch {
-    return [];
-  }
-}
-
-function writeAllEntries(entries: AdminAuditLogEntry[]): void {
-  if (!canUseStorage()) return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries.slice(-MAX_ENTRIES)));
-  } catch {
-    // Ignore localStorage write failures.
-  }
-}
 
 async function readApiEntries(adminAddress?: string): Promise<AdminAuditLogEntry[]> {
   const url = new URL(API_ENDPOINT, window.location.origin);
@@ -82,20 +61,23 @@ export async function appendAdminAuditLog(
     adminAddress: string;
   },
 ): Promise<void> {
-  const nextEntry: AdminAuditLogEntry = {
+  const nextEntry = appendTimestamp<AdminAuditLogEntry>({
     ...entry,
     adminAddress: normalizeAddress(entry.adminAddress),
-    timestamp: Date.now(),
-  };
+  });
 
   try {
     await persistApiEntry(nextEntry);
-    writeAllEntries([...readAllEntries(), nextEntry]);
+    writeAllEntries(
+      STORAGE_KEY,
+      [...readAllEntries<AdminAuditLogEntry>(STORAGE_KEY), nextEntry],
+      MAX_ENTRIES,
+    );
     return;
   } catch {
-    const allEntries = readAllEntries();
+    const allEntries = readAllEntries<AdminAuditLogEntry>(STORAGE_KEY);
     allEntries.push(nextEntry);
-    writeAllEntries(allEntries);
+    writeAllEntries(STORAGE_KEY, allEntries, MAX_ENTRIES);
   }
 }
 
@@ -108,15 +90,17 @@ export async function getAdminAuditLog(
   try {
     const apiEntries = await readApiEntries(normalizedAddress);
     if (apiEntries.length > 0) {
-      writeAllEntries(apiEntries);
+      writeAllEntries(STORAGE_KEY, apiEntries, MAX_ENTRIES);
       return apiEntries.sort((a, b) => b.timestamp - a.timestamp).slice(0, Math.max(0, limit));
     }
   } catch {
     // Fall back to local cache below.
   }
 
-  return readAllEntries()
-    .filter((entry) => normalizeAddress(entry.adminAddress) === normalizedAddress)
-    .sort((a, b) => b.timestamp - a.timestamp)
-    .slice(0, Math.max(0, limit));
+  return filterAndSortByTimestamp(
+    readAllEntries<AdminAuditLogEntry>(STORAGE_KEY),
+    "adminAddress",
+    normalizedAddress,
+    limit,
+  );
 }

--- a/src/lib/logUtil.ts
+++ b/src/lib/logUtil.ts
@@ -1,0 +1,50 @@
+import { normalizeAddress } from "./stellar";
+
+export function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function readAllEntries<T>(storageKey: string): T[] {
+  if (!canUseStorage()) return [];
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as T[];
+  } catch {
+    return [];
+  }
+}
+
+export function writeAllEntries<T>(storageKey: string, entries: T[], maxEntries?: number): void {
+  if (!canUseStorage()) return;
+
+  try {
+    const toStore = maxEntries != null ? entries.slice(-maxEntries) : entries;
+    window.localStorage.setItem(storageKey, JSON.stringify(toStore));
+  } catch {
+    // Ignore localStorage write failures.
+  }
+}
+
+export function appendTimestamp<T extends object>(
+  entry: Omit<T, "timestamp"> & { timestamp?: number },
+): T {
+  return { ...entry, timestamp: Date.now() } as T;
+}
+
+export function filterAndSortByTimestamp<T extends { timestamp: number }>(
+  entries: T[],
+  addressField: keyof T,
+  address: string,
+  limit?: number,
+): T[] {
+  const normalized = normalizeAddress(address);
+  const filtered = entries.filter(
+    (entry) => normalizeAddress(entry[addressField] as string) === normalized,
+  );
+  const sorted = filtered.sort((a, b) => b.timestamp - a.timestamp);
+  return limit != null ? sorted.slice(0, Math.max(0, limit)) : sorted;
+}

--- a/src/lib/transactionLog.ts
+++ b/src/lib/transactionLog.ts
@@ -17,36 +17,14 @@ export interface WalletTransactionLogEntry {
 
 import { normalizeAddress } from "./stellar";
 import { hasOffchainApiBaseUrl, requestOffchainJson } from "./offchainApiClient";
+import {
+  readAllEntries,
+  writeAllEntries,
+  appendTimestamp,
+  filterAndSortByTimestamp,
+} from "./logUtil";
 
 const STORAGE_KEY = "proof_of_heart_wallet_tx_log_v1";
-
-function canUseStorage(): boolean {
-  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
-}
-
-function readAllEntries(): WalletTransactionLogEntry[] {
-  if (!canUseStorage()) return [];
-
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed as WalletTransactionLogEntry[];
-  } catch {
-    return [];
-  }
-}
-
-function writeAllEntries(entries: WalletTransactionLogEntry[]): void {
-  if (!canUseStorage()) return;
-
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
-  } catch {
-    // Ignore localStorage write failures.
-  }
-}
 
 async function syncWalletTransaction(entry: WalletTransactionLogEntry): Promise<void> {
   if (!hasOffchainApiBaseUrl()) return;
@@ -66,21 +44,21 @@ async function syncWalletTransaction(entry: WalletTransactionLogEntry): Promise<
 }
 
 export function appendWalletTransaction(entry: Omit<WalletTransactionLogEntry, "timestamp">): void {
-  const allEntries = readAllEntries();
-  const normalizedEntry: WalletTransactionLogEntry = {
+  const normalizedEntry = appendTimestamp<WalletTransactionLogEntry>({
     ...entry,
     walletAddress: normalizeAddress(entry.walletAddress),
-    timestamp: Date.now(),
-  };
+  });
 
+  const allEntries = readAllEntries<WalletTransactionLogEntry>(STORAGE_KEY);
   allEntries.push(normalizedEntry);
-  writeAllEntries(allEntries.slice(-1000));
+  writeAllEntries(STORAGE_KEY, allEntries, 1000);
   void syncWalletTransaction(normalizedEntry);
 }
 
 export function getWalletTransactions(walletAddress: string): WalletTransactionLogEntry[] {
-  const normalizedAddress = normalizeAddress(walletAddress);
-  return readAllEntries()
-    .filter((entry) => normalizeAddress(entry.walletAddress) === normalizedAddress)
-    .sort((a, b) => b.timestamp - a.timestamp);
+  return filterAndSortByTimestamp(
+    readAllEntries<WalletTransactionLogEntry>(STORAGE_KEY),
+    "walletAddress",
+    walletAddress,
+  );
 }


### PR DESCRIPTION
PR #838 

Extract duplicated canUseStorage, readAllEntries, writeAllEntries, appendTimestamp, and filterAndSortByTimestamp logic from transactionLog.ts and adminLog.ts into a shared logUtil.ts module.

Both modules now import from logUtil instead of maintaining their own copies of localStorage access, timestamp assignment, and filter-sort-paginate patterns.

## Summary

<!-- Briefly describe what changed and why. -->



## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Chore / maintenance
- [ ] Documentation
- [ ] Test coverage

## Contributor Checklist

- [ ] Linked the related issue above.
- [ ] Reviewed `CONTRIBUTING.md` for branch, commit, and PR title conventions.
- [ ] Confirmed this follows the current Stellar Wave contribution flow, if applicable.
- [ ] Added or updated tests when behavior changed.
- [ ] Updated docs, examples, or translations when needed.

## Validation

- [ ] `npm run lint`
- [ ] `npm run format:check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] Not run; reason:


Closes #838 